### PR TITLE
Makefile: skip helm push when not on a git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ image-push: ensure-buildx
 		--push
 
 helm-package:
-	@test -n "$(CHART_VERSION)" || (echo "ERROR: not on an exact git tag, cannot package helm chart"; exit 1)
+	@test -n "$(HELM_TAG)" || (echo "ERROR: not on an exact git tag, cannot package helm chart"; exit 1)
 	helm package deployments/helm/dranet \
 		--version "$(CHART_VERSION)" \
 		--app-version "$(HELM_TAG)" \
@@ -115,5 +115,12 @@ kind-image: image-build
 	kubectl delete -f install.yaml || true
 	kubectl apply -f install.yaml
 
-# The main release target, which pushes all images and helm charts
-release: ensure-helm image-push helm-push
+# The main release target, which pushes all images and helm charts.
+# Helm chart packaging and push is skipped when not on an exact git tag.
+release: image-push
+	@if [ -n "$(HELM_TAG)" ]; then \
+		echo "On tag $(HELM_TAG), packaging and pushing helm chart..."; \
+		$(MAKE) ensure-helm helm-push; \
+	else \
+		echo "Not on a tag, skipping helm chart push"; \
+	fi


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
The `release` Makefile target previously always ran `helm-package` and `helm-push`, causing postsubmit CI failures on non-tag commits. Now helm steps are conditionally skipped when `HELM_TAG` is not set

#### Which issue(s) this PR is related to:
Fixes: https://github.com/kubernetes-sigs/dranet/issues/140
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```