### PR TITLE
docs: migrate repository links from google to kubernetes-sigs org

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Allocation](https://cloud.google.com/kubernetes-engine/docs/how-to/set-up-dra)
 Install the latest stable version of DRANET using the provided manifest:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/google/dranet/refs/heads/main/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/dranet/refs/heads/main/install.yaml
 ```
 
 ### How to Use It

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -6,7 +6,7 @@ title: DRANET
 <a class="btn btn-lg btn-primary me-3 mb-4" href="/docs/">
   Learn More <i class="fas fa-arrow-alt-circle-right ms-2"></i>
 </a>
-<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/google/dranet">
+<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/kubernetes-sigs/dranet">
   Repository <i class="fab fa-github ms-2 "></i>
 </a>
 <p class="lead mt-5">A Kubernetes Network Driver!</p>

--- a/site/content/docs/quick-start.md
+++ b/site/content/docs/quick-start.md
@@ -56,7 +56,7 @@ kubernetes_feature_enabled{name="DynamicResourceAllocation",stage="BETA"} 1
 You can install the latest stable version of `DRANET` using the provided manifest:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/google/dranet/refs/heads/main/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/dranet/refs/heads/main/install.yaml
 ```
 
 ### How to use it

--- a/site/content/docs/user/gke-rdma.md
+++ b/site/content/docs/user/gke-rdma.md
@@ -87,7 +87,7 @@ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container
 Apply the following manifest to install DRANET:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/google/dranet/refs/heads/main/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/dranet/refs/heads/main/install.yaml
 ```
 
 Once DRANET is running you'll be able to obtain the network resources exposed via the daemonsets, per example, this specific node has 8 RDMA nics as per the machine specification:

--- a/site/content/docs/user/gke-tpu-performance.md
+++ b/site/content/docs/user/gke-tpu-performance.md
@@ -49,7 +49,7 @@ gcloud container node-pools create POOL_NAME \
 Apply the following manifest to install DRANET:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/google/dranet/refs/heads/main/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/dranet/refs/heads/main/install.yaml
 ```
 
 Once DRANET is running you'll be able to obtain the network resources exposed by the dranet Pods, in order to avoid noise, DRANET has a flag that allow to set client side filter to control the exposed resources, in this case, we can set the flag to ignore network devices that are `virtual`, the manifest will look like:

--- a/site/content/docs/user/mpi-operator.md
+++ b/site/content/docs/user/mpi-operator.md
@@ -9,7 +9,7 @@ The goal is resource compartmentalization: ensuring that each part of your distr
 
 ## DRANET + MPI Operator: A Powerful Combination
 
-- DRANET: Provides the mechanism to discover RDMA-capable NICs on your Kubernetes nodes and make them available for Pods to claim. Through DRA, Pods can request a specific NIC, and DRANET, via NRI hooks, will configure it within the Pod's namespace, [even naming it predictably (e.g., dranet0)](google/dranet/dranet-dcd98f563b1a24f4800cf3d2d502ec5b2f488ddc/site/content/docs/user/interface-configuration.md)
+- DRANET: Provides the mechanism to discover RDMA-capable NICs on your Kubernetes nodes and make them available for Pods to claim. Through DRA, Pods can request a specific NIC, and DRANET, via NRI hooks, will configure it within the Pod's namespace, [even naming it predictably (e.g., dranet0)](/docs/user/interface-configuration.md)
 
 - [Kubeflow MPI Operator](https://github.com/kubeflow/mpi-operator): Simplifies the deployment and management of MPI-based applications on Kubernetes. It handles the setup of MPI ranks, hostfiles, and the execution of mpirun.
 

--- a/site/content/docs/user/nvidia-dranet.md
+++ b/site/content/docs/user/nvidia-dranet.md
@@ -95,7 +95,7 @@ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container
 
 Install DRANET
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/google/dranet/refs/heads/main/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/dranet/refs/heads/main/install.yaml
 ```
 
 #### Installing Nvidia DRA Drivers
@@ -114,7 +114,7 @@ Please ensure the GPU Driver image [includes the standard attribute
 so both GPU DRA driver and DRANET can use it for NIC alignment.
 
 ```
-helm upgrade -i --create-namespace --namespace nvidia-dra-driver-gpu nvidia-dra-driver-gpu ./k8s-dra-driver-gpu/deployments/helm/nvidia-dra-driver-gpu --values https://raw.githubusercontent.com/google/dranet/refs/heads/main/examples/demo_nvidia_dranet/values.yaml --wait
+helm upgrade -i --create-namespace --namespace nvidia-dra-driver-gpu nvidia-dra-driver-gpu ./k8s-dra-driver-gpu/deployments/helm/nvidia-dra-driver-gpu --values https://raw.githubusercontent.com/kubernetes-sigs/dranet/refs/heads/main/examples/demo_nvidia_dranet/values.yaml --wait
 ```
 
 The values.yaml adds some additional tolerations and removes some priorities

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -62,7 +62,7 @@ privacy_policy = "https://policies.google.com/privacy"
 # images = ["images/project-illustration.png"]
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/google/dranet"
+github_repo = "https://github.com/kubernetes-sigs/dranet"
 
 # Specify a value here if your content directory is not in your repo's root directory
 github_subdir = "site"
@@ -112,7 +112,7 @@ enable = false
   desc = "Discussion and help from your fellow users"
 [[params.links.developer]]
   name = "GitHub"
-  url = "https://github.com/google/dranet"
+  url = "https://github.com/kubernetes-sigs/dranet"
   icon = "fab fa-github"
   desc = "Development takes place here!"
 [[params.links.developer]]


### PR DESCRIPTION
The code and tests were migrated to kubernetes-sigs organization, but the documentation was still referencing the old google/dranet repo.

This commit updates all documentation links to point to the new kubernetes-sigs/dranet repository to avoid user confusion.

Ref: #45