### PR TITLE
chore: Add rolling update support for DRA driver

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -130,6 +130,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
DRA plugins can be restarted with rolling update mode and this actually helped fixing dra driver restart issue https://github.com/kubernetes-sigs/dranet/issues/19. 

To support this, driver must pass pod UID to kubeletplugin.RollingUpdate. Rolling update is not enabled by default and to enable, user has to set `--pod-uid` as argument when invoking dra.

