### PR TITLE
Provide the ability to hint the cloud provider that is expected to lower startup time.

### DIFF
--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -50,14 +50,15 @@ const (
 )
 
 var (
-	hostnameOverride string
-	kubeconfig       string
-	bindAddress      string
-	celExpression    string
-	minPollInterval  time.Duration
-	maxPollInterval  time.Duration
-	pollBurst        int
-	moveIBInterfaces bool
+	hostnameOverride  string
+	kubeconfig        string
+	bindAddress       string
+	celExpression     string
+	minPollInterval   time.Duration
+	maxPollInterval   time.Duration
+	pollBurst         int
+	moveIBInterfaces  bool
+	cloudProviderHint string
 
 	ready atomic.Bool
 )
@@ -71,6 +72,7 @@ func init() {
 	flag.DurationVar(&maxPollInterval, "inventory-max-poll-interval", 1*time.Minute, "The maximum interval between two consecutive polls of the inventory.")
 	flag.IntVar(&pollBurst, "inventory-poll-burst", 5, "The number of polls that can be run in a burst.")
 	flag.BoolVar(&moveIBInterfaces, "move-ib-interfaces", true, "If true, InfiniBand (IPoIB) network interfaces associated with PCI devices are moved into pod network namespace. If false, moving IB network interfaces are skipped and the underlying device is exposed as an IB-only RDMA device.")
+	flag.StringVar(&cloudProviderHint, "cloud-provider-hint", "", "Hint for the cloud provider that will be used to select the appropriate provider plugin. Supported values: (GCE, AZURE, OKE, NONE). If left unset, the cloud provider is auto-detected (which may delay startup) and defaults to 'NONE' if detection fails.")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: dranet [options]\n\n")
@@ -165,6 +167,7 @@ func main() {
 		inventory.WithRateLimiter(rate.NewLimiter(rate.Every(minPollInterval), pollBurst)),
 		inventory.WithMaxPollInterval(maxPollInterval),
 		inventory.WithMoveIBInterfaces(moveIBInterfaces),
+		inventory.WithCloudProviderHint(cloudProviderHint),
 	)
 	opts = append(opts, driver.WithInventory(db))
 	dranet, err := driver.Start(ctx, driverName, clientset, nodeName, opts...)

--- a/pkg/inventory/cloud.go
+++ b/pkg/inventory/cloud.go
@@ -32,27 +32,58 @@ import (
 	"sigs.k8s.io/dranet/pkg/cloudprovider/oke"
 )
 
-// getInstanceProperties get the instace properties and stores them in a global variable to be used in discovery
-func getInstanceProperties(ctx context.Context) cloudprovider.CloudInstance {
-	var err error
-	var instance cloudprovider.CloudInstance
-	switch {
-	case metadata.OnGCE():
-		// Get google compute instance metadata for network interfaces
-		// https://cloud.google.com/compute/docs/metadata/predefined-metadata-keys
-		klog.Infof("running on GCE")
-		instance, err = gce.GetInstance(ctx)
-	case azure.OnAzure(ctx):
-		// Get Azure instance metadata for placement group and VM size
-		// https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service
-		klog.Infof("running on Azure")
-		instance, err = azure.GetInstance(ctx)
-	case oke.OnOKE(ctx):
-		// Get OCI instance metadata for shape, fault domain, and availability domain
-		// https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm
-		klog.Infof("running on OKE")
-		instance, err = oke.GetInstance(ctx)
+type CloudProviderHint string
+
+const (
+	CloudProviderHintGCE   CloudProviderHint = "GCE"
+	CloudProviderHintAzure CloudProviderHint = "AZURE"
+	CloudProviderHintOKE   CloudProviderHint = "OKE"
+	CloudProviderHintNone  CloudProviderHint = "NONE"
+)
+
+func discoverCloudProvider(ctx context.Context) CloudProviderHint {
+	discoverers := map[CloudProviderHint]func(context.Context) bool{
+		CloudProviderHintGCE: func(ctx context.Context) bool {
+			return metadata.OnGCE()
+		},
+		CloudProviderHintAzure: azure.OnAzure,
+		CloudProviderHintOKE:   oke.OnOKE,
 	}
+
+	for hint, discoverer := range discoverers {
+		if discoverer(ctx) {
+			return hint
+		}
+	}
+
+	klog.Warning("could not discover cloud provider")
+	return CloudProviderHintNone
+}
+
+// getInstanceProperties gets the instance properties using the cloud provider hint if provided.
+func getInstanceProperties(ctx context.Context, cloudProviderHint CloudProviderHint) cloudprovider.CloudInstance {
+	if cloudProviderHint == CloudProviderHintNone {
+		klog.Infof("cloud provider hint is none, skipping instance properties retrieval")
+		return nil
+	}
+
+	providers := map[CloudProviderHint]func(context.Context) (cloudprovider.CloudInstance, error){
+		CloudProviderHintGCE:   gce.GetInstance,
+		CloudProviderHintAzure: azure.GetInstance,
+		CloudProviderHintOKE:   oke.GetInstance,
+	}
+
+	provider, ok := providers[cloudProviderHint]
+	if !ok {
+		klog.Infof("unknown cloud provider hint: %s", cloudProviderHint)
+		return nil
+	}
+	instance, err := provider(ctx)
+	if err != nil {
+		klog.Infof("could not get instance properties: %v", err)
+		return nil
+	}
+
 	if err != nil {
 		klog.Infof("could not get instance properties: %v", err)
 		return nil

--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -92,6 +92,11 @@ type DB struct {
 	// When false, IPoIB interfaces are skipped and the underlying device is
 	// exposed as an IB-only RDMA device.
 	moveIBInterfaces bool
+
+	// cloudProviderHint is a hint for the cloud provider that will be used to
+	// select the appropriate provider plugin. Supported values: (GCE, AZURE, OKE, NONE).
+	// If not set, the cloud provider will be auto-detected, but may take longer to start.
+	cloudProviderHint CloudProviderHint
 }
 
 type Option func(*DB)
@@ -111,6 +116,19 @@ func WithMaxPollInterval(d time.Duration) Option {
 func WithMoveIBInterfaces(move bool) Option {
 	return func(db *DB) {
 		db.moveIBInterfaces = move
+	}
+}
+
+func WithCloudProviderHint(hint string) Option {
+	return func(db *DB) {
+		if hint != "" {
+			// validate hint
+			h := CloudProviderHint(hint)
+			if h != CloudProviderHintGCE && h != CloudProviderHintAzure && h != CloudProviderHintOKE && h != CloudProviderHintNone {
+				klog.Fatalf("unknown cloud provider hint %q", hint)
+			}
+			db.cloudProviderHint = h
+		}
 	}
 }
 
@@ -168,7 +186,10 @@ func (db *DB) Run(ctx context.Context) error {
 	}
 
 	// Obtain data that will not change after the startup
-	db.instance = getInstanceProperties(ctx)
+	if db.cloudProviderHint == "" {
+		db.cloudProviderHint = discoverCloudProvider(ctx)
+	}
+	db.instance = getInstanceProperties(ctx, db.cloudProviderHint)
 	db.gwInterfaces = getDefaultGwInterfaces()
 	klog.V(2).Infof("Default gateway interfaces: %v", db.gwInterfaces.UnsortedList())
 


### PR DESCRIPTION
When reviewing https://github.com/kubernetes-sigs/dranet/pull/116 I saw that we don't run these getters in parallel. Since all of them time out after ~5 seconds, worst case scenario we take 5*(# of providers) to start up. Run these in parallel, the network overhead should be minimal and we already reduce the worst case startup time by 10 seconds.

```release-note
Add the cloud-provider-hint command line flag that allows the administrator to specify what cloud they are running on. If specified it will skip discovery, allowing for faster startup.
```
