### PR TITLE
deployments: add Helm chart for DRANET

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,18 @@
+name: Helm Lint
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'deployments/helm/**'
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Run Helm lint
+        run: make helm-lint

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ e2e-test:
 lint:
 	hack/lint.sh
 
+helm-lint:
+	helm lint --strict deployments/helm/dranet
+
 update:
 	go mod tidy
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Install the latest stable version of DRANET using the provided manifest:
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/dranet/refs/heads/main/install.yaml
 ```
 
+To install using the Helm chart from a local tree:
+
+```sh
+helm upgrade --install dranet ./deployments/helm/dranet -n kube-system
+```
+
+For available configuration options, see the [chart README](deployments/helm/dranet/README.md).
+
 ### How to Use It
 
 Once DRANET is running, you can inspect the network interfaces and their

--- a/deployments/helm/dranet/.helmignore
+++ b/deployments/helm/dranet/.helmignore
@@ -1,0 +1,6 @@
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp

--- a/deployments/helm/dranet/Chart.yaml
+++ b/deployments/helm/dranet/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: dranet
+description: Helm chart for deploying DRANET, a Kubernetes network driver using Dynamic Resource Allocation (DRA)
+type: application
+version: 0.1.0
+appVersion: "stable"
+home: https://github.com/kubernetes-sigs/dranet
+sources:
+  - https://github.com/kubernetes-sigs/dranet
+keywords:
+  - networking
+  - dra
+  - dynamic-resource-allocation
+maintainers:
+  - name: aojea
+  - name: gauravkghildiyal
+  - name: michaelasp
+  - name: fmuyassarov

--- a/deployments/helm/dranet/README.md
+++ b/deployments/helm/dranet/README.md
@@ -1,0 +1,40 @@
+# DRANET Helm Chart
+
+## Installation
+
+From a local checkout:
+
+```sh
+helm upgrade --install dranet ./deployments/helm/dranet -n kube-system
+```
+
+## Configuration
+
+The following table lists the configurable parameters and their default values:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nameOverride` | Override the chart name | `""` |
+| `fullnameOverride` | Override the full release name | `""` |
+| `image.repository` | Container image repository | `registry.k8s.io/networking/dranet` |
+| `image.tag` | Container image tag | `stable` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `imagePullSecrets` | List of image pull secrets | `[]` |
+| `rbac.create` | Create RBAC resources | `true` |
+| `podAnnotations` | Annotations to add to pods | `{}` |
+| `podLabels` | Labels to add to pods | `{}` |
+| `logVerbosity` | Log verbosity level | `4` |
+| `tolerations` | Pod tolerations | `[{operator: Exists, effect: NoSchedule}]` |
+| `resources.requests.cpu` | CPU resource request | `100m` |
+| `resources.requests.memory` | Memory resource request | `50Mi` |
+| `resources.limits.cpu` | CPU resource limit | `""` (not set) |
+| `resources.limits.memory` | Memory resource limit | `""` (not set) |
+| `readinessProbe.httpGet.path` | Readiness probe HTTP path | `/healthz` |
+| `readinessProbe.httpGet.port` | Readiness probe HTTP port | `9177` |
+
+Parameters can be set at install time using `--set` or a custom values file:
+
+```sh
+helm upgrade --install dranet ./deployments/helm/dranet -n kube-system --set logVerbosity=6
+helm upgrade --install dranet ./deployments/helm/dranet -n kube-system -f my-values.yaml
+```

--- a/deployments/helm/dranet/templates/_helpers.tpl
+++ b/deployments/helm/dranet/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{- define "dranet.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "dranet.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "dranet.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "dranet.labels" -}}
+helm.sh/chart: {{ include "dranet.chart" . }}
+app.kubernetes.io/name: {{ include "dranet.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "dranet.selectorLabels" -}}
+app: {{ include "dranet.name" . }}
+{{- end -}}
+
+{{- define "dranet.serviceAccountName" -}}
+{{- include "dranet.fullname" . -}}
+{{- end -}}

--- a/deployments/helm/dranet/templates/daemonset.yaml
+++ b/deployments/helm/dranet/templates/daemonset.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "dranet.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dranet.labels" . | nindent 4 }}
+    tier: node
+    app: {{ include "dranet.name" . }}
+    k8s-app: {{ include "dranet.name" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "dranet.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "dranet.labels" . | nindent 8 }}
+        {{- include "dranet.selectorLabels" . | nindent 8 }}
+        tier: node
+        k8s-app: {{ include "dranet.name" . }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      hostNetwork: true
+      serviceAccountName: {{ include "dranet.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      containers:
+        - name: dranet
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - /dranet
+            - --v={{ .Values.logVerbosity }}
+            - --hostname-override=$(NODE_NAME)
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              {{- toYaml .Values.resources.requests | nindent 14 }}
+            {{- with .Values.resources.limits }}
+            limits:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+          securityContext:
+            privileged: true
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/plugins
+            - name: plugin-registry
+              mountPath: /var/lib/kubelet/plugins_registry
+            - name: nri-plugin
+              mountPath: /var/run/nri
+            - name: netns
+              mountPath: /var/run/netns
+              mountPropagation: HostToContainer
+            - name: infiniband
+              mountPath: /dev/infiniband
+              mountPropagation: HostToContainer
+            - name: bpf-programs
+              mountPath: /sys/fs/bpf
+              mountPropagation: HostToContainer
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/plugins
+        - name: plugin-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+        - name: nri-plugin
+          hostPath:
+            path: /var/run/nri
+        - name: netns
+          hostPath:
+            path: /var/run/netns
+        - name: infiniband
+          hostPath:
+            path: /dev/infiniband
+        - name: bpf-programs
+          hostPath:
+            path: /sys/fs/bpf

--- a/deployments/helm/dranet/templates/rbac.yaml
+++ b/deployments/helm/dranet/templates/rbac.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dranet.fullname" . }}
+  labels:
+    {{- include "dranet.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceslices
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceclaims
+      - deviceclasses
+    verbs:
+      - get
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceclaims/status
+    verbs:
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dranet.fullname" . }}
+  labels:
+    {{- include "dranet.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dranet.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dranet.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deployments/helm/dranet/templates/serviceaccount.yaml
+++ b/deployments/helm/dranet/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dranet.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dranet.labels" . | nindent 4 }}

--- a/deployments/helm/dranet/values.yaml
+++ b/deployments/helm/dranet/values.yaml
@@ -1,0 +1,35 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: registry.k8s.io/networking/dranet
+  tag: stable
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+rbac:
+  create: true
+
+podAnnotations: {}
+podLabels: {}
+
+logVerbosity: 4
+
+tolerations:
+  - operator: Exists
+    effect: NoSchedule
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 50Mi
+  limits: {}
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 9177
+
+serviceAccount:
+  annotations: {}


### PR DESCRIPTION
Add a Helm chart under deployments/helm/dranet as an alternative to the existing static install.yaml. Also introduce a CI workflow to run helm lint for validation. As a follow-up, I’m preparing a patch to publish chart artifacts as OCI artifacts as part of the release process. This will require some additional work on the registry side which I will take care, as well as integration with [Artifact Hub.](https://artifacthub.io/).

fixes: https://github.com/kubernetes-sigs/dranet/issues/113