### PR TITLE
add check to fix duplicate IPv6 routes

### DIFF
--- a/tests/manifests/resourceclaim_ipv6_subnet.yaml
+++ b/tests/manifests/resourceclaim_ipv6_subnet.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-ipv6
+  labels:
+    app: pod-ipv6
+spec:
+  containers:
+  - name: ctr1
+    image: registry.k8s.io/e2e-test-images/agnhost:2.54
+    securityContext:
+      privileged: true
+  resourceClaims:
+  - name: dummy1
+    resourceClaimName: dummy-interface-ipv6
+---
+apiVersion: resource.k8s.io/v1
+kind:  ResourceClaim
+metadata:
+  name: dummy-interface-ipv6
+spec:
+  devices:
+    requests:
+    - name: req-dummy
+      exactly:
+        deviceClassName: dra.net
+        selectors:
+          - cel:
+              expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "dummy-ipv6"


### PR DESCRIPTION
Fix google/dranet#274

Before adding a new route, we first check for an existing route. If route exists, skip adding a new route since it is likely a kernel route.