### PR TITLE
chore: add helm chart packaging & pushing to release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,14 @@ update:
 ensure-buildx:
 	./hack/init-buildx.sh
 
+HELM_VERSION_SHA?=a2369ca71c0ef633bf6e4fccd66d634eb379b371 # v3.20.1
+.PHONY: ensure-helm
+ensure-helm:
+	@if ! helm version >/dev/null 2>&1; then \
+		echo "Helm not found, installing helm@$(HELM_VERSION_SHA) ..."; \
+		go install helm.sh/helm/v3/cmd/helm@$(HELM_VERSION_SHA); \
+	fi
+
 # get image name from directory we're building
 IMAGE_NAME=dranet
 # docker image registry, default to upstream
@@ -58,6 +66,10 @@ REGISTRY?=gcr.io/k8s-staging-networking
 TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
 # the full image tag
 IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
+CHART_REGISTRY?=$(REGISTRY)/charts/$(IMAGE_NAME)
+HELM_TAG?=$(shell git describe --tags --exact-match 2>/dev/null)
+# for helm chart version strip 'v' to have valid semver (example: v0.1.0 → 0.1.0)
+CHART_VERSION=$(shell echo "$(HELM_TAG)" | sed 's/^v//')
 PLATFORMS?=linux/amd64,linux/arm64
 
 # base images (defaults are in the Dockerfile)
@@ -84,6 +96,16 @@ image-push: ensure-buildx
 		--tag="${IMAGE}" \
 		--push
 
+helm-package:
+	@test -n "$(CHART_VERSION)" || (echo "ERROR: not on an exact git tag, cannot package helm chart"; exit 1)
+	helm package deployments/helm/dranet \
+		--version "$(CHART_VERSION)" \
+		--app-version "$(HELM_TAG)" \
+		--destination $(OUT_DIR)
+
+helm-push: helm-package
+	helm push $(OUT_DIR)/dranet-$(CHART_VERSION).tgz oci://$(CHART_REGISTRY)
+
 kind-cluster:
 	kind create cluster --name dra --config kind.yaml
 
@@ -93,5 +115,5 @@ kind-image: image-build
 	kubectl delete -f install.yaml || true
 	kubectl apply -f install.yaml
 
-# The main release target, which pushes all images
-release: image-push
+# The main release target, which pushes all images and helm charts
+release: ensure-helm image-push helm-push


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind dependency
#### What this PR does / why we need it:
Add Helm chart publishing steps to the release pipeline so that dranet charts are automatically packaged and pushed to the OCI registry on every tagged release.
#### Which issue(s) this PR is related to:
Part of https://github.com/kubernetes-sigs/dranet/issues/128
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```