### PR TITLE
Fix 'kind-image' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ image-push: ensure-buildx
 kind-cluster:
 	kind create cluster --name dra --config kind.yaml
 
-kind-image: image
+kind-image: image-build
 	docker tag ${IMAGE} registry.k8s.io/networking/dranet:stable
 	kind load docker-image registry.k8s.io/networking/dranet:stable --name dra
 	kubectl delete -f install.yaml || true


### PR DESCRIPTION
I believe this is a bug. I noticed it when doing the 1.25 work. 