### PR TITLE
Changes to provide build and distro images to Dockerfile as arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 # setup cross-compile env
-FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+ARG GOLANG_IMAGE=golang:1.26
+ARG BASE_IMAGE=gcr.io/distroless/base-debian12
+
+FROM --platform=$BUILDPLATFORM $GOLANG_IMAGE AS builder
 ARG TARGETARCH
 ARG GOARCH=${TARGETARCH} CGO_ENABLED=0
 
@@ -27,6 +30,6 @@ COPY . .
 RUN go build -o /go/bin/dranet ./cmd/dranet
 
 # copy binary onto base image
-FROM gcr.io/distroless/base-debian12
+FROM $BASE_IMAGE
 COPY --from=builder --chown=root:root /go/bin/dranet /dranet
 CMD ["/dranet"]

--- a/Makefile
+++ b/Makefile
@@ -57,16 +57,27 @@ TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
 IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
 PLATFORMS?=linux/amd64,linux/arm64
 
+# base images (defaults are in the Dockerfile)
+BUILD_ARGS?=
+ifdef GOLANG_IMAGE
+BUILD_ARGS+=--build-arg GOLANG_IMAGE=$(GOLANG_IMAGE)
+endif
+ifdef BASE_IMAGE
+BUILD_ARGS+=--build-arg BASE_IMAGE=$(BASE_IMAGE)
+endif
+
 # required to enable buildx
 export DOCKER_CLI_EXPERIMENTAL=enabled
 image-build: ensure-buildx
 	docker buildx build . \
+		$(BUILD_ARGS) \
 		--tag="${IMAGE}" \
 		--load
 
 image-push: ensure-buildx
 	docker buildx build . \
 		--platform=$(PLATFORMS) \
+		$(BUILD_ARGS) \
 		--tag="${IMAGE}" \
 		--push
 


### PR DESCRIPTION
Made the Dockerfile's base images configurable by introducing GOLANG_IMAGE and BASE_IMAGE build arguments, allowing different cloud providers to specify custom Go compiler and runtime images instead of hardcoded versions. 

This enables flexibility for different build environments, security requirements, or when using alternative image registries while maintaining golang:1.26 and gcr.io/distroless/base-debian12 as defaults.