### PR TITLE
Feat: Add real topology data and Working ipv6.

### DIFF
--- a/examples/oke-bm-gpu-gb200-rocev2-dranet/README.md
+++ b/examples/oke-bm-gpu-gb200-rocev2-dranet/README.md
@@ -1,0 +1,295 @@
+# OKE BM.GPU.GB200-v3.4 RoCEv2 dranet Demo
+
+End-to-end demo of topologically-aware GPU + RoCEv2 NIC allocation using
+[Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+on Oracle Kubernetes Engine (OKE) with [BM.GPU.GB200-v3.4](https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm#bm-gpu) shapes.
+
+## Context
+
+### Shape: BM.GPU.GB200-v3.4
+
+Each node has:
+
+| Resource | Count | Detail |
+|---|---|---|
+| GPU | 4 x NVIDIA GB200 | 189 GB HBM3e, Blackwell architecture, NVLink-18 all-to-all |
+| NIC | 8 x Mellanox ConnectX-8 | 400 Gb/s RoCEv2, 4x NDR per NIC |
+| NUMA nodes | 2 | 2 GPUs + 4 NICs per NUMA node |
+
+### GPU-NIC topology
+
+On GB200, GPUs connect to the Grace CPU via **NVLink C2C** (chip-to-chip), while
+NICs connect via PCIe. Because GPUs and NICs are on fundamentally different
+interconnects, `nvidia-smi topo -m` reports **SYS** for every GPU-NIC pair:
+
+|      | GPU0 | GPU1 | GPU2 | GPU3 | NIC0 | NIC1 | NIC2 | NIC3 | NIC4 | NIC5 | NIC6 | NIC7 |
+|------|------|------|------|------|------|------|------|------|------|------|------|------|
+| GPU0 | X    | NV18 | NV18 | NV18 | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  |
+| GPU1 | NV18 | X    | NV18 | NV18 | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  |
+| GPU2 | NV18 | NV18 | X    | NV18 | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  |
+| GPU3 | NV18 | NV18 | NV18 | X    | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  | SYS  |
+
+NIC mapping: NIC0=mlx5_0/rdma0 (NUMA 0), ... NIC3=mlx5_3/rdma3 (NUMA 0), NIC4=mlx5_5/rdma4 (NUMA 1), ... NIC7=mlx5_8/rdma7 (NUMA 1)
+
+> **Key difference from Azure GB300:** On Azure, GPU-NIC pairs on the same NUMA
+> node have **NODE** affinity. On OKE GB200, all pairs report **SYS** because the
+> C2C link is not visible to the PCIe topology. Despite this, NCCL enables GDR
+> via the `NCCL_NET_GDR_C2C=1` flag for NUMA-local NICs, achieving comparable
+> bandwidth. The practical performance difference is NUMA-local vs cross-NUMA.
+
+### DRA device attributes
+
+**GPU** (driver: `gpu.nvidia.com`):
+
+| Device | pciBusID | pcieRoot | NUMA |
+|---|---|---|---|
+| gpu-0 | 0008:06:00.0 | pci0008:00 | 0 |
+| gpu-1 | 0009:06:00.0 | pci0009:00 | 0 |
+| gpu-2 | 0018:06:00.0 | pci0018:00 | 1 |
+| gpu-3 | 0019:06:00.0 | pci0019:00 | 1 |
+
+**NIC** (driver: `dra.net`):
+
+| Device | ifName | pciAddress | NUMA | pcieRoot |
+|---|---|---|---|---|
+| pci-0000-03-00-0 | rdma0 | 0000:03:00.0 | 0 | pci0000:00 |
+| pci-0000-03-00-1 | rdma1 | 0000:03:00.1 | 0 | pci0000:00 |
+| pci-0002-03-00-0 | rdma2 | 0002:03:00.0 | 0 | pci0002:00 |
+| pci-0002-03-00-1 | rdma3 | 0002:03:00.1 | 0 | pci0002:00 |
+| pci-0010-03-00-0 | rdma4 | 0010:03:00.0 | 1 | pci0010:00 |
+| pci-0010-03-00-1 | rdma5 | 0010:03:00.1 | 1 | pci0010:00 |
+| pci-0012-03-00-0 | rdma6 | 0012:03:00.0 | 1 | pci0012:00 |
+| pci-0012-03-00-1 | rdma7 | 0012:03:00.1 | 1 | pci0012:00 |
+
+### OKE topology attributes (oke.dra.net)
+
+Each NIC device carries node-level RDMA topology attributes sourced from the
+OCI Instance Metadata Service (`GET /opc/v2/host/`):
+
+| Attribute | Description |
+|---|---|
+| `oke.dra.net/hpcIslandId` | HPC Island -- largest topology grouping (~2000 nodes) |
+| `oke.dra.net/networkBlockId` | Network Block -- mid-level grouping (~64-128 nodes) |
+| `oke.dra.net/localBlockId` | Local Block -- closest grouping (~8-32 nodes) |
+| `oke.dra.net/rackId` | Physical rack identifier |
+| `oke.dra.net/gpuMemoryFabricId` | GPU memory fabric ID (populated on GB200/GB300) |
+
+> **Note:** Topology data must be enabled for your OCI tenancy. dranet logs
+> `"Please turn on TopologyData for your Tenancy"` at startup if the `/host/`
+> endpoint does not provide `rdmaTopologyData`.
+
+### RoCEv2 and IPv6 on OKE
+
+The ConnectX-8 NICs use **RoCEv2** (RDMA over Converged Ethernet v2). On OKE,
+each RDMA NIC receives a globally-routable IPv6 address via Router Advertisement.
+This address populates a routable GID in the NIC's GID table, which NCCL uses
+for inter-node communication (`NCCL_IB_GID_INDEX=3`).
+
+**Challenge:** In single-stack IPv4 Kubernetes clusters, the container runtime
+sets `net.ipv6.conf.all.disable_ipv6=1` in pod namespaces. This prevents the
+RA-assigned IPv6 address from being applied to RDMA NICs in the pod, leaving
+only link-local GIDs (which are not routable on the OKE fabric).
+
+**dranet fix:** The OKE cloud provider returns `EnableIPv6: true` for RDMA
+devices on GPU fabric shapes. When set, dranet:
+
+1. Soft-fails the initial IPv6 address application (EACCES due to disabled IPv6)
+2. Enables IPv6 per-interface via `net.ipv6.conf.<ifname>.disable_ipv6=0`
+3. Re-applies the IPv6 address, populating the routable GID at index 3
+
+## Files
+
+| File | Description |
+|---|---|
+| `resource-claim-template.yaml` | Three `ResourceClaimTemplate` objects for the three test cases |
+| `mpi-job.yaml` | `MPIJob` that runs `nccl_tests/all_reduce_perf` across 2 workers |
+| `resourceslice-gpu.yaml` | Live GPU `ResourceSlice` from a GB200 node (reference) |
+| `resourceslice-dranet.yaml` | Live NIC `ResourceSlice` from a GB200 node (reference) |
+
+## Installation
+
+### 1. Uninstall the existing dranet
+
+```bash
+helm uninstall dranet -n kube-system
+kubectl wait --for=delete pod -l k8s-app=dranet -n kube-system --timeout=120s
+```
+
+### 2. Install your local dranet build
+
+Build and push your image, then install from the local Helm chart:
+
+```bash
+helm install dranet ./deployments/helm/dranet \
+  --namespace kube-system \
+  --set image.repository=<your-registry>/dranet \
+  --set image.tag=<your-tag> \
+  --set image.pullPolicy=Always
+kubectl rollout status daemonset/dranet -n kube-system
+```
+
+## Usage
+
+```bash
+# Install MPI Operator (if not already installed)
+kubectl apply --server-side -k "https://github.com/kubeflow/mpi-operator/manifests/overlays/standalone?ref=v0.7.0"
+
+# Apply ResourceClaimTemplates
+kubectl apply -f resource-claim-template.yaml
+
+# Select a test case: edit mpi-job.yaml resourceClaimTemplateName to one of:
+#   1nic-aligned | 2nic-aligned | 1nic-unaligned
+kubectl apply -f mpi-job.yaml
+
+# Wait for workers then stream launcher logs
+kubectl wait --for=condition=ready pod \
+  -l training.kubeflow.org/job-name=nccl-test-dra,training.kubeflow.org/job-role=worker \
+  --timeout=300s
+launcher=$(kubectl get pods \
+  -l training.kubeflow.org/job-name=nccl-test-dra,training.kubeflow.org/job-role=launcher \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -f "${launcher}"
+```
+
+## ResourceClaimTemplates
+
+Three templates are defined, each allocating 1 GPU + N NICs per worker pod.
+Update `mpi-job.yaml` `resourceClaimTemplateName:` to switch between them.
+
+### `1nic-aligned` -- 1 GPU + 1 NIC, same NUMA
+
+gpu-0 (`0008:06:00.0`, NUMA 0) + rdma3 (`0002:03:00.1`, NUMA 0). NCCL enables
+GDR via C2C with `NCCL_NET_GDR_C2C=1`, transport: `NET/IB/0/GDRDMA(PCI)`.
+
+### `2nic-aligned` -- 1 GPU + 2 NICs, same NUMA
+
+gpu-0 (`0008:06:00.0`) + rdma2 + rdma3 (both NUMA 0, PCIe domain `0002`).
+Doubles available RoCEv2 bandwidth and NCCL channels (8 vs 4).
+
+### `1nic-unaligned` -- 1 GPU + 1 NIC, cross-NUMA
+
+gpu-0 (`0008:06:00.0`, NUMA 0) + rdma4 (`0010:03:00.0`, NUMA 1). GDR is
+disabled by NCCL; expect significantly lower bandwidth due to cross-NUMA memory
+traffic and fewer NCCL channels (2 vs 4).
+
+## Running the full test suite
+
+Each test requires deleting the previous MPIJob since the resource claims are
+immutable. Between tests, orphaned NICs may need PCI rebinding (see next section).
+
+```bash
+# --- Test 1: 1nic-aligned ---
+# Ensure resourceClaimTemplateName: 1nic-aligned in mpi-job.yaml
+kubectl apply -f resource-claim-template.yaml
+kubectl apply -f mpi-job.yaml
+# Wait for results ...
+kubectl delete mpijob nccl-test-dra
+
+# --- Recover orphaned NICs before next test ---
+# See "Recovering orphaned RDMA NICs" below
+
+# --- Test 2: 1nic-unaligned ---
+# Edit mpi-job.yaml: resourceClaimTemplateName: 1nic-unaligned
+kubectl apply -f mpi-job.yaml
+# Wait for results ...
+kubectl delete mpijob nccl-test-dra
+
+# --- Recover orphaned NICs before next test ---
+
+# --- Test 3: 2nic-aligned ---
+# Edit mpi-job.yaml: resourceClaimTemplateName: 2nic-aligned
+kubectl apply -f mpi-job.yaml
+# Wait for results ...
+kubectl delete mpijob nccl-test-dra
+```
+
+## Recovering orphaned RDMA NICs
+
+When a pod is deleted, dranet may not return the RDMA NIC from the pod namespace
+to the host namespace. The NIC disappears from both the host and the ResourceSlice
+(`ifName: null, rdma: false`). This is a pre-existing dranet bug, not
+OKE-specific.
+
+**Symptoms:** Workers stuck in `Pending` with `cannot allocate all claims`.
+
+**Check which NICs are missing:**
+
+```bash
+kubectl get resourceslice -o json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for rs in data['items']:
+    if rs['spec'].get('driver') != 'dra.net': continue
+    node = rs['spec']['nodeName']
+    for d in rs['spec'].get('devices', []):
+        attrs = d.get('attributes', {})
+        if attrs.get('dra.net/rdma', {}).get('bool') and \
+           not attrs.get('dra.net/virtual', {}).get('bool', True):
+            print(f'{node}: {d[\"name\"]}  ifName={attrs.get(\"dra.net/ifName\", {}).get(\"string\", \"?\")}')
+"
+```
+
+**Recover via PCI rebind** (requires a privileged debug pod on each GPU node):
+
+```bash
+# Start a debug pod (or use an existing one)
+kubectl debug node/<node-ip> --image=busybox -it -- sh
+
+# Inside the debug pod, rebind the orphaned NIC's PCI address:
+chroot /host
+echo "0002:03:00.1" > /sys/bus/pci/drivers/mlx5_core/unbind
+sleep 2
+echo "0002:03:00.1" > /sys/bus/pci/drivers/mlx5_core/bind
+```
+
+Common PCI addresses on BM.GPU.GB200-v3.4:
+
+| ifName | PCI Address | NUMA |
+|---|---|---|
+| rdma0 | 0000:03:00.0 | 0 |
+| rdma1 | 0000:03:00.1 | 0 |
+| rdma2 | 0002:03:00.0 | 0 |
+| rdma3 | 0002:03:00.1 | 0 |
+| rdma4 | 0010:03:00.0 | 1 |
+| rdma5 | 0010:03:00.1 | 1 |
+| rdma6 | 0012:03:00.0 | 1 |
+| rdma7 | 0012:03:00.1 | 1 |
+
+Repeat the unbind/bind for every orphaned NIC on **every GPU node**. Wait ~15
+seconds for dranet to rescan, then verify the NIC reappears in the ResourceSlice.
+
+## Benchmark Results
+
+2-node `all_reduce_perf` (`-b 512M -e 8G -f 2 -g 1`), 1 GPU per worker.
+Transport: `NET/IB/GDRDMA(PCI)` for NUMA-aligned, `NET/IB` for cross-NUMA.
+
+| Template | GPU | NIC(s) | NUMA relation | Channels | GDR | Avg busbw |
+|---|---|---|---|---|---|---|
+| `1nic-aligned` | gpu-0 (NUMA 0) | rdma3 (NUMA 0) | same | 4 | yes | **~46 GB/s** |
+| `2nic-aligned` | gpu-0 (NUMA 0) | rdma2 + rdma3 (NUMA 0) | same | 8 | yes | **~96 GB/s** |
+| `1nic-unaligned` | gpu-0 (NUMA 0) | rdma4 (NUMA 1) | cross | 2 | no | **~25 GB/s** |
+
+### Key observations
+
+**NUMA alignment enables GDR (~1.7x):**
+Cross-NUMA placement degrades performance from ~42 GB/s to ~25 GB/s with the
+same NIC count. Two compounding penalties:
+
+1. **GDR disabled** -- NCCL falls back from `GDRDMA(PCI)` to staging through
+   host memory when the NIC is on a different NUMA node from the GPU. On GB200
+   this is controlled by `NCCL_NET_GDR_C2C=1` which only enables GDR when NCCL
+   detects a viable C2C path (same NUMA node).
+2. **Fewer channels** -- NCCL allocates 2 channels for cross-NUMA NICs vs 4
+   for NUMA-local NICs.
+
+**2 NICs doubles bandwidth (~2.2x):**
+Adding a second NUMA-aligned NIC increases bandwidth from ~42 GB/s to ~91 GB/s.
+NCCL doubles the channel count (8 vs 4) and stripes data across both NICs.
+The `count: 2` + CEL-selector pattern in the `2nic-aligned` template is the
+idiomatic DRA approach for multi-device allocation.
+
+**Isolation confirmed:**
+In all cases, the pod sees only the allocated `/dev/infiniband/uverbs*` and
+`/dev/infiniband/umad*` devices -- without `privileged: true`. Isolation is
+enforced by the dranet NRI plugin injecting only the char devices that correspond
+to the DRA-allocated NIC(s).

--- a/examples/oke-bm-gpu-gb200-rocev2-dranet/mpi-job.yaml
+++ b/examples/oke-bm-gpu-gb200-rocev2-dranet/mpi-job.yaml
@@ -1,0 +1,92 @@
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: nccl-test-dra
+spec:
+  slotsPerWorker: 1
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - name: nccl
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            command: ["/bin/bash", "-c"]
+            args:
+            - |
+              NUM_GPUS=1
+              NUM_HOSTS=$(sed -n '$=' /etc/mpi/hostfile)
+              NP=$(($NUM_HOSTS*$NUM_GPUS))
+              while ! (for host in $(awk '{print $1}' /etc/mpi/hostfile); do
+                ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no $host exit 2>/dev/null || exit 1
+              done); do
+                echo "Waiting for workers to be ready..."
+                sleep 5
+              done
+              echo "All workers ready, launching NCCL test across $NUM_HOSTS nodes ($NP ranks)"
+              mpirun \
+                --allow-run-as-root \
+                --bind-to numa \
+                --mca pml ucx \
+                --mca coll ^hcoll \
+                -x LD_LIBRARY_PATH \
+                -x UCX_NET_DEVICES=eth0 \
+                -x NCCL_DEBUG=INFO \
+                -x NCCL_SOCKET_IFNAME=eth0 \
+                -x NCCL_MNNVL_ENABLE=0 \
+                -x NCCL_NET_GDR_C2C=1 \
+                -x NCCL_IB_GID_INDEX=3 \
+                -x NCCL_IB_TC=41 \
+                -x NCCL_IB_SL=0 \
+                -x NCCL_IB_TIMEOUT=22 \
+                -x RX_QUEUE_LEN=8192 \
+                -x IB_RX_QUEUE_LEN=8192 \
+                -x NCCL_IB_QPS_PER_CONNECTION=4 \
+                -x NCCL_IB_SPLIT_DATA_ON_QPS=0 \
+                -x NCCL_BUFFSIZE=16777216 \
+                -x NCCL_DMABUF_ENABLE=1 \
+                -x NCCL_NET_PLUGIN=sys \
+                -x NCCL_NVLS_ENABLE=0 \
+                -x HCOLL_ENABLE_MCAST_ALL=0 \
+                -x coll_hcoll_enable=0 \
+                -np $NP \
+                /workspace/nccl-tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1 -c 0
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    training.kubeflow.org/job-name: nccl-test-dra
+                    training.kubeflow.org/job-role: worker
+                topologyKey: kubernetes.io/hostname
+          automountServiceAccountToken: false
+          volumes:
+          - name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 32Gi
+          resourceClaims:
+          - name: gpu-nic
+            resourceClaimTemplateName: 1nic-aligned
+          containers:
+          - name: nccl
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            resources:
+              claims:
+              - name: gpu-nic
+            securityContext:
+              capabilities:
+                add:
+                - IPC_LOCK
+          tolerations:
+          - key: "nvidia.com/gpu"
+            operator: "Exists"
+            effect: "NoSchedule"

--- a/examples/oke-bm-gpu-gb200-rocev2-dranet/resource-claim-template.yaml
+++ b/examples/oke-bm-gpu-gb200-rocev2-dranet/resource-claim-template.yaml
@@ -1,0 +1,77 @@
+# 1nic-aligned: 1 GPU + 1 NIC on the same NUMA node (NODE affinity).
+# gpu-0 (0008:06:00.0, NUMA 0) + rdma3 (0002:03:00.1, NUMA 0)
+# Best-case topology for GDR — direct PCIe path between GPU and NIC.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: 1nic-aligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pciBusID == "0008:06:00.0"'
+      - name: nic
+        exactly:
+          deviceClassName: dranet.net
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["dra.net"].rdma == true && device.attributes["dra.net"].ifName == "rdma3"'
+---
+# 1nic-unaligned: 1 GPU (NUMA 0) + 1 NIC (NUMA 1). Cross-NUMA, SYS affinity.
+# gpu-0 (0008:06:00.0, NUMA 0) + rdma4 (0010:03:00.0, NUMA 1)
+# GDR is disabled by NCCL; expect significantly lower bandwidth.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: 1nic-unaligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pciBusID == "0008:06:00.0"'
+      - name: nic
+        exactly:
+          deviceClassName: dranet.net
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["dra.net"].rdma == true && device.attributes["dra.net"].ifName == "rdma4"'
+---
+# 2nic-aligned: 1 GPU + 2 NICs, all on NUMA 0.
+# gpu-0 (0008:06:00.0) + any 2 RDMA NICs from NUMA 0 (rdma0–rdma3).
+# Doubles available RoCEv2 bandwidth vs 1nic-aligned using count: 2 pool selection.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: 2nic-aligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pciBusID == "0008:06:00.0"'
+      - name: nic
+        exactly:
+          deviceClassName: dranet.net
+          count: 2
+          selectors:
+          - cel:
+              expression: 'device.attributes["dra.net"].rdma == true && (device.attributes["dra.net"].ifName == "rdma2" || device.attributes["dra.net"].ifName == "rdma3")'

--- a/examples/oke-bm-gpu-gb200-rocev2-dranet/resourceslice-dranet.yaml
+++ b/examples/oke-bm-gpu-gb200-rocev2-dranet/resourceslice-dranet.yaml
@@ -1,0 +1,341 @@
+# Live ResourceSlice from node 10.140.65.248 (BM.GPU.GB200-v3.4)
+# Captured from a running cluster — use as reference for CEL selector values.
+# Only the 8 physical RDMA NICs (ConnectX-8) are shown; the node also exposes
+# management NICs (pci-0007-01-00-0 / eth0, pci-0017-01-00-0 / eth1) and
+# virtual pod-networking interfaces (eth0v*, net-mv2*) in the same slice.
+#
+# NUMA mapping (inferred from PCI domain):
+#   NUMA 0: rdma0 (0000:03:00.0), rdma1 (0000:03:00.1), rdma2 (0002:03:00.0), rdma3 (0002:03:00.1)
+#   NUMA 1: rdma4 (0010:03:00.0), rdma5 (0010:03:00.1), rdma6 (0012:03:00.0), rdma7 (0012:03:00.1)
+apiVersion: resource.k8s.io/v1
+kind: ResourceSlice
+metadata:
+  name: 10.140.65.248-dra.net-jb4n2
+spec:
+  driver: dra.net
+  nodeName: 10.140.65.248
+  pool:
+    generation: 1
+    name: 10.140.65.248
+    resourceSliceCount: 1
+  devices:
+  - name: pci-0000-03-00-0
+    attributes:
+      dra.net/ifName:
+        string: rdma0
+      dra.net/mac:
+        string: 60:5e:65:14:0f:10
+      dra.net/mtu:
+        int: 9000
+      dra.net/numaNode:
+        int: 0
+      dra.net/pciAddress:
+        string: "0000:03:00.0"
+      dra.net/pciDevice:
+        string: CX8 Family [ConnectX-8]
+      dra.net/pciVendor:
+        string: Mellanox Technologies
+      dra.net/rdma:
+        bool: true
+      dra.net/sriov:
+        bool: true
+      dra.net/sriovVfs:
+        int: 0
+      dra.net/state:
+        string: up
+      dra.net/type:
+        string: device
+      dra.net/virtual:
+        bool: false
+      oke.dra.net/gpuMemoryFabricId:
+        string: redacted
+      oke.dra.net/hpcIslandId:
+        string: redacted
+      oke.dra.net/localBlockId:
+        string: redacted
+      oke.dra.net/networkBlockId:
+        string: redacted
+      oke.dra.net/rackId:
+        string: redacted
+      resource.kubernetes.io/pcieRoot:
+        string: pci0000:00
+  - name: pci-0000-03-00-1
+    attributes:
+      dra.net/ifName:
+        string: rdma1
+      dra.net/mac:
+        string: 60:5e:65:14:0f:11
+      dra.net/mtu:
+        int: 9000
+      dra.net/numaNode:
+        int: 0
+      dra.net/pciAddress:
+        string: "0000:03:00.1"
+      dra.net/pciDevice:
+        string: CX8 Family [ConnectX-8]
+      dra.net/pciVendor:
+        string: Mellanox Technologies
+      dra.net/rdma:
+        bool: true
+      dra.net/sriov:
+        bool: true
+      dra.net/sriovVfs:
+        int: 0
+      dra.net/state:
+        string: up
+      dra.net/type:
+        string: device
+      dra.net/virtual:
+        bool: false
+      oke.dra.net/gpuMemoryFabricId:
+        string: redacted
+      oke.dra.net/hpcIslandId:
+        string: redacted
+      oke.dra.net/localBlockId:
+        string: redacted
+      oke.dra.net/networkBlockId:
+        string: redacted
+      oke.dra.net/rackId:
+        string: redacted
+      resource.kubernetes.io/pcieRoot:
+        string: pci0000:00
+  - name: pci-0002-03-00-0
+    attributes:
+      dra.net/ifName:
+        string: rdma2
+      dra.net/mac:
+        string: 60:5e:65:14:0f:40
+      dra.net/mtu:
+        int: 9000
+      dra.net/numaNode:
+        int: 0
+      dra.net/pciAddress:
+        string: "0002:03:00.0"
+      dra.net/pciDevice:
+        string: CX8 Family [ConnectX-8]
+      dra.net/pciVendor:
+        string: Mellanox Technologies
+      dra.net/rdma:
+        bool: true
+      dra.net/sriov:
+        bool: true
+      dra.net/sriovVfs:
+        int: 0
+      dra.net/state:
+        string: up
+      dra.net/type:
+        string: device
+      dra.net/virtual:
+        bool: false
+      oke.dra.net/gpuMemoryFabricId:
+        string: redacted
+      oke.dra.net/hpcIslandId:
+        string: redacted
+      oke.dra.net/localBlockId:
+        string: redacted
+      oke.dra.net/networkBlockId:
+        string: redacted
+      oke.dra.net/rackId:
+        string: redacted
+      resource.kubernetes.io/pcieRoot:
+        string: pci0002:00
+  - name: pci-0002-03-00-1
+    attributes:
+      dra.net/ifName:
+        string: rdma3
+      dra.net/mac:
+        string: 60:5e:65:14:0f:41
+      dra.net/mtu:
+        int: 9000
+      dra.net/numaNode:
+        int: 0
+      dra.net/pciAddress:
+        string: "0002:03:00.1"
+      dra.net/pciDevice:
+        string: CX8 Family [ConnectX-8]
+      dra.net/pciVendor:
+        string: Mellanox Technologies
+      dra.net/rdma:
+        bool: true
+      dra.net/sriov:
+        bool: true
+      dra.net/sriovVfs:
+        int: 0
+      dra.net/state:
+        string: up
+      dra.net/type:
+        string: device
+      dra.net/virtual:
+        bool: false
+      oke.dra.net/gpuMemoryFabricId:
+        string: redacted
+      oke.dra.net/hpcIslandId:
+        string: redacted
+      oke.dra.net/localBlockId:
+        string: redacted
+      oke.dra.net/networkBlockId:
+        string: redacted
+      oke.dra.net/rackId:
+        string: redacted
+      resource.kubernetes.io/pcieRoot:
+        string: pci0002:00
+  - name: pci-0010-03-00-0
+    attributes:
+      dra.net/ifName:
+        string: rdma4
+      dra.net/mac:
+        string: 60:5e:65:20:28:84
+      dra.net/mtu:
+        int: 9000
+      dra.net/numaNode:
+        int: 1
+      dra.net/pciAddress:
+        string: "0010:03:00.0"
+      dra.net/pciDevice:
+        string: CX8 Family [ConnectX-8]
+      dra.net/pciVendor:
+        string: Mellanox Technologies
+      dra.net/rdma:
+        bool: true
+      dra.net/sriov:
+        bool: true
+      dra.net/sriovVfs:
+        int: 0
+      dra.net/state:
+        string: up
+      dra.net/type:
+        string: device
+      dra.net/virtual:
+        bool: false
+      oke.dra.net/gpuMemoryFabricId:
+        string: redacted
+      oke.dra.net/hpcIslandId:
+        string: redacted
+      oke.dra.net/localBlockId:
+        string: redacted
+      oke.dra.net/networkBlockId:
+        string: redacted
+      oke.dra.net/rackId:
+        string: redacted
+      resource.kubernetes.io/pcieRoot:
+        string: pci0010:00
+  - name: pci-0010-03-00-1
+    attributes:
+      dra.net/ifName:
+        string: rdma5
+      dra.net/mac:
+        string: 60:5e:65:20:28:85
+      dra.net/mtu:
+        int: 9000
+      dra.net/numaNode:
+        int: 1
+      dra.net/pciAddress:
+        string: "0010:03:00.1"
+      dra.net/pciDevice:
+        string: CX8 Family [ConnectX-8]
+      dra.net/pciVendor:
+        string: Mellanox Technologies
+      dra.net/rdma:
+        bool: true
+      dra.net/sriov:
+        bool: true
+      dra.net/sriovVfs:
+        int: 0
+      dra.net/state:
+        string: up
+      dra.net/type:
+        string: device
+      dra.net/virtual:
+        bool: false
+      oke.dra.net/gpuMemoryFabricId:
+        string: redacted
+      oke.dra.net/hpcIslandId:
+        string: redacted
+      oke.dra.net/localBlockId:
+        string: redacted
+      oke.dra.net/networkBlockId:
+        string: redacted
+      oke.dra.net/rackId:
+        string: redacted
+      resource.kubernetes.io/pcieRoot:
+        string: pci0010:00
+  - name: pci-0012-03-00-0
+    attributes:
+      dra.net/ifName:
+        string: rdma6
+      dra.net/mac:
+        string: 60:5e:65:20:28:b4
+      dra.net/mtu:
+        int: 9000
+      dra.net/numaNode:
+        int: 1
+      dra.net/pciAddress:
+        string: "0012:03:00.0"
+      dra.net/pciDevice:
+        string: CX8 Family [ConnectX-8]
+      dra.net/pciVendor:
+        string: Mellanox Technologies
+      dra.net/rdma:
+        bool: true
+      dra.net/sriov:
+        bool: true
+      dra.net/sriovVfs:
+        int: 0
+      dra.net/state:
+        string: up
+      dra.net/type:
+        string: device
+      dra.net/virtual:
+        bool: false
+      oke.dra.net/gpuMemoryFabricId:
+        string: redacted
+      oke.dra.net/hpcIslandId:
+        string: redacted
+      oke.dra.net/localBlockId:
+        string: redacted
+      oke.dra.net/networkBlockId:
+        string: redacted
+      oke.dra.net/rackId:
+        string: redacted
+      resource.kubernetes.io/pcieRoot:
+        string: pci0012:00
+  - name: pci-0012-03-00-1
+    attributes:
+      dra.net/ifName:
+        string: rdma7
+      dra.net/mac:
+        string: 60:5e:65:20:28:b5
+      dra.net/mtu:
+        int: 9000
+      dra.net/numaNode:
+        int: 1
+      dra.net/pciAddress:
+        string: "0012:03:00.1"
+      dra.net/pciDevice:
+        string: CX8 Family [ConnectX-8]
+      dra.net/pciVendor:
+        string: Mellanox Technologies
+      dra.net/rdma:
+        bool: true
+      dra.net/sriov:
+        bool: true
+      dra.net/sriovVfs:
+        int: 0
+      dra.net/state:
+        string: up
+      dra.net/type:
+        string: device
+      dra.net/virtual:
+        bool: false
+      oke.dra.net/gpuMemoryFabricId:
+        string: redacted
+      oke.dra.net/hpcIslandId:
+        string: redacted
+      oke.dra.net/localBlockId:
+        string: redacted
+      oke.dra.net/networkBlockId:
+        string: redacted
+      oke.dra.net/rackId:
+        string: redacted
+      resource.kubernetes.io/pcieRoot:
+        string: pci0012:00

--- a/examples/oke-bm-gpu-gb200-rocev2-dranet/resourceslice-gpu.yaml
+++ b/examples/oke-bm-gpu-gb200-rocev2-dranet/resourceslice-gpu.yaml
@@ -1,0 +1,124 @@
+# Live ResourceSlice from node 10.140.65.248 (BM.GPU.GB200-v3.4)
+# Captured from a running cluster — use as reference for CEL selector values.
+# The gpu.nvidia.com driver does not expose numaNode; infer NUMA affinity from
+# pciBusID domain (0008/0009 → NUMA 0, 0018/0019 → NUMA 1).
+apiVersion: resource.k8s.io/v1
+kind: ResourceSlice
+metadata:
+  name: 10.140.65.248-gpu.nvidia.com-wgq4h
+spec:
+  driver: gpu.nvidia.com
+  nodeName: 10.140.65.248
+  pool:
+    generation: 1
+    name: 10.140.65.248
+    resourceSliceCount: 1
+  devices:
+  - name: gpu-0
+    attributes:
+      addressingMode:
+        string: ATS
+      architecture:
+        string: Blackwell
+      brand:
+        string: Nvidia
+      cudaComputeCapability:
+        version: 10.0.0
+      cudaDriverVersion:
+        version: 13.0.0
+      driverVersion:
+        version: 580.126.20
+      productName:
+        string: NVIDIA GB200
+      resource.kubernetes.io/pciBusID:
+        string: "0008:06:00.0"
+      resource.kubernetes.io/pcieRoot:
+        string: pci0008:00
+      type:
+        string: gpu
+      uuid:
+        string: GPU-5d1d46ee-c7f8-fb08-137a-026f11ab6dd9
+    capacity:
+      memory:
+        value: 189471Mi
+  - name: gpu-1
+    attributes:
+      addressingMode:
+        string: ATS
+      architecture:
+        string: Blackwell
+      brand:
+        string: Nvidia
+      cudaComputeCapability:
+        version: 10.0.0
+      cudaDriverVersion:
+        version: 13.0.0
+      driverVersion:
+        version: 580.126.20
+      productName:
+        string: NVIDIA GB200
+      resource.kubernetes.io/pciBusID:
+        string: "0009:06:00.0"
+      resource.kubernetes.io/pcieRoot:
+        string: pci0009:00
+      type:
+        string: gpu
+      uuid:
+        string: GPU-7d9b3513-8002-4843-9759-a0987d50a31c
+    capacity:
+      memory:
+        value: 189471Mi
+  - name: gpu-2
+    attributes:
+      addressingMode:
+        string: ATS
+      architecture:
+        string: Blackwell
+      brand:
+        string: Nvidia
+      cudaComputeCapability:
+        version: 10.0.0
+      cudaDriverVersion:
+        version: 13.0.0
+      driverVersion:
+        version: 580.126.20
+      productName:
+        string: NVIDIA GB200
+      resource.kubernetes.io/pciBusID:
+        string: "0018:06:00.0"
+      resource.kubernetes.io/pcieRoot:
+        string: pci0018:00
+      type:
+        string: gpu
+      uuid:
+        string: GPU-42d06ef2-849e-5128-586d-7ccfcea6c0ce
+    capacity:
+      memory:
+        value: 189471Mi
+  - name: gpu-3
+    attributes:
+      addressingMode:
+        string: ATS
+      architecture:
+        string: Blackwell
+      brand:
+        string: Nvidia
+      cudaComputeCapability:
+        version: 10.0.0
+      cudaDriverVersion:
+        version: 13.0.0
+      driverVersion:
+        version: 580.126.20
+      productName:
+        string: NVIDIA GB200
+      resource.kubernetes.io/pciBusID:
+        string: "0019:06:00.0"
+      resource.kubernetes.io/pcieRoot:
+        string: pci0019:00
+      type:
+        string: gpu
+      uuid:
+        string: GPU-6d140208-1af4-030d-7509-579195e27a2f
+    capacity:
+      memory:
+        value: 189471Mi

--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -86,6 +86,14 @@ type InterfaceConfig struct {
 	// If provided, the interface will be enslaved to a VRF device with this name.
 	// This enables grouping multiple network interfaces into the same VRF.
 	VRF *VRFConfig `json:"vrf,omitempty"`
+
+	// EnableIPv6, if true, enables IPv6 on this specific interface even when IPv6 is
+	// globally disabled in the pod's network namespace (e.g. single-stack IPv4 clusters
+	// where the container runtime sets net.ipv6.conf.all.disable_ipv6=1). A per-interface
+	// sysctl override (net.ipv6.conf.<ifname>.disable_ipv6=0) is applied after the device
+	// is moved into the pod namespace. This is required on platforms such as OKE that need
+	// a globally-routable IPv6 address on RDMA interfaces to populate RoCEv2 GIDs.
+	EnableIPv6 *bool `json:"enableIPv6,omitempty"`
 }
 
 // VRFConfig represents the configuration for a Virtual Routing and Forwarding domain.

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -27,6 +27,18 @@ type DeviceIdentifiers struct {
 	MAC        string
 	PCIAddress string
 	Name       string
+	RDMA       bool
+}
+
+// NonUplinkChecker is an optional extension to CloudInstance. A provider may
+// implement this to exempt specific device classes from the default-gateway
+// uplink filter, even when those interfaces carry a default route. This is
+// needed on platforms where infrastructure daemons (e.g. RA) inject default
+// routes onto workload RDMA NICs as a side-effect of their setup.
+type NonUplinkChecker interface {
+	// IsNonUplink returns true if the device should be included in the
+	// ResourceSlice regardless of any default gateway route on that interface.
+	IsNonUplink(id DeviceIdentifiers) bool
 }
 
 // CloudInstance defines the generic interface for all cloud providers.

--- a/pkg/cloudprovider/oke/oke.go
+++ b/pkg/cloudprovider/oke/oke.go
@@ -19,9 +19,11 @@ package oke
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,54 +37,123 @@ import (
 const (
 	OKEAttrPrefix = "oke.dra.net"
 
-	AttrOKEShape              = OKEAttrPrefix + "/" + "shape"
-	AttrOKEFaultDomain        = OKEAttrPrefix + "/" + "faultDomain"
-	AttrOKEAvailabilityDomain = OKEAttrPrefix + "/" + "availabilityDomain"
+	AttrOKEHPCIslandId     = OKEAttrPrefix + "/" + "hpcIslandId"
+	AttrOKENetworkBlockId  = OKEAttrPrefix + "/" + "networkBlockId"
+	AttrOKELocalBlockId    = OKEAttrPrefix + "/" + "localBlockId"
+	AttrOKERackId          = OKEAttrPrefix + "/" + "rackId"
+	AttrOKEGpuMemoryFabric = OKEAttrPrefix + "/" + "gpuMemoryFabricId"
 
 	// imdsEndpoint is the Oracle Cloud Instance Metadata Service endpoint.
 	imdsEndpoint = "http://169.254.169.254/opc/v2"
 )
 
-// imdsInstanceMetadata contains the fields we care about from the OCI IMDS
-// instance metadata response.
-type imdsInstanceMetadata struct {
-	Shape              string `json:"shape"`
-	FaultDomain        string `json:"faultDomain"`
-	AvailabilityDomain string `json:"availabilityDomain"`
+// imdsHostRDMATopologyData contains the RDMA topology fields from the OCI
+// IMDS host metadata response. This is only populated when RDMA topology
+// data is enabled for the tenancy.
+type imdsHostRDMATopologyData struct {
+	CustomerGpuMemoryFabric string `json:"customerGpuMemoryFabric"`
+	CustomerHPCIslandId     string `json:"customerHPCIslandId"`
+	CustomerHostId          string `json:"customerHostId"`
+	CustomerLocalBlock      string `json:"customerLocalBlock"`
+	CustomerNetworkBlock    string `json:"customerNetworkBlock"`
+}
+
+// imdsHostMetadata contains the fields we care about from the OCI IMDS
+// host metadata response at /opc/v2/host/.
+type imdsHostMetadata struct {
+	NetworkBlockId   string                    `json:"networkBlockId"`
+	RackId           string                    `json:"rackId"`
+	RDMATopologyData *imdsHostRDMATopologyData `json:"rdmaTopologyData"`
 }
 
 var _ cloudprovider.CloudInstance = (*OKEInstance)(nil)
+var _ cloudprovider.NonUplinkChecker = (*OKEInstance)(nil)
 
-// OKEInstance holds OCI/OKE specific instance data.
+// OKEInstance holds OCI/OKE specific instance topology data.
 type OKEInstance struct {
-	Shape              string
-	FaultDomain        string
-	AvailabilityDomain string
+	HPCIslandId    string
+	NetworkBlockId string
+	LocalBlockId   string
+	RackId         string
+	// GpuMemoryFabric is only populated on shapes that use a GPU memory fabric
+	// interconnect (e.g. BM.GPU.GB200, BM.GPU.GB300). It will be empty on all
+	// other shapes such as BM.GPU.H100.8.
+	GpuMemoryFabric string
 }
 
-// GetDeviceAttributes returns OKE-specific attributes for a device.
-// These are node-level attributes applied to all devices since OCI IMDS
-// does not expose per-RDMA-NIC metadata.
+// GetDeviceAttributes returns OKE-specific topology attributes for a device.
+// These are node-level attributes applied to all devices since the OCI IMDS
+// host endpoint exposes per-node topology, not per-NIC metadata.
 func (o *OKEInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 
-	if o.Shape != "" {
-		attributes[AttrOKEShape] = resourceapi.DeviceAttribute{StringValue: &o.Shape}
+	if o.HPCIslandId != "" {
+		attributes[AttrOKEHPCIslandId] = resourceapi.DeviceAttribute{StringValue: &o.HPCIslandId}
 	}
-	if o.FaultDomain != "" {
-		attributes[AttrOKEFaultDomain] = resourceapi.DeviceAttribute{StringValue: &o.FaultDomain}
+	if o.NetworkBlockId != "" {
+		attributes[AttrOKENetworkBlockId] = resourceapi.DeviceAttribute{StringValue: &o.NetworkBlockId}
 	}
-	if o.AvailabilityDomain != "" {
-		attributes[AttrOKEAvailabilityDomain] = resourceapi.DeviceAttribute{StringValue: &o.AvailabilityDomain}
+	if o.LocalBlockId != "" {
+		attributes[AttrOKELocalBlockId] = resourceapi.DeviceAttribute{StringValue: &o.LocalBlockId}
+	}
+	if o.RackId != "" {
+		attributes[AttrOKERackId] = resourceapi.DeviceAttribute{StringValue: &o.RackId}
+	}
+	if o.GpuMemoryFabric != "" {
+		attributes[AttrOKEGpuMemoryFabric] = resourceapi.DeviceAttribute{StringValue: &o.GpuMemoryFabric}
 	}
 
 	return attributes
 }
 
-// GetDeviceConfig returns nil as OCI does not provide device-specific
-// network configuration through IMDS.
+// ocidSuffix returns the unique identifier suffix of an OCI OCID — the segment
+// after the last '.'. DRA string attributes are capped at 64 bytes, but full
+// OCIDs are ~90+ characters; the suffix is always 60 characters and is unique
+// per resource within a tenancy, making it safe to use as an attribute value.
+func ocidSuffix(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	if !strings.Contains(s, "ocid") {
+		return "", fmt.Errorf("not a valid OCID (missing 'ocid' prefix): %q", s)
+	}
+	i := strings.LastIndex(s, ".")
+	if i < 0 {
+		return "", fmt.Errorf("not a valid OCID (missing '.' separator): %q", s)
+	}
+	suffix := s[i+1:]
+	if len(suffix) > 60 {
+		suffix = suffix[len(suffix)-60:]
+	}
+	return suffix, nil
+}
+
+// GetDeviceConfig returns OKE-specific per-device network configuration.
+// On OKE GPU RDMA shapes (BM.GPU.GB200, BM.GPU.GB300, …), RDMA NICs receive a
+// globally-routable IPv6 address via Router Advertisement. That address is required
+// to populate a routable RoCEv2 GID (GID index ≥ 2) in the pod namespace.
+// EnableIPv6 signals dranet to override the pod-level disable_ipv6=1 sysctl for
+// this specific interface so the RA-assigned global address can be applied.
 func (o *OKEInstance) GetDeviceConfig(id cloudprovider.DeviceIdentifiers) *apis.NetworkConfig {
+	if o.GpuMemoryFabric != "" && id.RDMA {
+		enableIPv6 := true
+		return &apis.NetworkConfig{
+			Interface: apis.InterfaceConfig{
+				EnableIPv6: &enableIPv6,
+			},
+		}
+	}
 	return nil
+}
+
+// IsNonUplink returns true for RDMA-capable devices on OKE GPU RDMA shapes
+// (BM.GPU.GB200, BM.GPU.GB300, …). On these shapes OCI's Router Advertisement
+// daemon injects an IPv6 default route into the main routing table for every
+// RDMA interface as an infrastructure side-effect. Those interfaces are
+// workload NICs, not transit uplinks — without this override the default
+// gateway filter would remove them from the ResourceSlice entirely.
+func (o *OKEInstance) IsNonUplink(id cloudprovider.DeviceIdentifiers) bool {
+	return o.GpuMemoryFabric != "" && id.RDMA
 }
 
 // OnOKE returns true if running on an Oracle Cloud Infrastructure instance.
@@ -106,48 +177,80 @@ func OnOKE(ctx context.Context) bool {
 	}) == nil
 }
 
-// GetInstance retrieves OCI instance properties by querying the IMDS.
+// GetInstance retrieves OCI instance topology by querying the IMDS host endpoint.
+// Returns an error if the host endpoint is unreachable or if RDMA topology data
+// is not present, which indicates that TopologyData is not enabled for the tenancy.
 func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
 	var instance *OKEInstance
 	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imdsEndpoint+"/instance/", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imdsEndpoint+"/host/", nil)
 		if err != nil {
-			klog.Infof("could not create OCI IMDS request ... retrying: %v", err)
+			klog.Infof("could not create OCI IMDS host request ... retrying: %v", err)
 			return false, nil
 		}
 		req.Header.Set("Authorization", "Bearer Oracle")
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			klog.Infof("could not reach OCI IMDS ... retrying: %v", err)
+			klog.Infof("could not reach OCI IMDS host endpoint ... retrying: %v", err)
 			return false, nil
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			klog.Infof("OCI IMDS returned status %d ... retrying", resp.StatusCode)
+			klog.Infof("OCI IMDS host endpoint returned status %d ... retrying", resp.StatusCode)
 			return false, nil
 		}
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			klog.Infof("could not read OCI IMDS response ... retrying: %v", err)
+			klog.Infof("could not read OCI IMDS host response ... retrying: %v", err)
 			return false, nil
 		}
 
-		var metadata imdsInstanceMetadata
+		var metadata imdsHostMetadata
 		if err := json.Unmarshal(body, &metadata); err != nil {
-			return false, fmt.Errorf("could not parse OCI IMDS response: %w", err)
+			return false, fmt.Errorf("could not parse OCI IMDS host response: %w", err)
+		}
+
+		// rdmaTopologyData is absent on non-RDMA shapes. Proceed with an empty
+		// instance so non-RDMA nodes get no topology attributes rather than an error.
+		topo := metadata.RDMATopologyData
+		if topo == nil {
+			instance = &OKEInstance{}
+			return true, nil
+		}
+
+		hpcIslandId, err := ocidSuffix(topo.CustomerHPCIslandId)
+		if err != nil {
+			return false, fmt.Errorf("invalid HPCIslandId: %w", err)
+		}
+		networkBlockId, err := ocidSuffix(topo.CustomerNetworkBlock)
+		if err != nil {
+			return false, fmt.Errorf("invalid NetworkBlockId: %w", err)
+		}
+		localBlockId, err := ocidSuffix(topo.CustomerLocalBlock)
+		if err != nil {
+			return false, fmt.Errorf("invalid LocalBlockId: %w", err)
+		}
+		gpuMemoryFabric, err := ocidSuffix(topo.CustomerGpuMemoryFabric)
+		if err != nil {
+			return false, fmt.Errorf("invalid GpuMemoryFabric: %w", err)
 		}
 
 		instance = &OKEInstance{
-			Shape:              metadata.Shape,
-			FaultDomain:        metadata.FaultDomain,
-			AvailabilityDomain: metadata.AvailabilityDomain,
+			HPCIslandId:     hpcIslandId,
+			NetworkBlockId:  networkBlockId,
+			LocalBlockId:    localBlockId,
+			RackId:          metadata.RackId,
+			GpuMemoryFabric: gpuMemoryFabric,
 		}
 		return true, nil
 	})
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("please enable TopologyData for your tenancy: %w", err)
+		}
 		return nil, err
 	}
 	return instance, nil

--- a/pkg/cloudprovider/oke/oke_test.go
+++ b/pkg/cloudprovider/oke/oke_test.go
@@ -35,47 +35,65 @@ func TestGetDeviceAttributes(t *testing.T) {
 		want     map[resourceapi.QualifiedName]resourceapi.DeviceAttribute
 	}{
 		{
-			name: "instance with all metadata",
+			// OKEInstance stores the already-extracted OCID suffix (see ocidSuffix),
+			// so test values here are the short unique identifiers, not full OCIDs.
+			name: "full topology with gpu memory fabric (GB200/GB300 shapes)",
 			instance: &OKEInstance{
-				Shape:              "BM.GPU.H100.8",
-				FaultDomain:        "FAULT-DOMAIN-1",
-				AvailabilityDomain: "TrcQ:US-ASHBURN-AD-2",
+				HPCIslandId:     "fake-island-id",
+				NetworkBlockId:  "fake-network-block-id",
+				LocalBlockId:    "fake-local-block-id",
+				RackId:          "fake-rack-id",
+				GpuMemoryFabric: "fake-gpu-memory-fabric-id",
 			},
 			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
 			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttrOKEShape:              {StringValue: ptr.To("BM.GPU.H100.8")},
-				AttrOKEFaultDomain:        {StringValue: ptr.To("FAULT-DOMAIN-1")},
-				AttrOKEAvailabilityDomain: {StringValue: ptr.To("TrcQ:US-ASHBURN-AD-2")},
+				AttrOKEHPCIslandId:     {StringValue: ptr.To("fake-island-id")},
+				AttrOKENetworkBlockId:  {StringValue: ptr.To("fake-network-block-id")},
+				AttrOKELocalBlockId:    {StringValue: ptr.To("fake-local-block-id")},
+				AttrOKERackId:          {StringValue: ptr.To("fake-rack-id")},
+				AttrOKEGpuMemoryFabric: {StringValue: ptr.To("fake-gpu-memory-fabric-id")},
 			},
 		},
 		{
-			name: "instance with only shape",
+			name: "full topology without gpu memory fabric (H100 and older shapes)",
 			instance: &OKEInstance{
-				Shape:              "VM.Standard.E3.Flex",
-				FaultDomain:        "",
-				AvailabilityDomain: "",
+				HPCIslandId:    "fake-island-id",
+				NetworkBlockId: "fake-network-block-id",
+				LocalBlockId:   "fake-local-block-id",
+				RackId:         "fake-rack-id",
 			},
 			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
 			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttrOKEShape: {StringValue: ptr.To("VM.Standard.E3.Flex")},
+				AttrOKEHPCIslandId:    {StringValue: ptr.To("fake-island-id")},
+				AttrOKENetworkBlockId: {StringValue: ptr.To("fake-network-block-id")},
+				AttrOKELocalBlockId:   {StringValue: ptr.To("fake-local-block-id")},
+				AttrOKERackId:         {StringValue: ptr.To("fake-rack-id")},
 			},
 		},
 		{
-			name: "instance with no metadata",
+			name: "partial topology (only hpcIslandId and networkBlockId)",
 			instance: &OKEInstance{
-				Shape:              "",
-				FaultDomain:        "",
-				AvailabilityDomain: "",
+				HPCIslandId:    "fake-island-id",
+				NetworkBlockId: "fake-network-block-id",
 			},
-			id:   cloudprovider.DeviceIdentifiers{Name: "dev1"},
-			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
+			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttrOKEHPCIslandId:    {StringValue: ptr.To("fake-island-id")},
+				AttrOKENetworkBlockId: {StringValue: ptr.To("fake-network-block-id")},
+			},
+		},
+		{
+			name:     "no topology data",
+			instance: &OKEInstance{},
+			id:       cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want:     map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
 		},
 		{
 			name: "attributes are node-level, same for any device identifier",
 			instance: &OKEInstance{
-				Shape:              "BM.GPU.H100.8",
-				FaultDomain:        "FAULT-DOMAIN-3",
-				AvailabilityDomain: "TrcQ:US-ASHBURN-AD-2",
+				HPCIslandId:    "fake-island-id",
+				NetworkBlockId: "fake-network-block-id",
+				RackId:         "fake-rack-id",
 			},
 			id: cloudprovider.DeviceIdentifiers{
 				Name:       "pci-0000-0c-00-0",
@@ -83,9 +101,9 @@ func TestGetDeviceAttributes(t *testing.T) {
 				PCIAddress: "0000:0c:00.0",
 			},
 			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttrOKEShape:              {StringValue: ptr.To("BM.GPU.H100.8")},
-				AttrOKEFaultDomain:        {StringValue: ptr.To("FAULT-DOMAIN-3")},
-				AttrOKEAvailabilityDomain: {StringValue: ptr.To("TrcQ:US-ASHBURN-AD-2")},
+				AttrOKEHPCIslandId:    {StringValue: ptr.To("fake-island-id")},
+				AttrOKENetworkBlockId: {StringValue: ptr.To("fake-network-block-id")},
+				AttrOKERackId:         {StringValue: ptr.To("fake-rack-id")},
 			},
 		},
 	}
@@ -100,14 +118,117 @@ func TestGetDeviceAttributes(t *testing.T) {
 	}
 }
 
-func TestGetDeviceConfig(t *testing.T) {
-	instance := &OKEInstance{
-		Shape:              "BM.GPU.H100.8",
-		FaultDomain:        "FAULT-DOMAIN-1",
-		AvailabilityDomain: "TrcQ:US-ASHBURN-AD-2",
+func TestOCIDSuffix(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "valid OCID extracts 60-char suffix",
+			input: "ocid1.hpcisland.oc1.test-region-1.aaaaaaaa2mvjha24vj6evyafdqtis6nzqibhrnxxhzt65zkc3upy4xlrz5za",
+			want:  "aaaaaaaa2mvjha24vj6evyafdqtis6nzqibhrnxxhzt65zkc3upy4xlrz5za",
+		},
+		{
+			name:  "OCID with suffix longer than 60 chars is truncated to last 60",
+			input: "ocid1.hpcisland.oc1.test-region-1.xaaaaaaaa2mvjha24vj6evyafdqtis6nzqibhrnxxhzt65zkc3upy4xlrz5za",
+			want:  "aaaaaaaa2mvjha24vj6evyafdqtis6nzqibhrnxxhzt65zkc3upy4xlrz5za",
+		},
+		{
+			name:    "non-OCID string without 'ocid' returns error",
+			input:   "fakehexhash",
+			wantErr: true,
+		},
+		{
+			name:  "empty string returns empty (field not present on shape)",
+			input: "",
+			want:  "",
+		},
+		{
+			name:    "non-OCID dotted string returns error",
+			input:   "some.dotted.value",
+			wantErr: true,
+		},
+		{
+			name:    "OCID without dot separator returns error",
+			input:   "ocid1-hpcisland-no-dots",
+			wantErr: true,
+		},
 	}
-	got := instance.GetDeviceConfig(cloudprovider.DeviceIdentifiers{Name: "dev1"})
-	if got != nil {
-		t.Errorf("GetDeviceConfig() = %v, want nil", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ocidSuffix(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ocidSuffix(%q) = %q, want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ocidSuffix(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ocidSuffix(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDeviceConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *OKEInstance
+		id       cloudprovider.DeviceIdentifiers
+		wantNil  bool
+		wantIPv6 *bool
+	}{
+		{
+			name: "non-GPU-fabric shape returns nil config",
+			instance: &OKEInstance{
+				HPCIslandId:    "fake-island-id",
+				NetworkBlockId: "fake-network-block-id",
+				RackId:         "fake-rack-id",
+			},
+			id:      cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			wantNil: true,
+		},
+		{
+			name: "GPU fabric shape with non-RDMA device returns nil config",
+			instance: &OKEInstance{
+				HPCIslandId:     "fake-island-id",
+				GpuMemoryFabric: "fake-gpu-memory-fabric-id",
+			},
+			id:      cloudprovider.DeviceIdentifiers{Name: "dev1", RDMA: false},
+			wantNil: true,
+		},
+		{
+			name: "GPU fabric shape with RDMA device returns EnableIPv6",
+			instance: &OKEInstance{
+				HPCIslandId:     "fake-island-id",
+				GpuMemoryFabric: "fake-gpu-memory-fabric-id",
+			},
+			id:       cloudprovider.DeviceIdentifiers{Name: "rdma0", RDMA: true},
+			wantNil:  false,
+			wantIPv6: ptr.To(true),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.instance.GetDeviceConfig(tt.id)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("GetDeviceConfig() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("GetDeviceConfig() = nil, want non-nil")
+			}
+			if diff := cmp.Diff(tt.wantIPv6, got.Interface.EnableIPv6); diff != "" {
+				t.Errorf("GetDeviceConfig().Interface.EnableIPv6 mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -563,9 +563,16 @@ func getRouteInfo(nlHandle nlwrap.Handle, ifName string, link netlink.Link) ([]a
 				klog.V(5).Infof("Skipping IPv6 link-local route %s for interface %s", route.String(), ifName)
 				continue
 			}
-			// Discard IPv6 proto=kernel routes
+			// Discard IPv6 proto=kernel routes (auto-generated connected routes).
 			if route.Protocol == unix.RTPROT_KERNEL {
 				klog.V(5).Infof("Skipping IPv6 proto=kernel route %s for interface %s", route.String(), ifName)
+				continue
+			}
+			// Discard IPv6 RA-assigned routes. These are injected by the cloud
+			// provider's RA daemon as an infrastructure side-effect (e.g. OCI on
+			// RDMA NICs) and must not be propagated into pod namespaces.
+			if route.Protocol == unix.RTPROT_RA {
+				klog.V(5).Infof("Skipping IPv6 RA route %s for interface %s", route.String(), ifName)
 				continue
 			}
 		}

--- a/pkg/driver/hostdevice.go
+++ b/pkg/driver/hostdevice.go
@@ -150,6 +150,13 @@ func nsAttachNetdev(hostIfName string, containerNsPAth string, interfaceConfig a
 		}
 		err = nhNs.AddrAdd(nsLink, &netlink.Addr{IPNet: &net.IPNet{IP: ip, Mask: ipnet.Mask}})
 		if err != nil {
+			// IPv6 may be disabled in the pod namespace (single-stack IPv4 clusters set
+			// net.ipv6.conf.all.disable_ipv6=1). Soft-fail so that the caller can enable
+			// IPv6 per-interface and re-apply the address after moving the device.
+			if ip.To4() == nil && (errors.Is(err, unix.EACCES) || errors.Is(err, unix.EPERM)) {
+				klog.V(4).Infof("skipping IPv6 address %s on %s in namespace %s: IPv6 is disabled (will retry after per-interface enable)", address, nsLink.Attrs().Name, containerNsPAth)
+				continue
+			}
 			return nil, fmt.Errorf("failed to set up address %s on namespace %s: %w", address, containerNsPAth, err)
 		}
 		networkData.IPs = append(networkData.IPs, address)

--- a/pkg/driver/netnamespace.go
+++ b/pkg/driver/netnamespace.go
@@ -94,6 +94,13 @@ func applyRoutingConfig(containerNsPAth string, ifName string, routeConfig []api
 			r.Src = net.ParseIP(route.Source)
 		}
 		if err := nhNs.RouteAdd(&r); err != nil && !errors.Is(err, syscall.EEXIST) {
+			// Soft-fail EACCES/EPERM for IPv6 routes: these occur when IPv6 is disabled
+			// in the pod namespace (single-stack IPv4 clusters). The caller is responsible
+			// for enabling IPv6 per-interface and re-applying routes if needed.
+			if dst != nil && dst.IP.To4() == nil && (errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.EPERM)) {
+				klog.V(4).Infof("skipping IPv6 route %s for interface %s on namespace %s: IPv6 is disabled", r.String(), ifName, containerNsPAth)
+				continue
+			}
 			errorList = append(errorList, fmt.Errorf("fail to add route %s for interface %s on namespace %s: %w", r.String(), ifName, containerNsPAth, err))
 		}
 
@@ -298,6 +305,77 @@ func applyVRFConfig(containerNsPath string, ifName string, vrfConfig *apis.VRFCo
 	}
 
 	return int(vrfTable), nil
+}
+
+// enableIPv6ForInterface sets net.ipv6.conf.<ifname>.disable_ipv6=0 inside the
+// pod network namespace, enabling IPv6 on that specific interface even when the
+// pod-level net.ipv6.conf.all.disable_ipv6=1 is set by the container runtime.
+// This is needed for RDMA NICs on platforms such as OKE that require a globally-
+// routable IPv6 address to populate a routable RoCEv2 GID.
+func enableIPv6ForInterface(containerNsPath, ifName string) error {
+	containerNs, err := netns.GetFromPath(containerNsPath)
+	if err != nil {
+		return fmt.Errorf("could not get network namespace from path %s: %w", containerNsPath, err)
+	}
+	defer containerNs.Close()
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	origNs, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("failed to get current network namespace: %w", err)
+	}
+	defer origNs.Close() //nolint:errcheck
+
+	if err := netns.Set(containerNs); err != nil {
+		return fmt.Errorf("failed to enter namespace %s: %w", containerNsPath, err)
+	}
+	defer netns.Set(origNs) //nolint:errcheck
+
+	sysctlInterface := sysctl.New()
+	sysctlKey := fmt.Sprintf("net/ipv6/conf/%s/disable_ipv6", ifName)
+	if err := sysctlInterface.SetSysctl(sysctlKey, 0); err != nil {
+		return fmt.Errorf("failed to set %s: %w", sysctlKey, err)
+	}
+	return nil
+}
+
+// reapplyIPv6Addresses adds any IPv6 addresses from the list to the named interface
+// inside the pod namespace. Used after enableIPv6ForInterface to apply addresses
+// that were skipped by nsAttachNetdev when IPv6 was still disabled.
+func reapplyIPv6Addresses(containerNsPath, ifName string, addresses []string) error {
+	containerNs, err := netns.GetFromPath(containerNsPath)
+	if err != nil {
+		return fmt.Errorf("could not get network namespace from path %s: %w", containerNsPath, err)
+	}
+	defer containerNs.Close()
+
+	nhNs, err := nlwrap.NewHandleAt(containerNs)
+	if err != nil {
+		return fmt.Errorf("could not get netlink handle: %w", err)
+	}
+	defer nhNs.Close()
+
+	nsLink, err := nhNs.LinkByName(ifName)
+	if err != nil {
+		return fmt.Errorf("link not found for interface %s on namespace %s: %w", ifName, containerNsPath, err)
+	}
+
+	var errorList []error
+	for _, address := range addresses {
+		ip, ipnet, err := net.ParseCIDR(address)
+		if err != nil {
+			continue
+		}
+		if ip.To4() != nil {
+			continue // only re-apply IPv6 addresses
+		}
+		if err := nhNs.AddrAdd(nsLink, &netlink.Addr{IPNet: &net.IPNet{IP: ip, Mask: ipnet.Mask}}); err != nil && !errors.Is(err, syscall.EEXIST) {
+			errorList = append(errorList, fmt.Errorf("failed to add IPv6 address %s on %s in namespace %s: %w", address, ifName, containerNsPath, err))
+		}
+	}
+	return errors.Join(errorList...)
 }
 
 func enableVRFSysctls(containerNsFd int) error {

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -275,6 +275,20 @@ func attachNetdevToNS(pod *api.PodSandbox, ns, deviceName string, config DeviceC
 	// The interface name inside the container's namespace.
 	ifNameInNs := networkData.InterfaceName
 
+	// If EnableIPv6 is set, enable IPv6 per-interface and re-apply any IPv6 addresses
+	// that were skipped in nsAttachNetdev because IPv6 was globally disabled in the pod
+	// namespace. This is needed on platforms such as OKE where RDMA NICs require a
+	// globally-routable IPv6 address to populate a routable RoCEv2 GID.
+	if config.NetworkInterfaceConfigInPod.Interface.EnableIPv6 != nil &&
+		*config.NetworkInterfaceConfigInPod.Interface.EnableIPv6 {
+		if err := enableIPv6ForInterface(ns, ifNameInNs); err != nil {
+			return fmt.Errorf("failed to enable IPv6 for %s in namespace %s: %w", ifNameInNs, ns, err)
+		}
+		if err := reapplyIPv6Addresses(ns, ifNameInNs, config.NetworkInterfaceConfigInPod.Interface.Addresses); err != nil {
+			return fmt.Errorf("failed to re-apply IPv6 addresses for %s in namespace %s: %w", ifNameInNs, ns, err)
+		}
+	}
+
 	// Apply Ethtool configurations
 	if config.NetworkInterfaceConfigInPod.Ethtool != nil {
 		err = applyEthtoolConfig(ns, ifNameInNs, config.NetworkInterfaceConfigInPod.Ethtool)

--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -229,10 +229,28 @@ func (db *DB) scan() []resourceapi.Device {
 	devices = db.addCloudAttributes(devices)
 
 	// Remove default interface.
+	checker, hasChecker := db.instance.(cloudprovider.NonUplinkChecker)
 	filteredDevices := []resourceapi.Device{}
 	for _, device := range devices {
 		ifName := device.Attributes[apis.AttrInterfaceName].StringValue
 		if ifName != nil && db.gwInterfaces.Has(string(*ifName)) {
+			if hasChecker {
+				id := cloudprovider.DeviceIdentifiers{Name: device.Name}
+				if macAttr, ok := device.Attributes[apis.AttrMac]; ok && macAttr.StringValue != nil {
+					id.MAC = *macAttr.StringValue
+				}
+				if pciAttr, ok := device.Attributes[apis.AttrPCIAddress]; ok && pciAttr.StringValue != nil {
+					id.PCIAddress = *pciAttr.StringValue
+				}
+				if rdmaAttr, ok := device.Attributes[apis.AttrRDMA]; ok && rdmaAttr.BoolValue != nil {
+					id.RDMA = *rdmaAttr.BoolValue
+				}
+				if checker.IsNonUplink(id) {
+					klog.V(4).Infof("Interface %s has a default gateway route but is classified as a non-uplink by the cloud provider; including in discovery", *ifName)
+					filteredDevices = append(filteredDevices, device)
+					continue
+				}
+			}
 			klog.V(4).Infof("Ignoring interface %s from discovery since it is an uplink interface", *ifName)
 			continue
 		}
@@ -498,6 +516,9 @@ func (db *DB) updateDeviceStore(devices []resourceapi.Device) {
 			}
 			if pciAttr, ok := device.Attributes[apis.AttrPCIAddress]; ok && pciAttr.StringValue != nil {
 				id.PCIAddress = *pciAttr.StringValue
+			}
+			if rdmaAttr, ok := device.Attributes[apis.AttrRDMA]; ok && rdmaAttr.BoolValue != nil {
+				id.RDMA = *rdmaAttr.BoolValue
 			}
 
 			if conf := db.instance.GetDeviceConfig(id); conf != nil {


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Joint PR (happy to split up, just wanted to get eyes on it and work with you all to do so).

1. **OKE IMDS topology data** - (HPC island, network block, local block, rack, GPU memory fabric) is exposed as device attributes for topology-aware scheduling.
2. **OKE Example GB200** - adds an example doc for GB200 with performance numbers and importance of aligned NIC selection
3. **OCI's RA daemon injects IPv6 default routes** - onto every RDMA NIC, causing them to be misclassified as uplink interfaces and filtered from discovery. A new `NonUplinkChecker` interface allows the OKE provider to override this for RDMA devices on GPU fabric shapes.
4. **Pod namespaces have IPv6 disabled** (`net.ipv6.conf.all.disable_ipv6=1`), but RoCEv2 on OKE requires a globally-routable IPv6 address on RDMA interfaces to populate a routable GID (GID index >= 2). A new `EnableIPv6` field on `InterfaceConfig` triggers per-interface IPv6 enablement in the pod namespace via sysctl override, followed by re-application of the IPv6 address.

#### Which issue(s) this PR is related to:

#111 - doesn't close

#### Special notes for your reviewer:

**Note**: Again, happy to split this up, but did want to get it out to start the process if needed. dranet on OKE won't work for all GPU SKUs without this.

##### Why OKE needs these changes but AKS and GCE do not

The IPv6 and uplink-filtering changes are driven by OKE's bare-metal
infrastructure model, which differs fundamentally from how AKS and GCE expose
RDMA networking:

**AKS (Azure):** GB300 nodes use InfiniBand VFs, not RoCEv2. IB GIDs are derived
from the port GUID (a hardware identifier burned into the HCA), not from IP
addresses. There is no dependency on IPv6 addressing for GID generation --
`ibv_modify_qp` resolves paths using GUID-based GIDs and the IB subnet manager.
Because IB VFs have no Ethernet netdev, there is no RA daemon, no IPv6 address,
and no default-route side-effect to filter around. The dranet IB-only path
(char-device injection without netdev movement) handles this cleanly.

**GCE (Google Cloud):** GPU nodes use SR-IOV VFs for RDMA. The VFs are presented
as standard Ethernet NICs with IPv4 addresses managed by the GCE metadata
service. There is no RA daemon injecting IPv6 routes, and GIDs (when RoCEv2 is
used) are populated from the IPv4 address. The pod namespace does not need IPv6
enabled because the GID is IPv4-derived.

**OKE (Oracle Cloud) -- why it is different:** BM.GPU.GB200-v3.4 are bare-metal
shapes. The 8 ConnectX-8 NICs are full physical functions (PFs), not SR-IOV VFs.
OCI manages the RDMA fabric at the infrastructure level by running an RA
(Router Advertisement) daemon on the host that:

1. Assigns a globally-routable IPv6 address to each RDMA NIC (e.g.
   `fdcd:0:2a29:3032:364e:3a64:6758:428a/64`). This address populates a RoCEv2
   GID at index >= 2 in the NIC's GID table. The OCI fabric routes traffic using
   these IPv6-derived GIDs -- link-local GIDs (`fe80::`) are not routable
   (`ENETUNREACH` on `ibv_modify_qp`).

2. Injects an IPv6 default route via RA (`proto ra`) into the main routing table
   for every RDMA NIC. This is an infrastructure side-effect, not a signal that
   the NIC is an uplink/transit interface. Without the `NonUplinkChecker`
   override, dranet's gateway-interface filter removes these NICs from the
   ResourceSlice entirely.

The IPv6 problem compounds because Kubernetes single-stack IPv4 clusters (the
default on OKE) configure `net.ipv6.conf.all.disable_ipv6=1` in pod network
namespaces. When dranet moves the RDMA NIC into the pod namespace and attempts
to apply the RA-assigned IPv6 address, the kernel returns EACCES. Without the
address, the NIC has no routable GID and NCCL falls back to TCP or fails with
ENETUNREACH.

The `EnableIPv6` mechanism solves this with a per-interface sysctl override
(`net.ipv6.conf.<ifname>.disable_ipv6=0`) that enables IPv6 on just the RDMA
NIC without affecting the pod's primary network interface. This is safe because
the RDMA NIC is isolated in the pod namespace and the IPv6 address is only used
for GID generation, not for IP-level routing.

None of this applies to AKS (IB, GUID-based GIDs, no netdev) or GCE (VFs,
IPv4-based GIDs, no RA daemon).

##### Architecture context

On GB200, GPUs connect to the Grace CPU via NVLink C2C while NICs connect via
PCIe. `nvidia-smi topo -m` reports SYS for all GPU-NIC pairs. Despite this,
NCCL enables GDR for NUMA-local NICs via `NCCL_NET_GDR_C2C=1`. The meaningful
topology distinction is same-NUMA vs cross-NUMA, not PCIe host bridge alignment.

##### IPv6 flow

The `EnableIPv6` mechanism is intentionally outside `nsAttachNetdev` to keep
that function general-purpose. The sequence is:

1. `nsAttachNetdev` moves NIC to pod namespace, soft-fails IPv6 address (EACCES)
2. `attachNetdevToNS` enables IPv6 per-interface sysctl, re-applies IPv6 address
3. RDMA device generates routable GID from the applied IPv6 address

##### Known issue -- NIC orphaning - #137 

RDMA NICs are not reliably returned to the host namespace on pod deletion. This
is a pre-existing CRI-O / dranet bug (not introduced here). The example README documents
the PCI rebind recovery procedure.

##### Benchmark results

2-node `all_reduce_perf`, 1 GPU/worker, BM.GPU.GB200-v3.4:

| Template | NIC(s) | NUMA | Channels | GDR | Avg busbw |
|---|---|---|---|---|---|
| `1nic-aligned` | rdma3 (NUMA 0) | same | 4 | yes | ~46 GB/s |
| `2nic-aligned` | rdma2+rdma3 (NUMA 0) | same | 8 | yes | ~96 GB/s |
| `1nic-unaligned` | rdma4 (NUMA 1) | cross | 2 | no | ~25 GB/s |

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add OKE cloud provider support for BM.GPU.GB200 RoCEv2 RDMA networking. dranet
now correctly discovers RDMA NICs on OKE GPU shapes (despite RA-injected default
routes), enables per-interface IPv6 in pod namespaces for routable RoCEv2 GID
generation, and exposes OCI RDMA topology attributes (HPC island, network block,
local block, rack, GPU memory fabric) for topology-aware scheduling.
```