### PR TITLE
Add --move-ib-interfaces flag to control IPoIB interface handling

### DIFF
--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -57,6 +57,7 @@ var (
 	minPollInterval  time.Duration
 	maxPollInterval  time.Duration
 	pollBurst        int
+	moveIBInterfaces bool
 
 	ready atomic.Bool
 )
@@ -69,6 +70,7 @@ func init() {
 	flag.DurationVar(&minPollInterval, "inventory-min-poll-interval", 2*time.Second, "The minimum interval between two consecutive polls of the inventory.")
 	flag.DurationVar(&maxPollInterval, "inventory-max-poll-interval", 1*time.Minute, "The maximum interval between two consecutive polls of the inventory.")
 	flag.IntVar(&pollBurst, "inventory-poll-burst", 5, "The number of polls that can be run in a burst.")
+	flag.BoolVar(&moveIBInterfaces, "move-ib-interfaces", true, "If true, InfiniBand (IPoIB) network interfaces associated with PCI devices are moved into pod network namespace. If false, moving IB network interfaces are skipped and the underlying device is exposed as an IB-only RDMA device.")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: dranet [options]\n\n")
@@ -162,6 +164,7 @@ func main() {
 	db := inventory.New(
 		inventory.WithRateLimiter(rate.NewLimiter(rate.Every(minPollInterval), pollBurst)),
 		inventory.WithMaxPollInterval(maxPollInterval),
+		inventory.WithMoveIBInterfaces(moveIBInterfaces),
 	)
 	opts = append(opts, driver.WithInventory(db))
 	dranet, err := driver.Start(ctx, driverName, clientset, nodeName, opts...)

--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -85,6 +85,13 @@ type DB struct {
 	maxPollInterval time.Duration
 	notifications   chan []resourceapi.Device
 	hasDevices      bool
+
+	// moveIBInterfaces controls whether IPoIB network interfaces are
+	// associated with their PCI devices. When true (default), IPoIB interfaces
+	// are treated like regular network interfaces and moved into pod namespaces.
+	// When false, IPoIB interfaces are skipped and the underlying device is
+	// exposed as an IB-only RDMA device.
+	moveIBInterfaces bool
 }
 
 type Option func(*DB)
@@ -101,6 +108,12 @@ func WithMaxPollInterval(d time.Duration) Option {
 	}
 }
 
+func WithMoveIBInterfaces(move bool) Option {
+	return func(db *DB) {
+		db.moveIBInterfaces = move
+	}
+}
+
 func New(opts ...Option) *DB {
 	db := &DB{
 		podNetNsStore:     map[string]string{},
@@ -109,6 +122,7 @@ func New(opts ...Option) *DB {
 		rateLimiter:       rate.NewLimiter(rate.Every(defaultMinPollInterval), defaultPollBurst),
 		notifications:     make(chan []resourceapi.Device),
 		maxPollInterval:   defaultMaxPollInterval,
+		moveIBInterfaces:  true,
 	}
 	for _, o := range opts {
 		o(db)
@@ -298,12 +312,14 @@ func (db *DB) discoverNetworkInterfaces(pciDevices []resourceapi.Device) []resou
 			continue
 		}
 
-		// Skip IPoIB interfaces. The underlying PCI device will be discovered
-		// as an IB-only RDMA device (no netdev) via discoverRDMADevices.
-		// Associating the IPoIB netdev with the PCI device would mask the
-		// IB-only nature of the device and prevent correct RDMA char device
-		// injection into pods.
-		if link.Type() == "ipoib" {
+		// When moveIBInterfaces is false, skip IPoIB interfaces.
+		// The underlying PCI device will be discovered as an IB-only RDMA
+		// device (no netdev) via discoverRDMADevices. Associating the IPoIB
+		// netdev with the PCI device would mask the IB-only nature of the
+		// device and prevent correct RDMA char device injection into pods.
+		// When moveIBInterfaces is true (default), IPoIB interfaces
+		// are associated with their PCI device so they can be moved into pod namespace.
+		if link.Type() == "ipoib" && !db.moveIBInterfaces {
 			klog.V(4).Infof("Network Interface %s is IPoIB, skipping netdev association (will be discovered as IB-only RDMA device)", ifName)
 			continue
 		}


### PR DESCRIPTION
Adds a [`--move-ib-interfaces`] flag (default: `true`) to make IPoIB network interface handling configurable.

When true, IPoIB interfaces are associated with their PCI devices and moved into pod namespaces like regular network interfaces. When false, IPoIB interfaces are skipped during discovery and the underlying device is exposed as an IB-only RDMA device.