### PR TITLE
chore: remove unused volume etc

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -146,9 +146,6 @@ spec:
       - name: infiniband
         hostPath:
           path: /dev/infiniband
-      - name: etc
-        hostPath:
-          path: /etc
       - name: bpf-programs
         hostPath:
           path: /sys/fs/bpf


### PR DESCRIPTION
There is no volume mounting referencing to `/etc` and I think it was a leftover from init container that was used for enabling NRI bits on the runtime. 