### PR TITLE
refactor: Introduce PodConfig to capture pod level settings

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -216,7 +216,7 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 		netconf := *mergedConf
 
 		klog.V(4).Infof("PrepareResourceClaim %s/%s final Configuration %#v", claim.Namespace, claim.Name, netconf)
-		podCfg := PodConfig{
+		deviceCfg := DeviceConfig{
 			Claim: types.NamespacedName{
 				Namespace: claim.Namespace,
 				Name:      claim.Name,
@@ -245,11 +245,11 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 				errorList = append(errorList, fmt.Errorf("failed to get RDMA device name for IB-only device %s: %v", result.Device, err))
 				continue
 			}
-			podCfg.RDMADevice = buildRDMAConfig(rdmaDevName, charDevices)
+			deviceCfg.RDMADevice = buildRDMAConfig(rdmaDevName, charDevices)
 			for _, uid := range podUIDs {
-				np.podConfigStore.Set(uid, result.Device, podCfg)
+				np.podConfigStore.SetDeviceConfig(uid, result.Device, deviceCfg)
 			}
-			klog.V(4).Infof("IB-only claim resources for pods %v : %#v", podUIDs, podCfg)
+			klog.V(4).Infof("IB-only claim resources for pods %v : %#v", podUIDs, deviceCfg)
 			continue
 		}
 
@@ -264,17 +264,17 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			errorList = append(errorList, fmt.Errorf("failed to get netlink to interface %s: %v", ifName, err))
 			continue
 		}
-		podCfg.NetworkInterfaceConfigInHost.Interface.Name = ifName
+		deviceCfg.NetworkInterfaceConfigInHost.Interface.Name = ifName
 
-		if podCfg.NetworkInterfaceConfigInPod.Interface.Name == "" {
+		if deviceCfg.NetworkInterfaceConfigInPod.Interface.Name == "" {
 			// If the interface name was not explicitly overridden, use the same
 			// interface name within the pod's network namespace.
-			podCfg.NetworkInterfaceConfigInPod.Interface.Name = ifName
+			deviceCfg.NetworkInterfaceConfigInPod.Interface.Name = ifName
 		}
 
 		// If DHCP is requested, do a DHCP request to gather the network parameters (IPs and Routes)
 		// ... but we DO NOT apply them in the root namespace
-		if podCfg.NetworkInterfaceConfigInPod.Interface.DHCP != nil && *podCfg.NetworkInterfaceConfigInPod.Interface.DHCP {
+		if deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP != nil && *deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP {
 			klog.V(2).Infof("trying to get network configuration via DHCP")
 			contextCancel, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
@@ -282,10 +282,10 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			if err != nil {
 				errorList = append(errorList, fmt.Errorf("fail to get configuration via DHCP for %s: %w", ifName, err))
 			} else {
-				podCfg.NetworkInterfaceConfigInPod.Interface.Addresses = []string{ip}
-				podCfg.NetworkInterfaceConfigInPod.Routes = append(podCfg.NetworkInterfaceConfigInPod.Routes, routes...)
+				deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses = []string{ip}
+				deviceCfg.NetworkInterfaceConfigInPod.Routes = append(deviceCfg.NetworkInterfaceConfigInPod.Routes, routes...)
 			}
-		} else if len(podCfg.NetworkInterfaceConfigInPod.Interface.Addresses) == 0 {
+		} else if len(deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses) == 0 {
 			// If there is no custom addresses and no DHCP, then use the existing ones
 			// get the existing IP addresses
 			nlAddresses, err := nlHandle.AddrList(link, netlink.FAMILY_ALL)
@@ -299,13 +299,13 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 					if address.Scope != unix.RT_SCOPE_UNIVERSE {
 						continue
 					}
-					podCfg.NetworkInterfaceConfigInPod.Interface.Addresses = append(podCfg.NetworkInterfaceConfigInPod.Interface.Addresses, address.IPNet.String())
+					deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses = append(deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses, address.IPNet.String())
 				}
 			}
 		}
 
 		// Obtain the existing supported ethtool features and validate the config
-		if podCfg.NetworkInterfaceConfigInPod.Ethtool != nil {
+		if deviceCfg.NetworkInterfaceConfigInPod.Ethtool != nil {
 			client, err := newEthtoolClient(0)
 			if err != nil {
 				errorList = append(errorList, fmt.Errorf("fail to create ethtool client %v", err))
@@ -321,7 +321,7 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 
 			// translate features to the actual kernel names
 			ethtoolFeatures := map[string]bool{}
-			for feature, value := range podCfg.NetworkInterfaceConfigInPod.Ethtool.Features {
+			for feature, value := range deviceCfg.NetworkInterfaceConfigInPod.Ethtool.Features {
 				aliases := ifFeatures.Get(feature)
 				if len(aliases) == 0 {
 					errorList = append(errorList, fmt.Errorf("feature %s not supported by interface", feature))
@@ -331,7 +331,7 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 					ethtoolFeatures[alias] = value
 				}
 			}
-			podCfg.NetworkInterfaceConfigInPod.Ethtool.Features = ethtoolFeatures
+			deviceCfg.NetworkInterfaceConfigInPod.Ethtool.Features = ethtoolFeatures
 		}
 
 		// Obtain the routes and rules associated with the interface.
@@ -340,15 +340,15 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			errorList = append(errorList, err)
 			continue
 		}
-		podCfg.NetworkInterfaceConfigInPod.Routes = append(podCfg.NetworkInterfaceConfigInPod.Routes, routes...)
+		deviceCfg.NetworkInterfaceConfigInPod.Routes = append(deviceCfg.NetworkInterfaceConfigInPod.Routes, routes...)
 
 		// If VRF is enabled, we do not need to copy the rules from the host
 		// because the VRF handles the routing table lookup.
-		if podCfg.NetworkInterfaceConfigInPod.Interface.VRF == nil {
+		if deviceCfg.NetworkInterfaceConfigInPod.Interface.VRF == nil {
 			for _, table := range tables.UnsortedList() {
 				if rules, ok := rulesByTable[table]; ok {
 					klog.V(5).Infof("Adding %d rules for table %d associated with interface %s", len(rules), table, ifName)
-					podCfg.NetworkInterfaceConfigInPod.Rules = append(podCfg.NetworkInterfaceConfigInPod.Rules, rules...)
+					deviceCfg.NetworkInterfaceConfigInPod.Rules = append(deviceCfg.NetworkInterfaceConfigInPod.Rules, rules...)
 					// Avoid adding the same rule twice
 					delete(rulesByTable, table)
 				}
@@ -372,20 +372,20 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 				Destination:  neigh.IP.String(),
 				HardwareAddr: neigh.HardwareAddr.String(),
 			}
-			podCfg.NetworkInterfaceConfigInPod.Neighbors = append(podCfg.NetworkInterfaceConfigInPod.Neighbors, neighCfg)
+			deviceCfg.NetworkInterfaceConfigInPod.Neighbors = append(deviceCfg.NetworkInterfaceConfigInPod.Neighbors, neighCfg)
 		}
 
 		// Get RDMA configuration: link and char devices
 		if rdmaDev, err := inventory.GetRdmaDevice(ifName); err == nil && rdmaDev != "" {
 			klog.V(2).Infof("RunPodSandbox processing RDMA device: %s", rdmaDev)
-			podCfg.RDMADevice = buildRDMAConfig(rdmaDev, charDevices)
+			deviceCfg.RDMADevice = buildRDMAConfig(rdmaDev, charDevices)
 		}
 
 		// Remove the pinned programs before the NRI hooks since it
 		// has to walk the entire bpf virtual filesystem and is slow
 		// TODO: check if there is some other way to do this
-		if podCfg.NetworkInterfaceConfigInPod.Interface.DisableEBPFPrograms != nil &&
-			*podCfg.NetworkInterfaceConfigInPod.Interface.DisableEBPFPrograms {
+		if deviceCfg.NetworkInterfaceConfigInPod.Interface.DisableEBPFPrograms != nil &&
+			*deviceCfg.NetworkInterfaceConfigInPod.Interface.DisableEBPFPrograms {
 			err := unpinBPFPrograms(ifName)
 			if err != nil {
 				klog.Infof("error unpinning ebpf programs for %s : %v", ifName, err)
@@ -395,9 +395,9 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 		// TODO: support for multiple pods sharing the same device
 		// we'll create the subinterface here
 		for _, uid := range podUIDs {
-			np.podConfigStore.Set(uid, result.Device, podCfg)
+			np.podConfigStore.SetDeviceConfig(uid, result.Device, deviceCfg)
 		}
-		klog.V(4).Infof("Claim Resources for pods %v : %#v", podUIDs, podCfg)
+		klog.V(4).Infof("Claim Resources for pods %v : %#v", podUIDs, deviceCfg)
 	}
 
 	if len(errorList) > 0 {

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -196,7 +196,7 @@ func TestUnprepareResourceClaimsMetrics(t *testing.T) {
 			podConfigStore: NewPodConfigStore(),
 		}
 		claimName := types.NamespacedName{Name: "test-claim", Namespace: "test-ns"}
-		np.podConfigStore.Set("pod-uid-1", "device-a", PodConfig{Claim: claimName})
+		np.podConfigStore.SetDeviceConfig("pod-uid-1", "device-a", DeviceConfig{Claim: claimName})
 
 		claims := []kubeletplugin.NamespacedObject{
 			{NamespacedName: claimName, UID: "claim-uid-1"},
@@ -207,7 +207,7 @@ func TestUnprepareResourceClaimsMetrics(t *testing.T) {
 		}
 
 		// Verify the claim was removed from the store
-		if _, ok := np.podConfigStore.GetPodConfigs("pod-uid-1"); ok {
+		if _, ok := np.podConfigStore.GetPodConfig("pod-uid-1"); ok {
 			t.Errorf("Pod config should have been removed, but was found")
 		}
 

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -66,7 +66,7 @@ func (np *NetworkDriver) CreateContainer(ctx context.Context, pod *api.PodSandbo
 		nriPluginRequestsTotal.WithLabelValues(methodCreateContainer, status).Inc()
 		nriPluginRequestsLatencySeconds.WithLabelValues(methodCreateContainer, status).Observe(time.Since(start).Seconds())
 	}()
-	podConfig, ok := np.podConfigStore.GetPodConfigs(types.UID(pod.GetUid()))
+	podConfig, ok := np.podConfigStore.GetPodConfig(types.UID(pod.GetUid()))
 	if !ok {
 		return nil, nil, nil
 	}
@@ -79,12 +79,12 @@ func (np *NetworkDriver) CreateContainer(ctx context.Context, pod *api.PodSandbo
 	return adjust, update, err
 }
 
-func (np *NetworkDriver) createContainer(_ context.Context, _ *api.PodSandbox, _ *api.Container, podConfig map[string]PodConfig) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+func (np *NetworkDriver) createContainer(_ context.Context, _ *api.PodSandbox, _ *api.Container, podConfig PodConfig) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	// Containers only care about the RDMA char devices.
 	devPaths := set.Set[string]{}
 	adjust := &api.ContainerAdjustment{}
 
-	for _, config := range podConfig {
+	for _, config := range podConfig.DeviceConfigs {
 		for _, dev := range config.RDMADevice.DevChars {
 			// do not insert the same path multiple times
 			if devPaths.Has(dev.Path) {
@@ -115,7 +115,7 @@ func (np *NetworkDriver) RunPodSandbox(ctx context.Context, pod *api.PodSandbox)
 
 	}()
 	// get the devices associated to this Pod
-	podConfig, ok := np.podConfigStore.GetPodConfigs(types.UID(pod.GetUid()))
+	podConfig, ok := np.podConfigStore.GetPodConfig(types.UID(pod.GetUid()))
 	if !ok {
 		return nil
 	}
@@ -127,7 +127,7 @@ func (np *NetworkDriver) RunPodSandbox(ctx context.Context, pod *api.PodSandbox)
 	}
 	return err
 }
-func (np *NetworkDriver) runPodSandbox(_ context.Context, pod *api.PodSandbox, podConfig map[string]PodConfig) error {
+func (np *NetworkDriver) runPodSandbox(_ context.Context, pod *api.PodSandbox, podConfig PodConfig) error {
 	// get the pod network namespace
 	ns := getNetworkNamespace(pod)
 	// host network pods can not allocate network devices because it impact the host
@@ -140,7 +140,7 @@ func (np *NetworkDriver) runPodSandbox(_ context.Context, pod *api.PodSandbox, p
 	// Track all the status updates needed for the resource claims of the pod.
 	statusUpdates := map[types.NamespacedName]*resourceapply.ResourceClaimStatusApplyConfiguration{}
 	// Process the configurations of the ResourceClaim
-	for deviceName, config := range podConfig {
+	for deviceName, config := range podConfig.DeviceConfigs {
 		klog.V(4).Infof("RunPodSandbox processing device: %s with config: %#v", deviceName, config)
 		resourceClaim := types.NamespacedName{Name: config.Claim.Name, Namespace: config.Claim.Namespace}
 		resourceClaimStatus := statusUpdates[resourceClaim]
@@ -231,7 +231,7 @@ func attachRdmaToNS(linkDev, ns string, resourceClaimStatusDevice *resourceapply
 // attachNetdevToNS moves the host network interface into the pod network namespace,
 // applies all associated configuration (ethtool, eBPF, routes, rules, neighbors),
 // and records the resulting status conditions on resourceClaimStatusDevice.
-func attachNetdevToNS(pod *api.PodSandbox, ns, deviceName string, config PodConfig, resourceClaimStatusDevice *resourceapply.AllocatedDeviceStatusApplyConfiguration) error {
+func attachNetdevToNS(pod *api.PodSandbox, ns, deviceName string, config DeviceConfig, resourceClaimStatusDevice *resourceapply.AllocatedDeviceStatusApplyConfiguration) error {
 	ifName := config.NetworkInterfaceConfigInHost.Interface.Name
 	klog.V(2).Infof("RunPodSandbox processing Network device: %s", ifName)
 	// TODO config options to rename the device and pass parameters
@@ -331,7 +331,7 @@ func (np *NetworkDriver) StopPodSandbox(ctx context.Context, pod *api.PodSandbox
 		nriPluginRequestsLatencySeconds.WithLabelValues(methodStopPodSandbox, status).Observe(time.Since(start).Seconds())
 	}()
 	// get the devices associated to this Pod
-	podConfig, ok := np.podConfigStore.GetPodConfigs(types.UID(pod.GetUid()))
+	podConfig, ok := np.podConfigStore.GetPodConfig(types.UID(pod.GetUid()))
 	if !ok {
 		return nil
 	}
@@ -344,7 +344,7 @@ func (np *NetworkDriver) StopPodSandbox(ctx context.Context, pod *api.PodSandbox
 	return err
 }
 
-func (np *NetworkDriver) stopPodSandbox(_ context.Context, pod *api.PodSandbox, podConfig map[string]PodConfig) error {
+func (np *NetworkDriver) stopPodSandbox(_ context.Context, pod *api.PodSandbox, podConfig PodConfig) error {
 	defer func() {
 		np.netdb.RemovePodNetNs(podKey(pod))
 	}()
@@ -360,7 +360,7 @@ func (np *NetworkDriver) stopPodSandbox(_ context.Context, pod *api.PodSandbox, 
 			return nil
 		}
 	}
-	for deviceName, config := range podConfig {
+	for deviceName, config := range podConfig.DeviceConfigs {
 		ifName := config.NetworkInterfaceConfigInPod.Interface.Name
 		if ifName != "" {
 			if err := nsDetachNetdev(ns, ifName, config.NetworkInterfaceConfigInHost.Interface.Name); err != nil {
@@ -385,7 +385,7 @@ func (np *NetworkDriver) RemovePodSandbox(ctx context.Context, pod *api.PodSandb
 		nriPluginRequestsTotal.WithLabelValues(methodRemovePodSandbox, status).Inc()
 		nriPluginRequestsLatencySeconds.WithLabelValues(methodRemovePodSandbox, status).Observe(time.Since(start).Seconds())
 	}()
-	if _, ok := np.podConfigStore.GetPodConfigs(types.UID(pod.GetUid())); !ok {
+	if _, ok := np.podConfigStore.GetPodConfig(types.UID(pod.GetUid())); !ok {
 		return nil
 	}
 	err := np.removePodSandbox(ctx, pod)

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -47,13 +47,13 @@ func TestCreateContainerNoDuplicateDevices(t *testing.T) {
 		{Path: "/dev/infiniband/uverbs0", Type: "c", Major: 231, Minor: 192},
 	}
 
-	podConfig := PodConfig{
+	deviceCfg := DeviceConfig{
 		RDMADevice: RDMAConfig{
 			DevChars: rdmaDevChars,
 		},
 	}
-	np.podConfigStore.Set(podUID, "eth0", podConfig)
-	np.podConfigStore.Set(podUID, "eth1", podConfig)
+	np.podConfigStore.SetDeviceConfig(podUID, "eth0", deviceCfg)
+	np.podConfigStore.SetDeviceConfig(podUID, "eth1", deviceCfg)
 
 	adjust, _, err := np.CreateContainer(context.Background(), pod, ctr)
 	if err != nil {
@@ -188,7 +188,7 @@ func TestRunPodSandboxMetrics(t *testing.T) {
 
 			// For the failure case, a pod config must exist.
 			if !tc.expectSuccess {
-				tc.podConfigStore.Set(podUIDHostNetwork, "eth0", PodConfig{})
+				tc.podConfigStore.SetDeviceConfig(podUIDHostNetwork, "eth0", DeviceConfig{})
 			}
 
 			np.RunPodSandbox(context.Background(), tc.pod)

--- a/pkg/driver/pod_device_config.go
+++ b/pkg/driver/pod_device_config.go
@@ -23,10 +23,18 @@ import (
 	"sigs.k8s.io/dranet/pkg/apis"
 )
 
-// PodConfig holds the set of configurations to be applied for a single
+// PodConfig holds all the device configurations for a Pod, and can be extended
+// with fields that are not specific to a single device.
+type PodConfig struct {
+	// DeviceConfigs maps the allocated network device names to their respective
+	// configurations.
+	DeviceConfigs map[string]DeviceConfig
+}
+
+// DeviceConfig holds the set of configurations to be applied for a single
 // network device allocated to a Pod. This includes network interface settings,
 // routes for the Pod's network namespace, and RDMA configurations.
-type PodConfig struct {
+type DeviceConfig struct {
 	Claim types.NamespacedName
 
 	// NetworkInterfaceConfigInHost is the config of the network interface as
@@ -68,42 +76,45 @@ type LinuxDevice struct {
 	GID      uint32
 }
 
-// PodConfigStore provides a thread-safe, centralized store for all network device configurations
-// across multiple Pods. It is indexed by the Pod's UID, and for each Pod, it maps
-// network device names (as allocated) to their specific Config.
+// PodConfigStore provides a thread-safe, centralized store for all network
+// device configurations across multiple Pods. It is indexed by the Pod's UID.
 type PodConfigStore struct {
 	mu      sync.RWMutex
-	configs map[types.UID]map[string]PodConfig
+	configs map[types.UID]PodConfig
 }
 
 // NewPodConfigStore creates and returns a new instance of PodConfigStore.
 func NewPodConfigStore() *PodConfigStore {
 	return &PodConfigStore{
-		configs: make(map[types.UID]map[string]PodConfig),
+		configs: make(map[types.UID]PodConfig),
 	}
 }
 
-// Set stores the configuration for a specific device under a given Pod UID.
+// SetDeviceConfig stores the configuration for a specific device under a given Pod UID.
 // If a configuration for the Pod UID or device name already exists, it will be overwritten.
-func (s *PodConfigStore) Set(podUID types.UID, deviceName string, config PodConfig) {
+func (s *PodConfigStore) SetDeviceConfig(podUID types.UID, deviceName string, config DeviceConfig) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.configs[podUID]; !ok {
-		s.configs[podUID] = make(map[string]PodConfig)
+	podConfig, ok := s.configs[podUID]
+	if !ok {
+		podConfig = PodConfig{
+			DeviceConfigs: make(map[string]DeviceConfig),
+		}
+		s.configs[podUID] = podConfig
 	}
-	s.configs[podUID][deviceName] = config
+	podConfig.DeviceConfigs[deviceName] = config
 }
 
-// Get retrieves the configuration for a specific device under a given Pod UID.
+// GetDeviceConfig retrieves the configuration for a specific device under a given Pod UID.
 // It returns the Config and true if found, otherwise an empty Config and false.
-func (s *PodConfigStore) Get(podUID types.UID, deviceName string) (PodConfig, bool) {
+func (s *PodConfigStore) GetDeviceConfig(podUID types.UID, deviceName string) (DeviceConfig, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if podConfigs, ok := s.configs[podUID]; ok {
-		config, found := podConfigs[deviceName]
+	if podConfig, ok := s.configs[podUID]; ok {
+		config, found := podConfig.DeviceConfigs[deviceName]
 		return config, found
 	}
-	return PodConfig{}, false
+	return DeviceConfig{}, false
 }
 
 // DeletePod removes all configurations associated with a given Pod UID.
@@ -113,22 +124,21 @@ func (s *PodConfigStore) DeletePod(podUID types.UID) {
 	delete(s.configs, podUID)
 }
 
-// GetPodConfigs retrieves all device configurations for a given Pod UID.
-// It is indexed by the Pod's UID, and for each Pod, it maps network device names (as allocated)
-// to their specific Config.
-func (s *PodConfigStore) GetPodConfigs(podUID types.UID) (map[string]PodConfig, bool) {
+// GetPodConfig retrieves all configurations for a given Pod UID.
+// It is indexed by the Pod's UID.
+func (s *PodConfigStore) GetPodConfig(podUID types.UID) (PodConfig, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	podConfigs, found := s.configs[podUID]
+	podConfig, found := s.configs[podUID]
 	if !found {
-		return nil, false
+		return PodConfig{}, false
 	}
 	// Return a copy to prevent external modification of the internal map
-	configsCopy := make(map[string]PodConfig, len(podConfigs))
-	for k, v := range podConfigs {
+	configsCopy := make(map[string]DeviceConfig, len(podConfig.DeviceConfigs))
+	for k, v := range podConfig.DeviceConfigs {
 		configsCopy[k] = v
 	}
-	return configsCopy, true
+	return PodConfig{DeviceConfigs: configsCopy}, true
 }
 
 // DeleteClaim removes all configurations associated with a given claim.
@@ -136,8 +146,8 @@ func (s *PodConfigStore) DeleteClaim(claim types.NamespacedName) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	podsToDelete := []types.UID{}
-	for uid, podConfigsMap := range s.configs {
-		for _, config := range podConfigsMap {
+	for uid, podConfig := range s.configs {
+		for _, config := range podConfig.DeviceConfigs {
 			if config.Claim == claim {
 				podsToDelete = append(podsToDelete, uid)
 				break // Found a match for this pod, no need to check other devices for the same pod

--- a/pkg/driver/pod_device_config_test.go
+++ b/pkg/driver/pod_device_config_test.go
@@ -40,7 +40,7 @@ func TestPodConfigStore_SetAndGet(t *testing.T) {
 	store := NewPodConfigStore()
 	podUID := types.UID("test-pod-uid-1")
 	deviceName := "eth0"
-	config := PodConfig{
+	config := DeviceConfig{
 		NetworkInterfaceConfigInPod: apis.NetworkConfig{
 			Interface: apis.InterfaceConfig{Name: "eth0-pod"},
 			Routes: []apis.RouteConfig{
@@ -54,14 +54,14 @@ func TestPodConfigStore_SetAndGet(t *testing.T) {
 	}
 
 	// Test Get on non-existent item
-	_, found := store.Get(podUID, deviceName)
+	_, found := store.GetDeviceConfig(podUID, deviceName)
 	if found {
 		t.Errorf("Get() found a config before Set(), expected not found")
 	}
 
-	store.Set(podUID, deviceName, config)
+	store.SetDeviceConfig(podUID, deviceName, config)
 
-	retrievedConfig, found := store.Get(podUID, deviceName)
+	retrievedConfig, found := store.GetDeviceConfig(podUID, deviceName)
 	if !found {
 		t.Fatalf("Get() did not find config after Set(), expected found")
 	}
@@ -70,26 +70,26 @@ func TestPodConfigStore_SetAndGet(t *testing.T) {
 	}
 
 	// Test Get with different deviceName
-	_, found = store.Get(podUID, "eth1")
+	_, found = store.GetDeviceConfig(podUID, "eth1")
 	if found {
 		t.Errorf("Get() found config for wrong deviceName 'eth1', expected not found")
 	}
 
 	// Test Get with different podUID
-	_, found = store.Get(types.UID("other-pod-uid"), deviceName)
+	_, found = store.GetDeviceConfig(types.UID("other-pod-uid"), deviceName)
 	if found {
 		t.Errorf("Get() found config for wrong podUID, expected not found")
 	}
 
 	// Test overwriting
-	newConfig := PodConfig{
+	newConfig := DeviceConfig{
 		NetworkInterfaceConfigInPod: apis.NetworkConfig{
 			Interface: apis.InterfaceConfig{Name: "eth0-new"},
 			Ethtool:   &apis.EthtoolConfig{PrivateFlags: map[string]bool{"custom-flag": false}},
 		},
 	}
-	store.Set(podUID, deviceName, newConfig)
-	retrievedConfig, found = store.Get(podUID, deviceName)
+	store.SetDeviceConfig(podUID, deviceName, newConfig)
+	retrievedConfig, found = store.GetDeviceConfig(podUID, deviceName)
 	if !found {
 		t.Fatalf("Get() did not find config after overwrite, expected found")
 	}
@@ -104,26 +104,26 @@ func TestPodConfigStore_DeletePod(t *testing.T) {
 	podUID2 := types.UID("test-pod-uid-2")
 	dev1 := "eth0"
 	dev2 := "eth1"
-	config1 := PodConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1eth0"}}}
-	config2 := PodConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1eth1"}}}
-	config3 := PodConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p2eth0"}}}
+	config1 := DeviceConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1eth0"}}}
+	config2 := DeviceConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1eth1"}}}
+	config3 := DeviceConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p2eth0"}}}
 
-	store.Set(podUID1, dev1, config1)
-	store.Set(podUID1, dev2, config2)
-	store.Set(podUID2, dev1, config3)
+	store.SetDeviceConfig(podUID1, dev1, config1)
+	store.SetDeviceConfig(podUID1, dev2, config2)
+	store.SetDeviceConfig(podUID2, dev1, config3)
 
 	store.DeletePod(podUID1)
 
-	_, found := store.Get(podUID1, dev1)
+	_, found := store.GetDeviceConfig(podUID1, dev1)
 	if found {
 		t.Errorf("Get() found config for podUID1 device %s after DeletePod(), expected not found", dev1)
 	}
-	_, found = store.Get(podUID1, dev2)
+	_, found = store.GetDeviceConfig(podUID1, dev2)
 	if found {
 		t.Errorf("Get() found config for podUID1 device %s after DeletePod(), expected not found", dev2)
 	}
 
-	retrievedConfig3, found := store.Get(podUID2, dev1)
+	retrievedConfig3, found := store.GetDeviceConfig(podUID2, dev1)
 	if !found {
 		t.Errorf("Get() did not find config for podUID2 after deleting podUID1, expected found")
 	}
@@ -141,38 +141,38 @@ func TestPodConfigStore_GetPodConfigs(t *testing.T) {
 	podUID2 := types.UID("test-pod-uid-2")
 	dev1 := "eth0"
 	dev2 := "eth1"
-	config1 := PodConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1eth0"}}}
-	config2 := PodConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1eth1"}}}
-	config3 := PodConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p2eth0"}}}
+	config1 := DeviceConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1eth0"}}}
+	config2 := DeviceConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1eth1"}}}
+	config3 := DeviceConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p2eth0"}}}
 
-	store.Set(podUID1, dev1, config1)
-	store.Set(podUID1, dev2, config2)
-	store.Set(podUID2, dev1, config3)
+	store.SetDeviceConfig(podUID1, dev1, config1)
+	store.SetDeviceConfig(podUID1, dev2, config2)
+	store.SetDeviceConfig(podUID2, dev1, config3)
 
-	expectedPod1Configs := map[string]PodConfig{
+	expectedPod1Config := PodConfig{DeviceConfigs: map[string]DeviceConfig{
 		dev1: config1,
 		dev2: config2,
-	}
+	}}
 
-	pod1Configs, found := store.GetPodConfigs(podUID1)
+	pod1Config, found := store.GetPodConfig(podUID1)
 	if !found {
 		t.Fatalf("GetPodConfigs() did not find configs for podUID1, expected found")
 	}
-	if !reflect.DeepEqual(pod1Configs, expectedPod1Configs) {
-		t.Errorf("GetPodConfigs() for podUID1 returned %+v, want %+v", pod1Configs, expectedPod1Configs)
+	if !reflect.DeepEqual(pod1Config, expectedPod1Config) {
+		t.Errorf("GetPodConfigs() for podUID1 returned %+v, want %+v", pod1Config, expectedPod1Config)
 	}
 
 	// Test GetPodConfigs for non-existent pod
-	_, found = store.GetPodConfigs(types.UID("non-existent-pod"))
+	_, found = store.GetPodConfig(types.UID("non-existent-pod"))
 	if found {
 		t.Errorf("GetPodConfigs() found configs for non-existent pod, expected not found")
 	}
 
 	// Modify returned map and check if original is unchanged
-	pod1Configs["newDev"] = PodConfig{}
-	originalPod1Configs, _ := store.GetPodConfigs(podUID1)
-	if !reflect.DeepEqual(originalPod1Configs, expectedPod1Configs) {
-		t.Errorf("Original map in store was modified after GetPodConfigs() returned map was changed. Original: %+v, Expected: %+v", originalPod1Configs, expectedPod1Configs)
+	pod1Config.DeviceConfigs["newDev"] = DeviceConfig{}
+	originalPod1Configs, _ := store.GetPodConfig(podUID1)
+	if !reflect.DeepEqual(originalPod1Configs, expectedPod1Config) {
+		t.Errorf("Original map in store was modified after GetPodConfigs() returned map was changed. Original: %+v, Expected: %+v", originalPod1Configs, expectedPod1Config)
 	}
 }
 
@@ -187,15 +187,15 @@ func TestPodConfigStore_ThreadSafety(t *testing.T) {
 			defer wg.Done()
 			podUID := types.UID(fmt.Sprintf("pod-%d", i))
 			deviceName := fmt.Sprintf("eth%d", i%2)
-			config := PodConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: fmt.Sprintf("dev-%d", i)}}}
-			store.Set(podUID, deviceName, config)
-			retrieved, _ := store.Get(podUID, deviceName)
+			config := DeviceConfig{NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: fmt.Sprintf("dev-%d", i)}}}
+			store.SetDeviceConfig(podUID, deviceName, config)
+			retrieved, _ := store.GetDeviceConfig(podUID, deviceName)
 			if !reflect.DeepEqual(retrieved, config) {
 				t.Errorf("goroutine %d: Get() retrieved %+v, want %+v", i, retrieved, config)
 			}
 			if i%10 == 0 {
 				store.DeletePod(podUID)
-				_, found := store.Get(podUID, deviceName)
+				_, found := store.GetDeviceConfig(podUID, deviceName)
 				if found {
 					t.Errorf("goroutine %d: Get() found config after DeletePod()", i)
 				}
@@ -216,56 +216,56 @@ func TestPodConfigStore_DeleteClaim(t *testing.T) {
 	dev1 := "eth0"
 	dev2 := "eth1"
 
-	config1_1 := PodConfig{Claim: claim1, NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1d1c1"}}} // Pod1, Dev1, Claim1
-	config1_2 := PodConfig{Claim: claim1, NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1d2c1"}}} // Pod1, Dev2, Claim1
-	config2_1 := PodConfig{Claim: claim1, NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p2d1c1"}}} // Pod2, Dev1, Claim1
-	config3_1 := PodConfig{Claim: claim2, NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p3d1c2"}}} // Pod3, Dev1, Claim2
+	config1_1 := DeviceConfig{Claim: claim1, NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1d1c1"}}} // Pod1, Dev1, Claim1
+	config1_2 := DeviceConfig{Claim: claim1, NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p1d2c1"}}} // Pod1, Dev2, Claim1
+	config2_1 := DeviceConfig{Claim: claim1, NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p2d1c1"}}} // Pod2, Dev1, Claim1
+	config3_1 := DeviceConfig{Claim: claim2, NetworkInterfaceConfigInPod: apis.NetworkConfig{Interface: apis.InterfaceConfig{Name: "p3d1c2"}}} // Pod3, Dev1, Claim2
 
 	tests := []struct {
 		name                string
 		initialConfigs      func() *PodConfigStore
 		claimToDelete       types.NamespacedName
-		expectedPodsAfter   map[types.UID]map[string]PodConfig
+		expectedPodsAfter   map[types.UID]PodConfig
 		checkSpecificConfig func(t *testing.T, store *PodConfigStore)
 	}{
 		{
 			name: "delete claim associated with one pod, one device",
 			initialConfigs: func() *PodConfigStore {
 				s := NewPodConfigStore()
-				s.Set(podUID3, dev1, config3_1) // Pod3 has Claim2
-				s.Set(podUID1, dev1, config1_1) // Pod1 has Claim1
+				s.SetDeviceConfig(podUID3, dev1, config3_1) // Pod3 has Claim2
+				s.SetDeviceConfig(podUID1, dev1, config1_1) // Pod1 has Claim1
 				return s
 			},
 			claimToDelete: claim2, // Delete Claim2
-			expectedPodsAfter: map[types.UID]map[string]PodConfig{
-				podUID1: {dev1: config1_1}, // Pod1 (Claim1) should remain
+			expectedPodsAfter: map[types.UID]PodConfig{
+				podUID1: {DeviceConfigs: map[string]DeviceConfig{dev1: config1_1}}, // Pod1 (Claim1) should remain
 			},
 		},
 		{
 			name: "delete claim associated with multiple pods",
 			initialConfigs: func() *PodConfigStore {
 				s := NewPodConfigStore()
-				s.Set(podUID1, dev1, config1_1) // Pod1, Dev1, Claim1
-				s.Set(podUID1, dev2, config1_2) // Pod1, Dev2, Claim1
-				s.Set(podUID2, dev1, config2_1) // Pod2, Dev1, Claim1
-				s.Set(podUID3, dev1, config3_1) // Pod3, Dev1, Claim2
+				s.SetDeviceConfig(podUID1, dev1, config1_1) // Pod1, Dev1, Claim1
+				s.SetDeviceConfig(podUID1, dev2, config1_2) // Pod1, Dev2, Claim1
+				s.SetDeviceConfig(podUID2, dev1, config2_1) // Pod2, Dev1, Claim1
+				s.SetDeviceConfig(podUID3, dev1, config3_1) // Pod3, Dev1, Claim2
 				return s
 			},
 			claimToDelete: claim1, // Delete Claim1
-			expectedPodsAfter: map[types.UID]map[string]PodConfig{
-				podUID3: {dev1: config3_1}, // Pod3 (Claim2) should remain
+			expectedPodsAfter: map[types.UID]PodConfig{
+				podUID3: {DeviceConfigs: map[string]DeviceConfig{dev1: config3_1}}, // Pod3 (Claim2) should remain
 			},
 		},
 		{
 			name: "delete non-existent claim",
 			initialConfigs: func() *PodConfigStore {
 				s := NewPodConfigStore()
-				s.Set(podUID1, dev1, config1_1)
+				s.SetDeviceConfig(podUID1, dev1, config1_1)
 				return s
 			},
 			claimToDelete: types.NamespacedName{Namespace: "ns-other", Name: "claim-non-existent"},
-			expectedPodsAfter: map[types.UID]map[string]PodConfig{
-				podUID1: {dev1: config1_1}, // Pod1 should remain
+			expectedPodsAfter: map[types.UID]PodConfig{
+				podUID1: {DeviceConfigs: map[string]DeviceConfig{dev1: config1_1}}, // Pod1 should remain
 			},
 		},
 		{
@@ -274,7 +274,7 @@ func TestPodConfigStore_DeleteClaim(t *testing.T) {
 				return NewPodConfigStore()
 			},
 			claimToDelete:     claim1,
-			expectedPodsAfter: map[types.UID]map[string]PodConfig{},
+			expectedPodsAfter: map[types.UID]PodConfig{},
 		},
 	}
 
@@ -297,7 +297,7 @@ func TestPodConfigStore_NoDuplicateDevices(t *testing.T) {
 	store := NewPodConfigStore()
 	podUID := types.UID("test-pod-uid-1")
 	deviceName1 := "eth0"
-	config1 := PodConfig{
+	config1 := DeviceConfig{
 		NetworkInterfaceConfigInPod: apis.NetworkConfig{
 			Interface: apis.InterfaceConfig{Name: "eth0-pod"},
 		},
@@ -311,7 +311,7 @@ func TestPodConfigStore_NoDuplicateDevices(t *testing.T) {
 		},
 	}
 	deviceName2 := "eth1"
-	config2 := PodConfig{
+	config2 := DeviceConfig{
 		NetworkInterfaceConfigInPod: apis.NetworkConfig{
 			Interface: apis.InterfaceConfig{Name: "eth2-pod"},
 		},
@@ -326,23 +326,23 @@ func TestPodConfigStore_NoDuplicateDevices(t *testing.T) {
 	}
 
 	// Set the same device config multiple times
-	store.Set(podUID, deviceName1, config1)
-	store.Set(podUID, deviceName2, config2)
-	store.Set(podUID, deviceName1, config1)
+	store.SetDeviceConfig(podUID, deviceName1, config1)
+	store.SetDeviceConfig(podUID, deviceName2, config2)
+	store.SetDeviceConfig(podUID, deviceName1, config1)
 
-	podConfigs, found := store.GetPodConfigs(podUID)
+	podConfigs, found := store.GetPodConfig(podUID)
 	if !found {
 		t.Fatalf("GetPodConfigs() did not find configs for podUID, expected found")
 	}
 
-	if len(podConfigs) != 2 {
-		t.Errorf("Expected 2 device config, but got %d", len(podConfigs))
+	if len(podConfigs.DeviceConfigs) != 2 {
+		t.Errorf("Expected 2 device config, but got %d", len(podConfigs.DeviceConfigs))
 	}
 
-	if _, ok := podConfigs[deviceName1]; !ok {
+	if _, ok := podConfigs.DeviceConfigs[deviceName1]; !ok {
 		t.Errorf("Device %s not found in pod configs", deviceName2)
 	}
-	if _, ok := podConfigs[deviceName2]; !ok {
+	if _, ok := podConfigs.DeviceConfigs[deviceName2]; !ok {
 		t.Errorf("Device %s not found in pod configs", deviceName2)
 	}
 }


### PR DESCRIPTION
The main delta in this change is:

```diff
 type PodConfigStore struct {
        mu      sync.RWMutex
-       configs map[types.UID]map[string]PodConfig
+       configs map[types.UID]PodConfig
 }
```

where PodConfig is:

```
type PodConfig struct {
	DeviceConfigs map[string]DeviceConfig
}
```

This is in preparation for introducing field that's not specific to an individual Device (and hence cannot go into the `DeviceConfig`, but is part of the Pod) in order to resolve this comment: https://github.com/kubernetes-sigs/dranet/pull/91#discussion_r2944700630. Example:

```diff
type PodConfig struct {
	DeviceConfigs map[string]DeviceConfig
+	LastNRIActivity time.Time
}
```