### PR TITLE
Add OKE (Oracle Cloud) provider for dranet

### DIFF
--- a/pkg/cloudprovider/oke/oke.go
+++ b/pkg/cloudprovider/oke/oke.go
@@ -1,0 +1,154 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oke
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"sigs.k8s.io/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
+)
+
+const (
+	OKEAttrPrefix = "oke.dra.net"
+
+	AttrOKEShape              = OKEAttrPrefix + "/" + "shape"
+	AttrOKEFaultDomain        = OKEAttrPrefix + "/" + "faultDomain"
+	AttrOKEAvailabilityDomain = OKEAttrPrefix + "/" + "availabilityDomain"
+
+	// imdsEndpoint is the Oracle Cloud Instance Metadata Service endpoint.
+	imdsEndpoint = "http://169.254.169.254/opc/v2"
+)
+
+// imdsInstanceMetadata contains the fields we care about from the OCI IMDS
+// instance metadata response.
+type imdsInstanceMetadata struct {
+	Shape              string `json:"shape"`
+	FaultDomain        string `json:"faultDomain"`
+	AvailabilityDomain string `json:"availabilityDomain"`
+}
+
+var _ cloudprovider.CloudInstance = (*OKEInstance)(nil)
+
+// OKEInstance holds OCI/OKE specific instance data.
+type OKEInstance struct {
+	Shape              string
+	FaultDomain        string
+	AvailabilityDomain string
+}
+
+// GetDeviceAttributes returns OKE-specific attributes for a device.
+// These are node-level attributes applied to all devices since OCI IMDS
+// does not expose per-RDMA-NIC metadata.
+func (o *OKEInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
+
+	if o.Shape != "" {
+		attributes[AttrOKEShape] = resourceapi.DeviceAttribute{StringValue: &o.Shape}
+	}
+	if o.FaultDomain != "" {
+		attributes[AttrOKEFaultDomain] = resourceapi.DeviceAttribute{StringValue: &o.FaultDomain}
+	}
+	if o.AvailabilityDomain != "" {
+		attributes[AttrOKEAvailabilityDomain] = resourceapi.DeviceAttribute{StringValue: &o.AvailabilityDomain}
+	}
+
+	return attributes
+}
+
+// GetDeviceConfig returns nil as OCI does not provide device-specific
+// network configuration through IMDS.
+func (o *OKEInstance) GetDeviceConfig(id cloudprovider.DeviceIdentifiers) *apis.NetworkConfig {
+	return nil
+}
+
+// OnOKE returns true if running on an Oracle Cloud Infrastructure instance.
+// Detection is done by probing the OCI IMDS v2 endpoint.
+func OnOKE(ctx context.Context) bool {
+	pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return wait.PollUntilContextCancel(pollCtx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imdsEndpoint+"/instance/", nil)
+		if err != nil {
+			return false, nil
+		}
+		req.Header.Set("Authorization", "Bearer Oracle")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false, nil
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK, nil
+	}) == nil
+}
+
+// GetInstance retrieves OCI instance properties by querying the IMDS.
+func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
+	var instance *OKEInstance
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imdsEndpoint+"/instance/", nil)
+		if err != nil {
+			klog.Infof("could not create OCI IMDS request ... retrying: %v", err)
+			return false, nil
+		}
+		req.Header.Set("Authorization", "Bearer Oracle")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			klog.Infof("could not reach OCI IMDS ... retrying: %v", err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			klog.Infof("OCI IMDS returned status %d ... retrying", resp.StatusCode)
+			return false, nil
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			klog.Infof("could not read OCI IMDS response ... retrying: %v", err)
+			return false, nil
+		}
+
+		var metadata imdsInstanceMetadata
+		if err := json.Unmarshal(body, &metadata); err != nil {
+			return false, fmt.Errorf("could not parse OCI IMDS response: %w", err)
+		}
+
+		instance = &OKEInstance{
+			Shape:              metadata.Shape,
+			FaultDomain:        metadata.FaultDomain,
+			AvailabilityDomain: metadata.AvailabilityDomain,
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return instance, nil
+}

--- a/pkg/cloudprovider/oke/oke_test.go
+++ b/pkg/cloudprovider/oke/oke_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oke
+
+import (
+	"testing"
+
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestGetDeviceAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *OKEInstance
+		id       cloudprovider.DeviceIdentifiers
+		want     map[resourceapi.QualifiedName]resourceapi.DeviceAttribute
+	}{
+		{
+			name: "instance with all metadata",
+			instance: &OKEInstance{
+				Shape:              "BM.GPU.H100.8",
+				FaultDomain:        "FAULT-DOMAIN-1",
+				AvailabilityDomain: "TrcQ:US-ASHBURN-AD-2",
+			},
+			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttrOKEShape:              {StringValue: ptr.To("BM.GPU.H100.8")},
+				AttrOKEFaultDomain:        {StringValue: ptr.To("FAULT-DOMAIN-1")},
+				AttrOKEAvailabilityDomain: {StringValue: ptr.To("TrcQ:US-ASHBURN-AD-2")},
+			},
+		},
+		{
+			name: "instance with only shape",
+			instance: &OKEInstance{
+				Shape:              "VM.Standard.E3.Flex",
+				FaultDomain:        "",
+				AvailabilityDomain: "",
+			},
+			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttrOKEShape: {StringValue: ptr.To("VM.Standard.E3.Flex")},
+			},
+		},
+		{
+			name: "instance with no metadata",
+			instance: &OKEInstance{
+				Shape:              "",
+				FaultDomain:        "",
+				AvailabilityDomain: "",
+			},
+			id:   cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
+		},
+		{
+			name: "attributes are node-level, same for any device identifier",
+			instance: &OKEInstance{
+				Shape:              "BM.GPU.H100.8",
+				FaultDomain:        "FAULT-DOMAIN-3",
+				AvailabilityDomain: "TrcQ:US-ASHBURN-AD-2",
+			},
+			id: cloudprovider.DeviceIdentifiers{
+				Name:       "pci-0000-0c-00-0",
+				MAC:        "a0:88:c2:a7:c5:04",
+				PCIAddress: "0000:0c:00.0",
+			},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttrOKEShape:              {StringValue: ptr.To("BM.GPU.H100.8")},
+				AttrOKEFaultDomain:        {StringValue: ptr.To("FAULT-DOMAIN-3")},
+				AttrOKEAvailabilityDomain: {StringValue: ptr.To("TrcQ:US-ASHBURN-AD-2")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.instance.GetDeviceAttributes(tt.id)
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("GetDeviceAttributes() returned unexpected diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetDeviceConfig(t *testing.T) {
+	instance := &OKEInstance{
+		Shape:              "BM.GPU.H100.8",
+		FaultDomain:        "FAULT-DOMAIN-1",
+		AvailabilityDomain: "TrcQ:US-ASHBURN-AD-2",
+	}
+	got := instance.GetDeviceConfig(cloudprovider.DeviceIdentifiers{Name: "dev1"})
+	if got != nil {
+		t.Errorf("GetDeviceConfig() = %v, want nil", got)
+	}
+}

--- a/pkg/inventory/cloud.go
+++ b/pkg/inventory/cloud.go
@@ -29,22 +29,29 @@ import (
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/azure"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/gce"
+	"sigs.k8s.io/dranet/pkg/cloudprovider/oke"
 )
 
 // getInstanceProperties get the instace properties and stores them in a global variable to be used in discovery
 func getInstanceProperties(ctx context.Context) cloudprovider.CloudInstance {
 	var err error
 	var instance cloudprovider.CloudInstance
-	if metadata.OnGCE() {
+	switch {
+	case metadata.OnGCE():
 		// Get google compute instance metadata for network interfaces
 		// https://cloud.google.com/compute/docs/metadata/predefined-metadata-keys
 		klog.Infof("running on GCE")
 		instance, err = gce.GetInstance(ctx)
-	} else if azure.OnAzure(ctx) {
+	case azure.OnAzure(ctx):
 		// Get Azure instance metadata for placement group and VM size
 		// https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service
 		klog.Infof("running on Azure")
 		instance, err = azure.GetInstance(ctx)
+	case oke.OnOKE(ctx):
+		// Get OCI instance metadata for shape, fault domain, and availability domain
+		// https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm
+		klog.Infof("running on OKE")
+		instance, err = oke.GetInstance(ctx)
 	}
 	if err != nil {
 		klog.Infof("could not get instance properties: %v", err)


### PR DESCRIPTION
  - Adds cloud provider module that queries OCI IMDS to publish: oke.dra.net/shape, oke.dra.net/faultDomain, and oke.dra.net/availabilityDomain as device attributes on ResourceSlices.

Test matrix for CSP:

- Build and push with changes to team container registry
- Deploy to OKE cluster with active H100 bare metal nodes with RDMA backend
```bash
k get resourceslice
NAME                               NODE          DRIVER           POOL          AGE
10.0.68.50-dra.net-vr8dh           10.0.68.50    dra.net          10.0.68.50    49m
10.0.68.50-gpu.nvidia.com-cb9cz    10.0.68.50    gpu.nvidia.com   10.0.68.50    41m
```
- Check the contents to verify PCIAddress and Device as well as config variables surfaced in code
```bash
k get resourceslice 10.0.68.50-dra.net-vr8dh -o yaml
...
  - attributes:
      dra.net/numaNode:
        int: 0
      dra.net/pciAddress:
        string: 0000:0c:00.0
      dra.net/pciDevice:
        string: MT2910 Family [ConnectX-7]
      dra.net/pciSubsystem:
        string: "0038"
      dra.net/pciVendor:
        string: Mellanox Technologies
      dra.net/rdma:
        bool: true
      oke.dra.net/availabilityDomain:
        string: TrcQ:US-ASHBURN-AD-2
      oke.dra.net/faultDomain:
        string: FAULT-DOMAIN-1
      oke.dra.net/shape:
        string: BM.GPU.H100.8
      resource.kubernetes.io/pcieRoot:
        string: pci0000:07
```
- run NCCL tests with new resource slices to verify perf.
