### PR TITLE
Limit test GitHub Action to main branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,14 @@
 # limitations under the License.
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
With the existing configuration this would run on any push to any branch and any pull request target. This limits the "on" condition to match the other similar workflows so tests are not run when not needed.