### PR TITLE
Fallback to get rdma device from sysfs

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/filter"
+	"sigs.k8s.io/dranet/pkg/inventory"
 
 	"github.com/Mellanox/rdmamap"
 	"github.com/vishvananda/netlink"
@@ -341,7 +342,7 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 		}
 
 		// Get RDMA configuration: link and char devices
-		if rdmaDev, _ := rdmamap.GetRdmaDeviceForNetdevice(ifName); rdmaDev != "" {
+		if rdmaDev, err := inventory.GetRdmaDevice(ifName); err == nil && rdmaDev != "" {
 			klog.V(2).Infof("RunPodSandbox processing RDMA device: %s", rdmaDev)
 			podCfg.RDMADevice.LinkDev = rdmaDev
 			// Obtain the char devices associated to the rdma device

--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -405,7 +405,7 @@ func (db *DB) discoverRDMADevices(devices []resourceapi.Device) []resourceapi.De
 			// against node GUID instead of port GUID:
 			// https://github.com/Mellanox/rdmamap/issues/15
 			if !isRDMA {
-				isRDMA = hasRDMADeviceInSysfs(*ifName)
+				isRDMA = isRdmaDeviceInSysfs(*ifName)
 			}
 		} else if pciAddr := devices[i].Attributes[apis.AttrPCIAddress].StringValue; pciAddr != nil && *pciAddr != "" {
 			rdmaDevices := rdmamap.GetRdmaDevicesForPcidev(*pciAddr)

--- a/pkg/inventory/sysfs.go
+++ b/pkg/inventory/sysfs.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Mellanox/rdmamap"
 	"k8s.io/klog/v2"
 )
 
@@ -100,7 +101,52 @@ func sriovNumVFs(name string) int {
 	return t
 }
 
-// hasRDMADeviceInSysfs checks if a network interface has RDMA capability by
+// GetRdmaDevice returns the RDMA device name for a given network interface by
+// first checking GetRdmaDeviceForNetdevice. If rdmamap fails, it falls back to
+// checking the sysfs infiniband directory. This serves as a workaround for
+// cases where the rdmamap library fails to detect RDMA devices, particularly
+// for InfiniBand interfaces where the library incorrectly compares against the
+// node GUID instead of the port GUID.
+func GetRdmaDevice(ifName string) (string, error) {
+	if rdmaDev, _ := rdmamap.GetRdmaDeviceForNetdevice(ifName); rdmaDev != "" {
+		return rdmaDev, nil
+	}
+
+	// Fallback to sysfs check if rdmamap fails. This is particularly related to a known
+	// issue to detect RDMA devices for certain Mellanox NICs
+	// https://github.com/Mellanox/rdmamap/issues/15
+
+	rdmaDev, err := getRdmaDeviceFromSysfs(sysnetPath, ifName)
+	if err != nil {
+		return "", fmt.Errorf("no RDMA device found for %s: %w", ifName, err)
+	}
+
+	return rdmaDev, nil
+}
+
+// getRdmaDeviceFromSysfs function checks /sys/class/net/{ifname}/device/infiniband/ for any RDMA
+// device entries. If the directory exists and contains at least one entry,
+// it returns the name of the first RDMA device found.
+// If the directory does not exist or contains no entries, it returns an error indicating
+// that no RDMA device was found for the specified interface.
+
+func getRdmaDeviceFromSysfs(basePath, ifName string) (string, error) {
+	rdmaDir := filepath.Join(basePath, ifName, "device", "infiniband")
+	entries, err := os.ReadDir(rdmaDir)
+	if err != nil {
+		return "", fmt.Errorf("no RDMA device for %s: %w", ifName, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			klog.V(4).Infof("Found RDMA device %s for interface %s via sysfs", entry.Name(), ifName)
+			return entry.Name(), nil // Return first RDMA device found (e.g., "mlx5_0")
+		}
+	}
+	return "", fmt.Errorf("no RDMA device found for %s", ifName)
+}
+
+// isRdmaDeviceInSysfs checks if a network interface has RDMA capability by
 // examining the sysfs infiniband directory. This serves as a workaround for
 // cases where the rdmamap library fails to detect RDMA devices, particularly
 // for InfiniBand interfaces where the library incorrectly compares against the
@@ -109,22 +155,16 @@ func sriovNumVFs(name string) int {
 // The function checks /sys/class/net/{ifname}/device/infiniband/ for any RDMA
 // device entries. If the directory exists and contains at least one entry, the
 // interface is considered RDMA-capable.
-func hasRDMADeviceInSysfs(ifName string) bool {
+func isRdmaDeviceInSysfs(ifName string) bool {
 	// Check if the infiniband directory exists under the device
-	ibPath := filepath.Join(sysnetPath, ifName, "device", "infiniband")
-	entries, err := os.ReadDir(ibPath)
+	rdmaName, err := getRdmaDeviceFromSysfs(sysnetPath, ifName)
 	if err != nil {
-		// Directory doesn't exist or can't be read
+		klog.V(4).Infof("No RDMA device found for interface %s via sysfs: %v", ifName, err)
 		return false
 	}
-	// If there's at least one entry (RDMA device), return true
-	for _, entry := range entries {
-		if entry.IsDir() {
-			klog.V(4).Infof("Found RDMA device %s for interface %s via sysfs", entry.Name(), ifName)
-			return true
-		}
-	}
-	return false
+
+	klog.V(4).Infof("Interface %s is RDMA-capable with device %s", ifName, rdmaName)
+	return true
 }
 
 // pciAddress BDF Notation

--- a/pkg/inventory/sysfs_test.go
+++ b/pkg/inventory/sysfs_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package inventory
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -132,6 +135,146 @@ func TestPCIAddressFromPath(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(pciAddress{})); diff != "" {
 				t.Errorf("pciAddressFromPath() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestGetRdmaDeviceFromSysfs tests the getRdmaDeviceFromSysfs function
+func TestGetRdmaDeviceFromSysfs(t *testing.T) {
+	testCases := []struct {
+		name        string
+		ifName      string
+		setupFunc   func(t *testing.T, baseDir string)
+		want        string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "valid RDMA device found",
+			ifName: "eth0",
+			setupFunc: func(t *testing.T, baseDir string) {
+				// Create mock sysfs structure: /sys/class/net/eth0/device/infiniband/mlx5_0
+				rdmaDir := filepath.Join(baseDir, "eth0", "device", "infiniband", "mlx5_0")
+				if err := os.MkdirAll(rdmaDir, 0755); err != nil {
+					t.Fatalf("failed to create mock sysfs dir: %v", err)
+				}
+			},
+			want:    "mlx5_0",
+			wantErr: false,
+		},
+		{
+			name:   "multiple RDMA devices returns first",
+			ifName: "eth1",
+			setupFunc: func(t *testing.T, baseDir string) {
+				// Create mock sysfs structure with multiple RDMA devices
+				for _, rdmaDev := range []string{"mlx5_0", "mlx5_1"} {
+					rdmaDir := filepath.Join(baseDir, "eth1", "device", "infiniband", rdmaDev)
+					if err := os.MkdirAll(rdmaDir, 0755); err != nil {
+						t.Fatalf("failed to create mock sysfs dir: %v", err)
+					}
+				}
+			},
+			want:    "", // Returns first found, but order is not guaranteed
+			wantErr: false,
+		},
+		{
+			name:   "no RDMA device - infiniband dir missing",
+			ifName: "eth2",
+			setupFunc: func(t *testing.T, baseDir string) {
+				// Create mock sysfs structure without infiniband dir
+				deviceDir := filepath.Join(baseDir, "eth2", "device")
+				if err := os.MkdirAll(deviceDir, 0755); err != nil {
+					t.Fatalf("failed to create mock sysfs dir: %v", err)
+				}
+			},
+			want:        "",
+			wantErr:     true,
+			errContains: "no RDMA device for eth2",
+		},
+		{
+			name:   "no RDMA device - empty infiniband dir",
+			ifName: "eth3",
+			setupFunc: func(t *testing.T, baseDir string) {
+				// Create mock sysfs structure with empty infiniband dir
+				rdmaDir := filepath.Join(baseDir, "eth3", "device", "infiniband")
+				if err := os.MkdirAll(rdmaDir, 0755); err != nil {
+					t.Fatalf("failed to create mock sysfs dir: %v", err)
+				}
+			},
+			want:        "",
+			wantErr:     true,
+			errContains: "no RDMA device found for eth3",
+		},
+		{
+			name:   "interface does not exist",
+			ifName: "nonexistent",
+			setupFunc: func(t *testing.T, baseDir string) {
+				// Don't create anything
+			},
+			want:        "",
+			wantErr:     true,
+			errContains: "no RDMA device for nonexistent",
+		},
+		{
+			name:   "only files in infiniband dir, no directories",
+			ifName: "eth4",
+			setupFunc: func(t *testing.T, baseDir string) {
+				// Create mock sysfs structure with only files (no directories)
+				rdmaDir := filepath.Join(baseDir, "eth4", "device", "infiniband")
+				if err := os.MkdirAll(rdmaDir, 0755); err != nil {
+					t.Fatalf("failed to create mock sysfs dir: %v", err)
+				}
+				// Create a file instead of directory
+				filePath := filepath.Join(rdmaDir, "somefile")
+				if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+					t.Fatalf("failed to create mock file: %v", err)
+				}
+			},
+			want:        "",
+			wantErr:     true,
+			errContains: "no RDMA device found for eth4",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create temporary directory to mock /sys/class/net
+			tmpDir := t.TempDir()
+
+			// Setup mock sysfs structure
+			tc.setupFunc(t, tmpDir)
+
+			// Call the sysfs fallback helper with the temp dir
+			got, err := getRdmaDeviceFromSysfs(tmpDir, tc.ifName)
+
+			// Check error conditions
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("getRdmaDeviceFromSysfs() expected error, got nil")
+					return
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("getRdmaDeviceFromSysfs() error = %v, want error containing %q", err, tc.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("getRdmaDeviceFromSysfs() unexpected error: %v", err)
+				return
+			}
+
+			// For the "multiple RDMA devices" case, just check we got something valid
+			if tc.name == "multiple RDMA devices returns first" {
+				if got != "mlx5_0" && got != "mlx5_1" {
+					t.Errorf("getRdmaDeviceFromSysfs() = %v, want mlx5_0 or mlx5_1", got)
+				}
+				return
+			}
+
+			if got != tc.want {
+				t.Errorf("getRdmaDeviceFromSysfs() = %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
if rdmamap call of GetRdmaDeviceForNetDevice failed, then dranet can fallback to get rdma device name via sysfs call.

This PR fixes similar to this PR https://github.com/kubernetes-sigs/dranet/pull/9 but in different part of code 

continuation of this PR: #57 