### PR TITLE
Fix incorrect makefile rule for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,4 @@ kind-image: image
 	kubectl apply -f install.yaml
 
 # The main release target, which pushes all images
-release: push-image
+release: image-push


### PR DESCRIPTION
Makefile rule `release` was calling the wrong make target. This fixes that.

Fixes: #23 