### PR TITLE
fix: update module paths to sigs.k8s.io/dranet

### DIFF
--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -31,11 +31,11 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
-	"github.com/google/dranet/pkg/driver"
-	"github.com/google/dranet/pkg/inventory"
-	"github.com/google/dranet/pkg/pcidb"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/time/rate"
+	"sigs.k8s.io/dranet/pkg/driver"
+	"sigs.k8s.io/dranet/pkg/inventory"
+	"sigs.k8s.io/dranet/pkg/pcidb"
 
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/client-go/kubernetes"

--- a/cmd/dranetctl/app.go
+++ b/cmd/dranetctl/app.go
@@ -24,10 +24,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/google/dranet/pkg/dranetctl/gke"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/dranet/pkg/dranetctl/gke"
 )
 
 var rootCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/dranet
+module sigs.k8s.io/dranet
 
 go 1.25.0
 

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -17,8 +17,8 @@ limitations under the License.
 package cloudprovider
 
 import (
-	"github.com/google/dranet/pkg/apis"
 	resourceapi "k8s.io/api/resource/v1"
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
 // DeviceIdentifiers contains locally discovered hardware identifiers

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
-	"github.com/google/dranet/pkg/apis"
-	"github.com/google/dranet/pkg/cloudprovider"
 	resourceapi "k8s.io/api/resource/v1"
+	"sigs.k8s.io/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
 )
 
 // GPUDirectSupport represents the type of GPUDirect support for a given machine type.

--- a/pkg/cloudprovider/gce/gce_test.go
+++ b/pkg/cloudprovider/gce/gce_test.go
@@ -19,7 +19,7 @@ package gce
 import (
 	"testing"
 
-	"github.com/google/dranet/pkg/cloudprovider"
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/pkg/dranetctl/gke/acceleratorpod.go
+++ b/pkg/dranetctl/gke/acceleratorpod.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/container/apiv1/containerpb"
-	"github.com/google/dranet/pkg/cloudprovider/gce"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/dranet/pkg/cloudprovider/gce"
 
 	"k8s.io/klog/v2"
 )

--- a/pkg/driver/dhcp.go
+++ b/pkg/driver/dhcp.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/google/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/apis"
 
-	"github.com/google/dranet/internal/nlwrap"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
 	"github.com/vishvananda/netlink"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 )
 
 func getDHCP(ctx context.Context, ifName string) (ip string, routes []apis.RouteConfig, err error) {

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -24,13 +24,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/dranet/pkg/apis"
-	"github.com/google/dranet/pkg/filter"
+	"sigs.k8s.io/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/filter"
 
 	"github.com/Mellanox/rdmamap"
-	"github.com/google/dranet/internal/nlwrap"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -22,13 +22,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/dranet/pkg/apis"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
-
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
 func TestPublishResourcesPrometheusMetrics(t *testing.T) {
@@ -277,4 +276,3 @@ func TestPublishResourcesMetrics(t *testing.T) {
 		}
 	})
 }
-

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -24,11 +24,11 @@ import (
 	"time"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/dranet/pkg/apis"
-	"github.com/google/dranet/pkg/inventory"
+	"sigs.k8s.io/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/inventory"
 
 	"github.com/containerd/nri/pkg/stub"
-	"github.com/google/dranet/internal/nlwrap"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -3,10 +3,10 @@ package driver
 import (
 	"context"
 
-	"github.com/google/dranet/pkg/apis"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
 // fakeDraPlugin is a mock implementation of the pluginHelper interface for testing.

--- a/pkg/driver/ebpf.go
+++ b/pkg/driver/ebpf.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
-	"github.com/google/dranet/internal/nlwrap"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 )
 
 // unpinBPFPrograms runs in the host namespace to delete all the pinned bpf programs

--- a/pkg/driver/ethtool.go
+++ b/pkg/driver/ethtool.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/apis"
 
 	"github.com/mdlayher/genetlink"
 	"github.com/mdlayher/netlink"

--- a/pkg/driver/ethtool_test.go
+++ b/pkg/driver/ethtool_test.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/dranet/internal/nlwrap"
-	"github.com/google/dranet/pkg/apis"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	"sigs.k8s.io/dranet/internal/nlwrap"
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
 func Test_applyEthtoolConfig(t *testing.T) {

--- a/pkg/driver/hostdevice.go
+++ b/pkg/driver/hostdevice.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/google/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/apis"
 
-	"github.com/google/dranet/internal/nlwrap"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/klog/v2"

--- a/pkg/driver/hostdevice_test.go
+++ b/pkg/driver/hostdevice_test.go
@@ -26,11 +26,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/dranet/internal/nlwrap"
-	"github.com/google/dranet/pkg/apis"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/dranet/internal/nlwrap"
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
 func Test_nhNetdev(t *testing.T) {

--- a/pkg/driver/netnamespace.go
+++ b/pkg/driver/netnamespace.go
@@ -23,11 +23,11 @@ import (
 	"slices"
 	"syscall"
 
-	"github.com/google/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/apis"
 
-	"github.com/google/dranet/internal/nlwrap"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 )
 
 func applyRoutingConfig(containerNsPAth string, ifName string, routeConfig []apis.RouteConfig) error {

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"github.com/containerd/nri/pkg/api"
-	"github.com/google/dranet/pkg/inventory"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/dranet/pkg/inventory"
 )
 
 func TestCreateContainerNoDuplicateDevices(t *testing.T) {

--- a/pkg/driver/pod_device_config.go
+++ b/pkg/driver/pod_device_config.go
@@ -19,8 +19,8 @@ package driver
 import (
 	"sync"
 
-	"github.com/google/dranet/pkg/apis"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
 // PodConfig holds the set of configurations to be applied for a single

--- a/pkg/driver/pod_device_config_test.go
+++ b/pkg/driver/pod_device_config_test.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/google/dranet/pkg/apis"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
 func TestNewPodConfigStore(t *testing.T) {

--- a/pkg/driver/rdmadevice.go
+++ b/pkg/driver/rdmadevice.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/google/dranet/internal/nlwrap"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 )
 
 // Based on existing RDMA CNI plugin

--- a/pkg/driver/subinterfaces.go
+++ b/pkg/driver/subinterfaces.go
@@ -19,9 +19,9 @@ package driver
 import (
 	"fmt"
 
-	"github.com/google/dranet/internal/nlwrap"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 )
 
 func addMacVlan(containerNsPAth string, devName string, mode netlink.MacvlanMode) error {

--- a/pkg/inventory/cloud.go
+++ b/pkg/inventory/cloud.go
@@ -24,10 +24,10 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"github.com/google/dranet/pkg/apis"
-	"github.com/google/dranet/pkg/cloudprovider"
-	"github.com/google/dranet/pkg/cloudprovider/gce"
 	resourceapi "k8s.io/api/resource/v1"
+	"sigs.k8s.io/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
+	"sigs.k8s.io/dranet/pkg/cloudprovider/gce"
 )
 
 // getInstanceProperties get the instace properties and stores them in a global variable to be used in discovery

--- a/pkg/inventory/cloud_test.go
+++ b/pkg/inventory/cloud_test.go
@@ -19,13 +19,13 @@ package inventory
 import (
 	"testing"
 
-	"github.com/google/dranet/pkg/apis"
-	"github.com/google/dranet/pkg/cloudprovider"
-	"github.com/google/dranet/pkg/cloudprovider/gce"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
+	"sigs.k8s.io/dranet/pkg/cloudprovider/gce"
 )
 
 // mockCloudInstance implements cloudprovider.CloudInstance for testing

--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -26,12 +26,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/dranet/pkg/apis"
-	"github.com/google/dranet/pkg/cloudprovider"
-	"github.com/google/dranet/pkg/names"
+	"sigs.k8s.io/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
+	"sigs.k8s.io/dranet/pkg/names"
 
 	"github.com/Mellanox/rdmamap"
-	"github.com/google/dranet/internal/nlwrap"
 	"github.com/jaypipes/ghw"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -41,6 +40,7 @@ import (
 	"k8s.io/dynamic-resource-allocation/deviceattribute"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 )
 
 const (

--- a/pkg/inventory/net.go
+++ b/pkg/inventory/net.go
@@ -19,9 +19,9 @@ package inventory
 import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
-	"github.com/google/dranet/internal/nlwrap"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"

--- a/pkg/pcidb/pcidb.go
+++ b/pkg/pcidb/pcidb.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/dranet/third_party"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/dranet/third_party"
 )
 
 var (

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/dranet
+module sigs.k8s.io/dranet
 
 go 1.23.4
 


### PR DESCRIPTION
Noticed this inconsistency between the current project home and the module path. It doesn't cause any visible issues with the build because imports are all evaluated locally and the go.mod declares the same module path as all of the imports, but if you try to `go get` it, for example:

```bash
$ go get sigs.k8s.io/dranet
go: downloading sigs.k8s.io/dranet v1.0.1
go: sigs.k8s.io/dranet@upgrade (v1.0.1) requires sigs.k8s.io/dranet@v1.0.1: parsing go.mod:
        module declares its path as: github.com/google/dranet
                but was required as: sigs.k8s.io/dranet
```

Which isn't resolvable since `github.com/google/dranet` still exists.

So ran a simple find/replace for `github.com/google/dranet -> sigs.k8s.io/dranet` then a `go fmt ./...` to reorder the new imports and made sure it still builds.