### PR TITLE
add vrf support and explain pbr functionality

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -3,11 +3,11 @@ name: bats
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 env:
@@ -25,6 +25,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: system-level-dependencies
+        run: |
+          sudo apt update
+          sudo apt -y install linux-modules-extra-$(uname -r)
+          sudo modprobe -v vrf
+
       - name: Setup Bats and bats libs
         id: setup-bats
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
@@ -34,8 +40,8 @@ jobs:
       - name: Bats tests
         shell: bash
         env:
-         BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
-         TERM: xterm
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+          TERM: xterm
         run: bats -o _artifacts --print-output-on-failure tests/
 
       - name: Upload logs
@@ -44,4 +50,3 @@ jobs:
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: ./_artifacts
- 

--- a/pkg/apis/constants.go
+++ b/pkg/apis/constants.go
@@ -29,4 +29,8 @@ const (
 	// Ref. https://man7.org/linux/man-pages/man8/rdma-system.8.html
 	RdmaNetnsModeShared    = "shared"
 	RdmaNetnsModeExclusive = "exclusive"
+
+	// VRFTableOffset is the offset used for VRF routing tables to avoid ID collisions
+	// with reserved tables (0, 253, 254, 255) and to identify DRANET managed tables.
+	VRFTableOffset = 1000
 )

--- a/pkg/apis/defaults.go
+++ b/pkg/apis/defaults.go
@@ -1,0 +1,25 @@
+package apis
+
+import (
+	"hash/fnv"
+)
+
+// Default applies default values to the NetworkConfig.
+func (c *NetworkConfig) Default() {
+	if c.Interface.VRF != nil {
+		c.Interface.VRF.Default()
+	}
+}
+
+// Default applies default values to the VRFConfig.
+func (c *VRFConfig) Default() {
+	if c.Table == nil && c.Name != "" {
+		// Derive a deterministic table ID from the VRF name to ensure interfaces
+		// joining the same VRF automatically share the same table ID.
+		h := fnv.New32a()
+		h.Write([]byte(c.Name))
+		// Use the constant from this package
+		tableID := int((h.Sum32() % 1000) + VRFTableOffset)
+		c.Table = &tableID
+	}
+}

--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -27,6 +27,7 @@ type NetworkConfig struct {
 	Routes []RouteConfig `json:"routes,omitempty"`
 
 	// Rules defines routing rules to be configured for this interface.
+	// Rules are not supported when VRF (Interface.VRF) is enabled.
 	Rules []RuleConfig `json:"rules,omitempty"`
 
 	// Neighbors defines permanent neighbor (ARP/NDP) entries to be added for this interface.
@@ -76,6 +77,27 @@ type InterfaceConfig struct {
 	// DisableEBPFPrograms, if true, attempts to detach all eBPF programs
 	// (both TC and TCX) from the network interface assigned to the Pod.
 	DisableEBPFPrograms *bool `json:"disableEbpfPrograms,omitempty"`
+
+	// Forwarding, if true, enables IP forwarding on this specific interface.
+	// This sets /proc/sys/net/ipv4/conf/<iface>/forwarding and the ipv6 counterpart.
+	Forwarding *bool `json:"forwarding,omitempty"`
+
+	// VRF specifies the Virtual Routing and Forwarding domain this interface should belong to.
+	// If provided, the interface will be enslaved to a VRF device with this name.
+	// This enables grouping multiple network interfaces into the same VRF.
+	VRF *VRFConfig `json:"vrf,omitempty"`
+}
+
+// VRFConfig represents the configuration for a Virtual Routing and Forwarding domain.
+type VRFConfig struct {
+	// Name is the name of the VRF device to create (e.g., "vrf0").
+	// If not specified, a name will be automatically generated based on the interface index.
+	Name string `json:"name,omitempty"`
+
+	// Table is the routing table ID to use for this VRF.
+	// If not specified, a unique table ID will be automatically assigned (typically interface index + 100).
+	// Common reserved tables: 255 (local), 254 (main), 253 (default).
+	Table *int `json:"table,omitempty"`
 }
 
 // RouteConfig represents a network route configuration.
@@ -90,6 +112,17 @@ type RouteConfig struct {
 	// Refers to Linux route scopes (e.g., 0 for RT_SCOPE_UNIVERSE, 253 for RT_SCOPE_LINK).
 	Scope uint8 `json:"scope,omitempty"`
 	// Table is the routing table to use for the route.
+	// 0 usually means "unspecified" and defaults to the 'main' table (254) in Linux.
+	//
+	// IMPORTANT: If VRF is enabled on the interface, this field is IGNORED.
+	// Dranet will automatically assign ALL routes for the interface to the VRF's table
+	// to ensure they are reachable via the VRF device.
+	//
+	// Common reserved tables:
+	// - 255: local (handled by kernel)
+	// - 254: main (default table for most routes)
+	// - 253: default
+	// - 0: unspec
 	Table int `json:"table,omitempty"`
 }
 
@@ -101,7 +134,7 @@ type RuleConfig struct {
 	Source string `json:"source,omitempty"`
 	// Destination is the destination IP address for the rule.
 	Destination string `json:"destination,omitempty"`
-	// Table is the routing table to use for the rule.
+	// Table is the routing table ID to look up if the rule matches.
 	Table int `json:"table,omitempty"`
 }
 

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -341,12 +341,16 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 		}
 		podCfg.NetworkInterfaceConfigInPod.Routes = append(podCfg.NetworkInterfaceConfigInPod.Routes, routes...)
 
-		for _, table := range tables.UnsortedList() {
-			if rules, ok := rulesByTable[table]; ok {
-				klog.V(5).Infof("Adding %d rules for table %d associated with interface %s", len(rules), table, ifName)
-				podCfg.NetworkInterfaceConfigInPod.Rules = append(podCfg.NetworkInterfaceConfigInPod.Rules, rules...)
-				// Avoid adding the same rule twice
-				delete(rulesByTable, table)
+		// If VRF is enabled, we do not need to copy the rules from the host
+		// because the VRF handles the routing table lookup.
+		if podCfg.NetworkInterfaceConfigInPod.Interface.VRF == nil {
+			for _, table := range tables.UnsortedList() {
+				if rules, ok := rulesByTable[table]; ok {
+					klog.V(5).Infof("Adding %d rules for table %d associated with interface %s", len(rules), table, ifName)
+					podCfg.NetworkInterfaceConfigInPod.Rules = append(podCfg.NetworkInterfaceConfigInPod.Rules, rules...)
+					// Avoid adding the same rule twice
+					delete(rulesByTable, table)
+				}
 			}
 		}
 

--- a/pkg/driver/netnamespace.go
+++ b/pkg/driver/netnamespace.go
@@ -20,17 +20,21 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"runtime"
 	"slices"
 	"syscall"
 
+	"sigs.k8s.io/dranet/internal/nlwrap"
 	"sigs.k8s.io/dranet/pkg/apis"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
-	"sigs.k8s.io/dranet/internal/nlwrap"
+	"k8s.io/component-helpers/node/util/sysctl"
+	"k8s.io/klog/v2"
 )
 
-func applyRoutingConfig(containerNsPAth string, ifName string, routeConfig []apis.RouteConfig) error {
+func applyRoutingConfig(containerNsPAth string, ifName string, routeConfig []apis.RouteConfig, vrfTable int) error {
 	containerNs, err := netns.GetFromPath(containerNsPAth)
 	if err != nil {
 		return err
@@ -66,10 +70,17 @@ func applyRoutingConfig(containerNsPAth string, ifName string, routeConfig []api
 	})
 
 	for _, route := range routeConfig {
+		table := route.Table
+		// If VRF is enabled (vrfTable > 0), all routes for this interface
+		// must go into the VRF table to be reachable via the VRF device.
+		if vrfTable > 0 {
+			table = vrfTable
+		}
+
 		r := netlink.Route{
 			LinkIndex: nsLink.Attrs().Index,
 			Scope:     netlink.Scope(route.Scope),
-			Table:     route.Table,
+			Table:     table,
 		}
 
 		_, dst, err := net.ParseCIDR(route.Destination)
@@ -174,4 +185,144 @@ func applyRulesConfig(containerNsPath string, rulesConfig []apis.RuleConfig) err
 		}
 	}
 	return errors.Join(errorList...)
+}
+
+// applyInterfaceForwarding enables IPv4 and IPv6 forwarding for a specific interface.
+// It uses the Kubernetes sysctl helper while locked into the pod's network namespace.
+func applyInterfaceForwarding(containerNsPath string, ifName string, enable bool) error {
+	if !enable {
+		return nil
+	}
+
+	origns, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("unexpected error trying to get namespace: %v", err)
+	}
+	defer origns.Close() // nolint:errcheck
+
+	containerNs, err := netns.GetFromPath(containerNsPath)
+	if err != nil {
+		return fmt.Errorf("could not get network namespace from path %s: %w", containerNsPath, err)
+	}
+	defer containerNs.Close()
+
+	// Lock the OS thread and switch into the container's network namespace
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	if err := netns.Set(containerNs); err != nil {
+		return fmt.Errorf("failed to join network namespace %s: %v", containerNsPath, err)
+	}
+	defer netns.Set(origns) // nolint:errcheck
+
+	// Initialize the Kubernetes sysctl interface
+	sysctlInterface := sysctl.New()
+	var errorList []error
+
+	// Enable IPv4 forwarding on the specific interface
+	v4Sysctl := fmt.Sprintf("net/ipv4/conf/%s/forwarding", ifName)
+	if err := sysctlInterface.SetSysctl(v4Sysctl, 1); err != nil {
+		errorList = append(errorList, fmt.Errorf("failed to set %s: %w", v4Sysctl, err))
+	}
+
+	// Enable IPv6 forwarding (gracefully handling disabled IPv6 stacks)
+	v6Sysctl := fmt.Sprintf("net/ipv6/conf/%s/forwarding", ifName)
+	if err := sysctlInterface.SetSysctl(v6Sysctl, 1); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// If the file doesn't exist, IPv6 is likely disabled on the node or namespace.
+			// We log this at V(4) so it doesn't spam normal logs, and we don't fail the setup.
+			klog.V(4).Infof("IPv6 sysctl %s not found; assuming IPv6 is disabled and skipping", v6Sysctl)
+		} else {
+			errorList = append(errorList, fmt.Errorf("failed to set %s: %w", v6Sysctl, err))
+		}
+	}
+	return errors.Join(errorList...)
+}
+
+func applyVRFConfig(containerNsPath string, ifName string, vrfConfig *apis.VRFConfig) (int, error) {
+	if vrfConfig == nil {
+		return 0, fmt.Errorf("vrf config is nil")
+	}
+	if vrfConfig.Name == "" {
+		return 0, fmt.Errorf("vrf name not specified")
+	}
+
+	if vrfConfig.Table == nil {
+		return 0, fmt.Errorf("vrf table not specified")
+	}
+
+	containerNs, err := netns.GetFromPath(containerNsPath)
+	if err != nil {
+		return 0, err
+	}
+	defer containerNs.Close()
+
+	nhNs, err := nlwrap.NewHandleAt(containerNs)
+	if err != nil {
+		return 0, fmt.Errorf("can not get netlink handle: %v", err)
+	}
+	defer nhNs.Close()
+
+	nsLink, err := nhNs.LinkByName(ifName)
+	if err != nil {
+		return 0, fmt.Errorf("link not found for interface %s on namespace %s: %w", ifName, containerNsPath, err)
+	}
+
+	vrfName := vrfConfig.Name
+	vrfTable := uint32(*vrfConfig.Table)
+
+	vrfLink, err := nhNs.LinkByName(vrfName)
+	if err != nil {
+		vrfReq := &netlink.Vrf{
+			LinkAttrs: netlink.LinkAttrs{Name: vrfName},
+			Table:     vrfTable,
+		}
+		if err := nhNs.LinkAdd(vrfReq); err != nil {
+			return 0, fmt.Errorf("failed to add vrf %s: %w", vrfName, err)
+		}
+		vrfLink, err = nhNs.LinkByName(vrfName)
+		if err != nil {
+			return 0, fmt.Errorf("failed to find vrf %s after creation: %w", vrfName, err)
+		}
+	}
+
+	if err := nhNs.LinkSetUp(vrfLink); err != nil {
+		return 0, fmt.Errorf("failed to set up vrf %s: %w", vrfName, err)
+	}
+
+	if err := nhNs.LinkSetMaster(nsLink, vrfLink); err != nil {
+		return 0, fmt.Errorf("failed to enslave %s to vrf %s: %w", ifName, vrfName, err)
+	}
+
+	if err := enableVRFSysctls(int(containerNs)); err != nil {
+		return 0, fmt.Errorf("failed to enable vrf sysctls: %w", err)
+	}
+
+	return int(vrfTable), nil
+}
+
+func enableVRFSysctls(containerNsFd int) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	origns, err := netns.Get()
+	if err != nil {
+		return err
+	}
+	defer origns.Close() //nolint:errcheck
+
+	if err := netns.Set(netns.NsHandle(containerNsFd)); err != nil {
+		return err
+	}
+	defer netns.Set(origns) //nolint:errcheck
+
+	sysctlInterface := sysctl.New()
+	if err := sysctlInterface.SetSysctl("net/ipv4/tcp_l3mdev_accept", 1); err != nil {
+		return fmt.Errorf("failed to set tcp_l3mdev_accept: %w", err)
+	}
+
+	if err := sysctlInterface.SetSysctl("net/ipv4/udp_l3mdev_accept", 1); err != nil {
+		return fmt.Errorf("failed to set udp_l3mdev_accept: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -276,18 +276,29 @@ func attachNetdevToNS(pod *api.PodSandbox, ns, deviceName string, config PodConf
 		}
 	}
 
+	vrfTable := 0
+	if config.NetworkInterfaceConfigInPod.Interface.VRF != nil {
+		vrfTable, err = applyVRFConfig(ns, ifNameInNs, config.NetworkInterfaceConfigInPod.Interface.VRF)
+		if err != nil {
+			return fmt.Errorf("error configuring VRF for device %s in ns %s: %w", deviceName, ns, err)
+		}
+	}
+
 	// Configure routes
-	err = applyRoutingConfig(ns, ifNameInNs, config.NetworkInterfaceConfigInPod.Routes)
+	err = applyRoutingConfig(ns, ifNameInNs, config.NetworkInterfaceConfigInPod.Routes, vrfTable)
 	if err != nil {
 		klog.Infof("RunPodSandbox error configuring device %s namespace %s routing: %v", deviceName, ns, err)
 		return fmt.Errorf("error configuring device %s routes on namespace %s: %v", deviceName, ns, err)
 	}
 
 	// Configure rules
-	err = applyRulesConfig(ns, config.NetworkInterfaceConfigInPod.Rules)
-	if err != nil {
-		klog.Infof("RunPodSandbox error configuring device %s namespace %s rules: %v", deviceName, ns, err)
-		return fmt.Errorf("error configuring device %s rules on namespace %s: %v", deviceName, ns, err)
+	// If VRF is enabled, rules are not needed/supported as routing is handled by the VRF table + l3mdev.
+	if vrfTable == 0 {
+		err = applyRulesConfig(ns, config.NetworkInterfaceConfigInPod.Rules)
+		if err != nil {
+			klog.Infof("RunPodSandbox error configuring device %s namespace %s rules: %v", deviceName, ns, err)
+			return fmt.Errorf("error configuring device %s rules on namespace %s: %v", deviceName, ns, err)
+		}
 	}
 
 	// Configure neighbors

--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -11,6 +11,7 @@ teardown() {
   fi
   cleanup_k8s_resources
   cleanup_dummy_interfaces
+  cleanup_veth_interfaces
   cleanup_bpf_programs
   # The driver is rate limited to updates with interval of atleast 5 seconds. So
   # we need to sleep for an equivalent amount of time to ensure state from a
@@ -61,6 +62,17 @@ cleanup_dummy_interfaces() {
       for dev in $(ip -br link show type dummy | awk "{print \$1}"); do
         ip link delete "$dev" || echo "Failed to delete $dev"
       done
+    '
+  done
+}
+
+cleanup_veth_interfaces() {
+  for node in "$CLUSTER_NAME"-worker "$CLUSTER_NAME"-worker2; do
+    docker exec "$node" bash -c '
+      ip link delete vrf-test-pod-1 || true
+      ip link delete vrf-test-pod-2 || true
+      ip link delete pbr-test-pod-1 || true
+      ip link delete pbr-test-pod-2 || true
     '
   done
 }
@@ -495,3 +507,69 @@ EOF
   refute_output --partial "fd36::3:0:e:0:0/96 dev dummy-ipv6 metric 1024 pref medium"
 }
 
+
+@test "validate pbr configuration" {
+  local NODE_NAME="$CLUSTER_NAME"-worker
+  
+  # Create veth pairs for Pod1 <-> Router and Pod2 <-> Router
+  # pbr-test-pod-1 connects to pbr-test-router-1 (Router Interface 1)
+  docker exec "$NODE_NAME" bash -c "ip link add pbr-test-pod-1 type veth peer name pbr-rtr-1"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev pbr-test-pod-1"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev pbr-rtr-1"
+
+  # pbr-test-pod-2 connects to pbr-test-router-2 (Router Interface 2)
+  docker exec "$NODE_NAME" bash -c "ip link add pbr-test-pod-2 type veth peer name pbr-rtr-2"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev pbr-test-pod-2"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev pbr-rtr-2"
+
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/deviceclass.yaml
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/resourceclaim_pbr.yaml
+  
+  kubectl wait --timeout=60s --for=condition=ready pods -l app=pod-pbr-1
+  kubectl wait --timeout=60s --for=condition=ready pods -l app=pod-pbr-router
+  kubectl wait --timeout=60s --for=condition=ready pods -l app=pod-pbr-2
+
+  POD_1=$(kubectl get pods -l app=pod-pbr-1 -o name)
+  
+  # Verify PBR routing: Ping from Pod 1 (192.168.100.10) to Pod 2 (192.168.200.10) via Router
+  # Traffic MUST use Table 100 to reach the gateway (192.168.100.2 - Router).
+  # Router then forwards to 192.168.200.2 which is its own interface on the other side?
+  # Interface 1: 192.168.100.2/24 (connected to pod-pbr-1)
+  # Interface 2: 192.168.200.2/24 (connected to pod-pbr-2)
+  # Pod-pbr-1 routes 192.168.200.0/24 via 192.168.100.2.
+  # Pod-pbr-2 has IP 192.168.200.10.
+  
+  run kubectl exec -it $POD_1 -- ping -c 1 192.168.200.10
+  assert_success
+}
+
+@test "validate vrf routing" {
+  local NODE_NAME="$CLUSTER_NAME"-worker
+  
+  # Create veth pairs for Pod1 <-> Router and Pod2 <-> Router
+  # vrf-test-pod-1 connects to vrf-test-router-1 (Router Interface 1)
+  docker exec "$NODE_NAME" bash -c "ip link add vrf-test-pod-1 type veth peer name vrf-rtr-1"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev vrf-test-pod-1"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev vrf-rtr-1"
+
+  # vrf-test-pod-2 connects to vrf-test-router-2 (Router Interface 2)
+  docker exec "$NODE_NAME" bash -c "ip link add vrf-test-pod-2 type veth peer name vrf-rtr-2"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev vrf-test-pod-2"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev vrf-rtr-2"
+
+  # Apply manifests for three pods
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/deviceclass.yaml
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/resourceclaim_vrf.yaml
+
+  kubectl wait --timeout=60s --for=condition=ready pods -l app=pod-vrf-1
+  kubectl wait --timeout=60s --for=condition=ready pods -l app=pod-vrf-router
+  kubectl wait --timeout=60s --for=condition=ready pods -l app=pod-vrf-2
+
+  POD_1=$(kubectl get pods -l app=pod-vrf-1 -o name)
+  
+  # Verify ping from Pod 1 to Pod 2 via the Router.
+  # Traffic flow: Pod1(eth1) -> Router(eth1) -> Router(eth2) -> Pod2(eth1)
+  # We use -I eth1 to force usage of the VRF domain/interface.
+  run kubectl exec -it $POD_1 -- ping -I eth1 -c 1 10.10.20.1
+  assert_success
+}

--- a/tests/manifests/resourceclaim_pbr.yaml
+++ b/tests/manifests/resourceclaim_pbr.yaml
@@ -1,0 +1,151 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: dynamic-interface-pbr-1
+spec:
+  devices:
+    requests:
+      - name: req-veth
+        exactly:
+          deviceClassName: dra.net
+          selectors:
+            - cel:
+                expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "pbr-test-pod-1"
+    config:
+      - opaque:
+          driver: dra.net
+          parameters:
+            interface:
+              name: "eth1"
+              addresses:
+                - "192.168.100.10/24"
+            rules:
+              - source: "192.168.100.0/24"
+                table: 100
+                priority: 32000
+              - destination: "192.168.200.0/24"
+                table: 100
+                priority: 32000
+            routes:
+              - destination: "0.0.0.0/0"
+                table: 100
+                gateway: "192.168.100.2"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-pbr-1
+  labels:
+    app: pod-pbr-1
+spec:
+  containers:
+    - name: ctr1
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
+      command: ["/agnhost", "netexec", "--http-port=8080"]
+  resourceClaims:
+    - name: pbr1
+      resourceClaimName: dynamic-interface-pbr-1
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: dynamic-interface-pbr-2
+spec:
+  devices:
+    requests:
+      - name: req-veth
+        exactly:
+          deviceClassName: dra.net
+          selectors:
+            - cel:
+                expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "pbr-test-pod-2"
+    config:
+      - opaque:
+          driver: dra.net
+          parameters:
+            interface:
+              name: "eth1"
+              addresses:
+                - "192.168.200.10/24"
+            rules:
+              - source: "192.168.200.0/24"
+                table: 100
+                priority: 32000
+              - destination: "192.168.100.0/24"
+                table: 100
+                priority: 32000
+            routes:
+              - destination: "0.0.0.0/0"
+                table: 100
+                gateway: "192.168.200.2"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-pbr-2
+  labels:
+    app: pod-pbr-2
+spec:
+  containers:
+    - name: ctr1
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
+      command: ["/agnhost", "netexec", "--http-port=8080"]
+  resourceClaims:
+    - name: pbr2
+      resourceClaimName: dynamic-interface-pbr-2
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: dynamic-interface-pbr-router
+spec:
+  devices:
+    requests:
+      - name: req-veth-router-1
+        exactly:
+          deviceClassName: dra.net
+          selectors:
+            - cel:
+                expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "pbr-rtr-1"
+      - name: req-veth-router-2
+        exactly:
+          deviceClassName: dra.net
+          selectors:
+            - cel:
+                expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "pbr-rtr-2"
+    config:
+      - requests:
+          - req-veth-router-1
+        opaque:
+          driver: dra.net
+          parameters:
+            interface:
+              name: "eth1"
+              addresses:
+                - "192.168.100.2/24"
+              forwarding: true
+      - requests:
+          - req-veth-router-2
+        opaque:
+          driver: dra.net
+          parameters:
+            interface:
+              name: "eth2"
+              addresses:
+                - "192.168.200.2/24"
+              forwarding: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-pbr-router
+  labels:
+    app: pod-pbr-router
+spec:
+  containers:
+    - name: ctr1
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
+      command: ["/agnhost", "netexec", "--http-port=8080"]
+  resourceClaims:
+    - name: pbr-router
+      resourceClaimName: dynamic-interface-pbr-router

--- a/tests/manifests/resourceclaim_vrf.yaml
+++ b/tests/manifests/resourceclaim_vrf.yaml
@@ -1,0 +1,143 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: dynamic-interface-vrf-1
+spec:
+  devices:
+    requests:
+      - name: req-veth-1
+        exactly:
+          deviceClassName: dra.net
+          selectors:
+            - cel:
+                expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "vrf-test-pod-1"
+    config:
+      - opaque:
+          driver: dra.net
+          parameters:
+            interface:
+              name: "eth1"
+              addresses:
+                - "10.10.10.1/24"
+              vrf:
+                name: "test-vrf"
+            routes:
+              - destination: "0.0.0.0/0"
+                gateway: "10.10.10.2"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-vrf-1
+  labels:
+    app: pod-vrf-1
+spec:
+  containers:
+    - name: ctr1
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
+      command: ["/agnhost", "netexec", "--http-port=8080"]
+  resourceClaims:
+    - name: vrf1
+      resourceClaimName: dynamic-interface-vrf-1
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: dynamic-interface-vrf-2
+spec:
+  devices:
+    requests:
+      - name: req-veth-2
+        exactly:
+          deviceClassName: dra.net
+          selectors:
+            - cel:
+                expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "vrf-test-pod-2"
+    config:
+      - opaque:
+          driver: dra.net
+          parameters:
+            interface:
+              name: "eth1"
+              addresses:
+                - "10.10.20.1/24"
+              vrf:
+                name: "test-vrf"
+            routes:
+              - destination: "0.0.0.0/0"
+                gateway: "10.10.20.2"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-vrf-2
+  labels:
+    app: pod-vrf-2
+spec:
+  containers:
+    - name: ctr1
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
+      command: ["/agnhost", "netexec", "--http-port=8080"]
+  resourceClaims:
+    - name: vrf2
+      resourceClaimName: dynamic-interface-vrf-2
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: dynamic-interface-vrf-router
+spec:
+  devices:
+    requests:
+      - name: req-veth-router-1
+        exactly:
+          deviceClassName: dra.net
+          selectors:
+            - cel:
+                expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "vrf-rtr-1"
+      - name: req-veth-router-2
+        exactly:
+          deviceClassName: dra.net
+          selectors:
+            - cel:
+                expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "vrf-rtr-2"
+    config:
+      - requests:
+          - req-veth-router-1
+        opaque:
+          driver: dra.net
+          parameters:
+            interface:
+              name: "eth1"
+              addresses:
+                - "10.10.10.2/24"
+              forwarding: true
+              vrf:
+                name: "test-vrf"
+      - requests:
+          - req-veth-router-2
+        opaque:
+          driver: dra.net
+          parameters:
+            interface:
+              name: "eth2"
+              addresses:
+                - "10.10.20.2/24"
+              forwarding: true
+              vrf:
+                name: "test-vrf"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-vrf-router
+  labels:
+    app: pod-vrf-router
+spec:
+  containers:
+    - name: ctr1
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
+      command: ["/agnhost", "netexec", "--http-port=8080"]
+  resourceClaims:
+    - name: vrf-router
+      resourceClaimName: dynamic-interface-vrf-router

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -41,7 +41,7 @@ function setup_suite {
     docker exec "$node" mount --make-shared /sys/fs/bpf
   done
 
-  _install=$(sed s#"$IMAGE_NAME".*#"$IMAGE_NAME":test# < "$BATS_TEST_DIRNAME"/../install.yaml)
+  _install=$(sed -e s#"$IMAGE_NAME".*#"$IMAGE_NAME":test# -e 's/--v=4/--v=4\n        - --filter=/' < "$BATS_TEST_DIRNAME"/../install.yaml)
   printf '%s' "${_install}" | kubectl apply -f -
   kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=dranet
 


### PR DESCRIPTION
There are some cases where users traditionally relay on PBR to implement route based policies, this is specially critical on multihomed environments since the assymetric routing can broke application behavior.

DRANET already supports PBR but that is error prone and hard to troubleshoot, the elegant way to solve this problem is using VRF but allowing the applications that bind to 0.0.0.0 and :: to listen also on the VRF interfaces, so we set the corresponding sysctl for the applications within the pod to listen on the VRF interfaces and expose a configuration option so users can attach interfaces to vrfs on pods.

Fixes: #42 