### PR TITLE
Create an inventory startup time metric

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -156,6 +156,8 @@ func (db *DB) GetPodNetNs(pod string) string {
 }
 
 func (db *DB) Run(ctx context.Context) error {
+	registerMetrics()
+	begin := time.Now()
 	defer close(db.notifications)
 
 	// Resources are published periodically or if there is a netlink notification
@@ -171,7 +173,7 @@ func (db *DB) Run(ctx context.Context) error {
 	db.instance = getInstanceProperties(ctx)
 	db.gwInterfaces = getDefaultGwInterfaces()
 	klog.V(2).Infof("Default gateway interfaces: %v", db.gwInterfaces.UnsortedList())
-
+	inventoryStartupDurationSeconds.Set(time.Since(begin).Seconds())
 	for {
 		err := db.rateLimiter.Wait(ctx)
 		if err != nil {

--- a/pkg/inventory/metrics.go
+++ b/pkg/inventory/metrics.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var registerMetricsOnce sync.Once
+
+func registerMetrics() {
+	registerMetricsOnce.Do(func() {
+		prometheus.MustRegister(inventoryStartupDurationSeconds)
+	})
+}
+
+var (
+	inventoryStartupDurationSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "dranet",
+		Subsystem: "inventory",
+		Name:      "inventory_startup_duration_seconds",
+		Help:      "The duration of the inventory startup.",
+	})
+)


### PR DESCRIPTION
Add a startup time metric for the device driver.

Traces to overall latency of startup, everything from creating the plugin path to discovering interfaces the first time around.