### PR TITLE
feat: Update oke topology to match customer tenancy data, add example

### DIFF
--- a/examples/oke-bm-gpu-h100-rocev2-dranet/README.md
+++ b/examples/oke-bm-gpu-h100-rocev2-dranet/README.md
@@ -1,0 +1,164 @@
+# OKE BM.GPU.H100.8 RoCEv2 dranet Demo
+
+End-to-end demo of topology-aware GPU + RoCEv2 NIC allocation using
+[Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+on Oracle Kubernetes Engine (OKE) with [BM.GPU.H100.8](https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm#bm-gpu) shapes.
+
+## Context
+
+### Shape: BM.GPU.H100.8
+
+Each node has:
+
+| Resource | Count | Detail |
+|---|---|---|
+| GPU | 8 x NVIDIA H100 | 80 GB HBM3, Hopper architecture, NVLink/NVSwitch all-to-all |
+| NIC | 16 x Mellanox ConnectX-7 (8 dual-port cards) | 400 Gb/s RoCEv2 per port |
+| NUMA nodes | 2 | 4 GPUs + 8 NICs per NUMA node |
+
+### NIC layout
+
+| Device | ifName | PCI Address |
+|---|---|---|
+| pci-0000-0c-00-0 | rdma0 | 0000:0c:00.0 |
+| pci-0000-0c-00-1 | rdma1 | 0000:0c:00.1 |
+| pci-0000-2a-00-0 | rdma2 | 0000:2a:00.0 |
+| pci-0000-2a-00-1 | rdma3 | 0000:2a:00.1 |
+| pci-0000-41-00-0 | rdma4 | 0000:41:00.0 |
+| pci-0000-41-00-1 | rdma5 | 0000:41:00.1 |
+| pci-0000-58-00-0 | rdma6 | 0000:58:00.0 |
+| pci-0000-58-00-1 | rdma7 | 0000:58:00.1 |
+| pci-0000-86-00-0 | rdma8 | 0000:86:00.0 |
+| pci-0000-86-00-1 | rdma9 | 0000:86:00.1 |
+| pci-0000-a5-00-0 | rdma10 | 0000:a5:00.0 |
+| pci-0000-a5-00-1 | rdma11 | 0000:a5:00.1 |
+| pci-0000-bd-00-0 | rdma12 | 0000:bd:00.0 |
+| pci-0000-bd-00-1 | rdma13 | 0000:bd:00.1 |
+| pci-0000-d5-00-0 | rdma14 | 0000:d5:00.0 |
+| pci-0000-d5-00-1 | rdma15 | 0000:d5:00.1 |
+
+### OKE topology attributes (oke.dra.net)
+
+Each device carries node-level topology attributes sourced from the
+OCI Instance Metadata Service (`GET /opc/v2/host/`):
+
+| Attribute | Description |
+|---|---|
+| `oke.dra.net/hpcIslandId` | HPC Island -- largest topology grouping (~2000 nodes) |
+| `oke.dra.net/networkBlockId` | Network Block -- mid-level grouping (~64-128 nodes) |
+| `oke.dra.net/localBlockId` | Local Block -- closest grouping (~8-32 nodes) |
+| `oke.dra.net/rackId` | Physical rack identifier |
+
+> **Note:** The full set of topology attributes requires RDMA topology data to be
+> enabled for your OCI tenancy. When `rdmaTopologyData` is absent from IMDS, only
+> `networkBlockId` and `rackId` (from the top-level host metadata) are populated.
+> The `gpuMemoryFabricId` attribute is specific to GB200/GB300 shapes and is not
+> present on H100.
+
+## Prerequisites
+
+- Kubernetes 1.34+ with `DynamicResourceAllocation` enabled
+- [NVIDIA DRA GPU driver](https://github.com/NVIDIA/k8s-dra-driver) installed
+- [MPI Operator](https://github.com/kubeflow/mpi-operator) installed
+
+## Files
+
+| File | Description |
+|---|---|
+| `deviceclass.yaml` | `DeviceClass` for dranet NIC devices |
+| `resource-claim-template.yaml` | `ResourceClaimTemplate` for 1 GPU + 1 RDMA NIC |
+| `mpi-job.yaml` | `MPIJob` that runs `nccl_tests/all_reduce_perf` across 2 workers |
+
+## Installation
+
+### 1. Install dranet
+
+```bash
+helm install dranet ./deployments/helm/dranet \
+  --namespace kube-system \
+  --set image.repository=<your-registry>/dranet \
+  --set image.tag=<your-tag> \
+  --set image.pullPolicy=Always
+kubectl rollout status daemonset/dranet -n kube-system
+```
+
+### 2. Create the DeviceClass
+
+The `dra.net` DeviceClass is required for DRA to match NIC ResourceClaims
+against dranet's ResourceSlice devices.
+
+```bash
+kubectl apply -f deviceclass.yaml
+```
+
+### 3. Verify devices
+
+```bash
+# Verify dranet ResourceSlices are published
+kubectl get resourceslice -l driver=dra.net
+
+# Verify GPU ResourceSlices (from NVIDIA DRA driver)
+kubectl get resourceslice -l driver=gpu.nvidia.com
+
+# List RDMA NIC devices and their attributes
+kubectl get resourceslice -o json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for rs in data['items']:
+    if rs['spec'].get('driver') != 'dra.net': continue
+    node = rs['spec']['nodeName']
+    for d in rs['spec'].get('devices', []):
+        attrs = d.get('attributes', {})
+        ifname = attrs.get('dra.net/ifName', {}).get('string', '?')
+        pci = attrs.get('dra.net/pciAddress', {}).get('string', '?')
+        rdma = attrs.get('dra.net/rdma', {}).get('bool', False)
+        nb = attrs.get('oke.dra.net/networkBlockId', {}).get('string', '')
+        rack = attrs.get('oke.dra.net/rackId', {}).get('string', '')
+        if rdma and ifname.startswith('rdma'):
+            print(f'{node}: {d[\"name\"]}  ifName={ifname}  pci={pci}  networkBlock={nb[:20]}  rack={rack[:20]}')
+"
+```
+
+## Usage
+
+```bash
+# Install MPI Operator (if not already installed)
+kubectl apply --server-side -k "https://github.com/kubeflow/mpi-operator/manifests/overlays/standalone?ref=v0.7.0"
+
+# Apply DeviceClass and ResourceClaimTemplates
+kubectl apply -f deviceclass.yaml
+kubectl apply -f resource-claim-template.yaml
+
+# Launch the MPIJob
+kubectl apply -f mpi-job.yaml
+
+# Wait for workers then stream launcher logs
+kubectl wait --for=condition=ready pod \
+  -l training.kubeflow.org/job-name=nccl-test-dra,training.kubeflow.org/job-role=worker \
+  --timeout=300s
+launcher=$(kubectl get pods \
+  -l training.kubeflow.org/job-name=nccl-test-dra,training.kubeflow.org/job-role=launcher \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -f "${launcher}"
+```
+
+## Recovering orphaned RDMA NICs
+
+When a pod is deleted, dranet may not return the RDMA NIC from the pod namespace
+to the host namespace (see [#137](https://github.com/kubernetes-sigs/dranet/issues/137)).
+
+**Symptoms:** Workers stuck in `Pending` with `cannot allocate all claims`.
+
+**Recover via PCI rebind** (requires a privileged debug pod on each GPU node):
+
+```bash
+kubectl debug node/<node-name> --image=busybox -it -- sh
+chroot /host
+# Replace with the actual PCI address of the orphaned NIC
+echo "0000:0c:00.0" > /sys/bus/pci/drivers/mlx5_core/unbind
+sleep 2
+echo "0000:0c:00.0" > /sys/bus/pci/drivers/mlx5_core/bind
+```
+
+Wait ~15 seconds for dranet to rescan, then verify the NIC reappears in the
+ResourceSlice.

--- a/examples/oke-bm-gpu-h100-rocev2-dranet/deviceclass.yaml
+++ b/examples/oke-bm-gpu-h100-rocev2-dranet/deviceclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: dra.net
+spec:
+  selectors:
+    - cel:
+        expression: device.driver == "dra.net"

--- a/examples/oke-bm-gpu-h100-rocev2-dranet/mpi-job.yaml
+++ b/examples/oke-bm-gpu-h100-rocev2-dranet/mpi-job.yaml
@@ -1,0 +1,88 @@
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: nccl-test-dra
+spec:
+  slotsPerWorker: 1
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - name: nccl
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            command: ["/bin/bash", "-c"]
+            args:
+            - |
+              NUM_GPUS=1
+              NUM_HOSTS=$(sed -n '$=' /etc/mpi/hostfile)
+              NP=$(($NUM_HOSTS*$NUM_GPUS))
+              while ! (for host in $(awk '{print $1}' /etc/mpi/hostfile); do
+                ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no $host exit 2>/dev/null || exit 1
+              done); do
+                echo "Waiting for workers to be ready..."
+                sleep 5
+              done
+              echo "All workers ready, launching NCCL test across $NUM_HOSTS nodes ($NP ranks)"
+              mpirun \
+                --allow-run-as-root \
+                --bind-to numa \
+                --mca pml ucx \
+                --mca coll ^hcoll \
+                -x LD_LIBRARY_PATH \
+                -x UCX_NET_DEVICES=eth0 \
+                -x NCCL_DEBUG=INFO \
+                -x NCCL_SOCKET_IFNAME=eth0 \
+                -x NCCL_IB_TC=41 \
+                -x NCCL_IB_SL=0 \
+                -x NCCL_IB_TIMEOUT=22 \
+                -x RX_QUEUE_LEN=8192 \
+                -x IB_RX_QUEUE_LEN=8192 \
+                -x NCCL_IB_QPS_PER_CONNECTION=4 \
+                -x NCCL_IB_SPLIT_DATA_ON_QPS=0 \
+                -x NCCL_BUFFSIZE=16777216 \
+                -x NCCL_DMABUF_ENABLE=1 \
+                -x NCCL_NVLS_ENABLE=0 \
+                -x HCOLL_ENABLE_MCAST_ALL=0 \
+                -x coll_hcoll_enable=0 \
+                -np $NP \
+                /workspace/nccl-tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1 -c 0
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    training.kubeflow.org/job-name: nccl-test-dra
+                    training.kubeflow.org/job-role: worker
+                topologyKey: kubernetes.io/hostname
+          automountServiceAccountToken: false
+          volumes:
+          - name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 32Gi
+          resourceClaims:
+          - name: gpu-nic
+            resourceClaimTemplateName: 1gpu-1nic
+          containers:
+          - name: nccl
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            resources:
+              claims:
+              - name: gpu-nic
+            securityContext:
+              capabilities:
+                add:
+                - IPC_LOCK
+          tolerations:
+          - key: "nvidia.com/gpu"
+            operator: "Exists"
+            effect: "NoSchedule"

--- a/examples/oke-bm-gpu-h100-rocev2-dranet/resource-claim-template.yaml
+++ b/examples/oke-bm-gpu-h100-rocev2-dranet/resource-claim-template.yaml
@@ -1,0 +1,21 @@
+# 1gpu-1nic: 1 GPU + 1 RDMA NIC per worker.
+# The scheduler co-allocates from the same node automatically.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: 1gpu-1nic
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+      - name: nic
+        exactly:
+          deviceClassName: dra.net
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["dra.net"].rdma == true && device.attributes["dra.net"].ifName.startsWith("rdma")'

--- a/pkg/cloudprovider/oke/oke.go
+++ b/pkg/cloudprovider/oke/oke.go
@@ -19,9 +19,11 @@ package oke
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,48 +37,95 @@ import (
 const (
 	OKEAttrPrefix = "oke.dra.net"
 
-	AttrOKEShape              = OKEAttrPrefix + "/" + "shape"
-	AttrOKEFaultDomain        = OKEAttrPrefix + "/" + "faultDomain"
-	AttrOKEAvailabilityDomain = OKEAttrPrefix + "/" + "availabilityDomain"
+	// RDMA topology attributes (from /opc/v2/host/).
+	AttrOKEHPCIslandId     = OKEAttrPrefix + "/" + "hpcIslandId"
+	AttrOKENetworkBlockId  = OKEAttrPrefix + "/" + "networkBlockId"
+	AttrOKELocalBlockId    = OKEAttrPrefix + "/" + "localBlockId"
+	AttrOKERackId          = OKEAttrPrefix + "/" + "rackId"
+	AttrOKEGpuMemoryFabric = OKEAttrPrefix + "/" + "gpuMemoryFabricId"
 
 	// imdsEndpoint is the Oracle Cloud Instance Metadata Service endpoint.
 	imdsEndpoint = "http://169.254.169.254/opc/v2"
 )
 
-// imdsInstanceMetadata contains the fields we care about from the OCI IMDS
-// instance metadata response.
-type imdsInstanceMetadata struct {
-	Shape              string `json:"shape"`
-	FaultDomain        string `json:"faultDomain"`
-	AvailabilityDomain string `json:"availabilityDomain"`
+// imdsHostRDMATopologyData contains the RDMA topology fields from the OCI
+// IMDS host metadata response. This is only populated when RDMA topology
+// data is enabled for the tenancy.
+type imdsHostRDMATopologyData struct {
+	CustomerGpuMemoryFabric string `json:"customerGpuMemoryFabric"`
+	CustomerHPCIslandId     string `json:"customerHPCIslandId"`
+	CustomerHostId          string `json:"customerHostId"`
+	CustomerLocalBlock      string `json:"customerLocalBlock"`
+	CustomerNetworkBlock    string `json:"customerNetworkBlock"`
+}
+
+// imdsHostMetadata contains the fields we care about from the OCI IMDS
+// host metadata response at /opc/v2/host/.
+type imdsHostMetadata struct {
+	NetworkBlockId   string                    `json:"networkBlockId"`
+	RackId           string                    `json:"rackId"`
+	RDMATopologyData *imdsHostRDMATopologyData `json:"rdmaTopologyData"`
 }
 
 var _ cloudprovider.CloudInstance = (*OKEInstance)(nil)
 
-// OKEInstance holds OCI/OKE specific instance data.
+// OKEInstance holds OCI/OKE specific instance topology data.
 type OKEInstance struct {
-	Shape              string
-	FaultDomain        string
-	AvailabilityDomain string
+	HPCIslandId    string
+	NetworkBlockId string
+	LocalBlockId   string
+	RackId         string
+	// GpuMemoryFabric is only populated on shapes that use a GPU memory fabric
+	// interconnect (e.g. BM.GPU.GB200, BM.GPU.GB300). It will be empty on all
+	// other shapes such as BM.GPU.H100.8.
+	GpuMemoryFabric string
 }
 
-// GetDeviceAttributes returns OKE-specific attributes for a device.
-// These are node-level attributes applied to all devices since OCI IMDS
-// does not expose per-RDMA-NIC metadata.
+// GetDeviceAttributes returns OKE-specific topology attributes for a device.
+// These are node-level attributes applied to all devices since the OCI IMDS
+// host endpoint exposes per-node topology, not per-NIC metadata.
 func (o *OKEInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 
-	if o.Shape != "" {
-		attributes[AttrOKEShape] = resourceapi.DeviceAttribute{StringValue: &o.Shape}
+	if o.HPCIslandId != "" {
+		attributes[AttrOKEHPCIslandId] = resourceapi.DeviceAttribute{StringValue: &o.HPCIslandId}
 	}
-	if o.FaultDomain != "" {
-		attributes[AttrOKEFaultDomain] = resourceapi.DeviceAttribute{StringValue: &o.FaultDomain}
+	if o.NetworkBlockId != "" {
+		attributes[AttrOKENetworkBlockId] = resourceapi.DeviceAttribute{StringValue: &o.NetworkBlockId}
 	}
-	if o.AvailabilityDomain != "" {
-		attributes[AttrOKEAvailabilityDomain] = resourceapi.DeviceAttribute{StringValue: &o.AvailabilityDomain}
+	if o.LocalBlockId != "" {
+		attributes[AttrOKELocalBlockId] = resourceapi.DeviceAttribute{StringValue: &o.LocalBlockId}
+	}
+	if o.RackId != "" {
+		attributes[AttrOKERackId] = resourceapi.DeviceAttribute{StringValue: &o.RackId}
+	}
+	if o.GpuMemoryFabric != "" {
+		attributes[AttrOKEGpuMemoryFabric] = resourceapi.DeviceAttribute{StringValue: &o.GpuMemoryFabric}
 	}
 
 	return attributes
+}
+
+// ocidSuffix returns the unique identifier suffix of an OCI OCID — the segment
+// after the last '.'. DRA string attributes are capped at 64 bytes, but full
+// OCIDs are ~90+ characters; the suffix is always 60 characters and is unique
+// per resource within a tenancy, making it safe to use as an attribute value.
+func ocidSuffix(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	if !strings.Contains(s, "ocid") {
+		return "", fmt.Errorf("not a valid OCID (missing 'ocid' prefix): %q", s)
+	}
+	i := strings.LastIndex(s, ".")
+	if i < 0 {
+		return "", fmt.Errorf("not a valid OCID (missing '.' separator): %q", s)
+	}
+	suffix := s[i+1:]
+	if len(suffix) > 60 {
+		suffix = suffix[len(suffix)-60:]
+	}
+	return suffix, nil
 }
 
 // GetDeviceConfig returns nil as OCI does not provide device-specific
@@ -106,48 +155,85 @@ func OnOKE(ctx context.Context) bool {
 	}) == nil
 }
 
-// GetInstance retrieves OCI instance properties by querying the IMDS.
+// GetInstance retrieves OCI instance topology by querying the IMDS host endpoint.
+// On shapes with RDMA topology data (GB200, GB300), all five topology attributes
+// are populated. On shapes without it (H100, etc.), only NetworkBlockId and
+// RackId are available from the host metadata.
 func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
 	var instance *OKEInstance
 	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imdsEndpoint+"/instance/", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imdsEndpoint+"/host/", nil)
 		if err != nil {
-			klog.Infof("could not create OCI IMDS request ... retrying: %v", err)
+			klog.Infof("could not create OCI IMDS host request ... retrying: %v", err)
 			return false, nil
 		}
 		req.Header.Set("Authorization", "Bearer Oracle")
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			klog.Infof("could not reach OCI IMDS ... retrying: %v", err)
+			klog.Infof("could not reach OCI IMDS host endpoint ... retrying: %v", err)
 			return false, nil
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			klog.Infof("OCI IMDS returned status %d ... retrying", resp.StatusCode)
+			klog.Infof("OCI IMDS host endpoint returned status %d ... retrying", resp.StatusCode)
 			return false, nil
 		}
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			klog.Infof("could not read OCI IMDS response ... retrying: %v", err)
+			klog.Infof("could not read OCI IMDS host response ... retrying: %v", err)
 			return false, nil
 		}
 
-		var metadata imdsInstanceMetadata
+		var metadata imdsHostMetadata
 		if err := json.Unmarshal(body, &metadata); err != nil {
-			return false, fmt.Errorf("could not parse OCI IMDS response: %w", err)
+			return false, fmt.Errorf("could not parse OCI IMDS host response: %w", err)
+		}
+
+		// rdmaTopologyData is absent on non-fabric shapes (H100, etc.).
+		// Fall back to the top-level networkBlockId and rackId which are
+		// available on all shapes that expose the /host/ endpoint.
+		topo := metadata.RDMATopologyData
+		if topo == nil {
+			instance = &OKEInstance{
+				NetworkBlockId: metadata.NetworkBlockId,
+				RackId:         metadata.RackId,
+			}
+			return true, nil
+		}
+
+		hpcIslandId, err := ocidSuffix(topo.CustomerHPCIslandId)
+		if err != nil {
+			return false, fmt.Errorf("invalid HPCIslandId: %w", err)
+		}
+		networkBlockId, err := ocidSuffix(topo.CustomerNetworkBlock)
+		if err != nil {
+			return false, fmt.Errorf("invalid NetworkBlockId: %w", err)
+		}
+		localBlockId, err := ocidSuffix(topo.CustomerLocalBlock)
+		if err != nil {
+			return false, fmt.Errorf("invalid LocalBlockId: %w", err)
+		}
+		gpuMemoryFabric, err := ocidSuffix(topo.CustomerGpuMemoryFabric)
+		if err != nil {
+			return false, fmt.Errorf("invalid GpuMemoryFabric: %w", err)
 		}
 
 		instance = &OKEInstance{
-			Shape:              metadata.Shape,
-			FaultDomain:        metadata.FaultDomain,
-			AvailabilityDomain: metadata.AvailabilityDomain,
+			HPCIslandId:     hpcIslandId,
+			NetworkBlockId:  networkBlockId,
+			LocalBlockId:    localBlockId,
+			RackId:          metadata.RackId,
+			GpuMemoryFabric: gpuMemoryFabric,
 		}
 		return true, nil
 	})
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("please enable TopologyData for your tenancy: %w", err)
+		}
 		return nil, err
 	}
 	return instance, nil

--- a/pkg/cloudprovider/oke/oke_test.go
+++ b/pkg/cloudprovider/oke/oke_test.go
@@ -35,47 +35,59 @@ func TestGetDeviceAttributes(t *testing.T) {
 		want     map[resourceapi.QualifiedName]resourceapi.DeviceAttribute
 	}{
 		{
-			name: "instance with all metadata",
+			name: "full topology with gpu memory fabric (GB200/GB300 shapes)",
 			instance: &OKEInstance{
-				Shape:              "BM.GPU.H100.8",
-				FaultDomain:        "FAULT-DOMAIN-1",
-				AvailabilityDomain: "TrcQ:US-ASHBURN-AD-2",
+				HPCIslandId:     "fake-island-id",
+				NetworkBlockId:  "fake-network-block-id",
+				LocalBlockId:    "fake-local-block-id",
+				RackId:          "fake-rack-id",
+				GpuMemoryFabric: "fake-gpu-memory-fabric-id",
 			},
 			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
 			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttrOKEShape:              {StringValue: ptr.To("BM.GPU.H100.8")},
-				AttrOKEFaultDomain:        {StringValue: ptr.To("FAULT-DOMAIN-1")},
-				AttrOKEAvailabilityDomain: {StringValue: ptr.To("TrcQ:US-ASHBURN-AD-2")},
+				AttrOKEHPCIslandId:     {StringValue: ptr.To("fake-island-id")},
+				AttrOKENetworkBlockId:  {StringValue: ptr.To("fake-network-block-id")},
+				AttrOKELocalBlockId:    {StringValue: ptr.To("fake-local-block-id")},
+				AttrOKERackId:          {StringValue: ptr.To("fake-rack-id")},
+				AttrOKEGpuMemoryFabric: {StringValue: ptr.To("fake-gpu-memory-fabric-id")},
 			},
 		},
 		{
-			name: "instance with only shape",
+			name: "H100 fallback: only networkBlockId and rackId (no rdmaTopologyData)",
 			instance: &OKEInstance{
-				Shape:              "VM.Standard.E3.Flex",
-				FaultDomain:        "",
-				AvailabilityDomain: "",
+				NetworkBlockId: "fake-network-block-id",
+				RackId:         "fake-rack-id",
 			},
 			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
 			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttrOKEShape: {StringValue: ptr.To("VM.Standard.E3.Flex")},
+				AttrOKENetworkBlockId: {StringValue: ptr.To("fake-network-block-id")},
+				AttrOKERackId:         {StringValue: ptr.To("fake-rack-id")},
 			},
 		},
 		{
-			name: "instance with no metadata",
+			name: "partial topology (only hpcIslandId and networkBlockId)",
 			instance: &OKEInstance{
-				Shape:              "",
-				FaultDomain:        "",
-				AvailabilityDomain: "",
+				HPCIslandId:    "fake-island-id",
+				NetworkBlockId: "fake-network-block-id",
 			},
-			id:   cloudprovider.DeviceIdentifiers{Name: "dev1"},
-			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
+			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttrOKEHPCIslandId:    {StringValue: ptr.To("fake-island-id")},
+				AttrOKENetworkBlockId: {StringValue: ptr.To("fake-network-block-id")},
+			},
+		},
+		{
+			name:     "no topology data",
+			instance: &OKEInstance{},
+			id:       cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want:     map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
 		},
 		{
 			name: "attributes are node-level, same for any device identifier",
 			instance: &OKEInstance{
-				Shape:              "BM.GPU.H100.8",
-				FaultDomain:        "FAULT-DOMAIN-3",
-				AvailabilityDomain: "TrcQ:US-ASHBURN-AD-2",
+				HPCIslandId:    "fake-island-id",
+				NetworkBlockId: "fake-network-block-id",
+				RackId:         "fake-rack-id",
 			},
 			id: cloudprovider.DeviceIdentifiers{
 				Name:       "pci-0000-0c-00-0",
@@ -83,9 +95,9 @@ func TestGetDeviceAttributes(t *testing.T) {
 				PCIAddress: "0000:0c:00.0",
 			},
 			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttrOKEShape:              {StringValue: ptr.To("BM.GPU.H100.8")},
-				AttrOKEFaultDomain:        {StringValue: ptr.To("FAULT-DOMAIN-3")},
-				AttrOKEAvailabilityDomain: {StringValue: ptr.To("TrcQ:US-ASHBURN-AD-2")},
+				AttrOKEHPCIslandId:    {StringValue: ptr.To("fake-island-id")},
+				AttrOKENetworkBlockId: {StringValue: ptr.To("fake-network-block-id")},
+				AttrOKERackId:         {StringValue: ptr.To("fake-rack-id")},
 			},
 		},
 	}
@@ -100,11 +112,68 @@ func TestGetDeviceAttributes(t *testing.T) {
 	}
 }
 
+func TestOCIDSuffix(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "valid OCID extracts 60-char suffix",
+			input: "ocid1.hpcisland.oc1.test-region-1.aaaaaaaa2mvjha24vj6evyafdqtis6nzqibhrnxxhzt65zkc3upy4xlrz5za",
+			want:  "aaaaaaaa2mvjha24vj6evyafdqtis6nzqibhrnxxhzt65zkc3upy4xlrz5za",
+		},
+		{
+			name:  "OCID with suffix longer than 60 chars is truncated to last 60",
+			input: "ocid1.hpcisland.oc1.test-region-1.xaaaaaaaa2mvjha24vj6evyafdqtis6nzqibhrnxxhzt65zkc3upy4xlrz5za",
+			want:  "aaaaaaaa2mvjha24vj6evyafdqtis6nzqibhrnxxhzt65zkc3upy4xlrz5za",
+		},
+		{
+			name:  "empty string returns empty (field not present on shape)",
+			input: "",
+			want:  "",
+		},
+		{
+			name:    "non-OCID string returns error",
+			input:   "fakehexhash",
+			wantErr: true,
+		},
+		{
+			name:    "non-OCID dotted string returns error",
+			input:   "some.dotted.value",
+			wantErr: true,
+		},
+		{
+			name:    "OCID without dot separator returns error",
+			input:   "ocid1-hpcisland-no-dots",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ocidSuffix(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ocidSuffix(%q) = %q, want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ocidSuffix(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ocidSuffix(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetDeviceConfig(t *testing.T) {
 	instance := &OKEInstance{
-		Shape:              "BM.GPU.H100.8",
-		FaultDomain:        "FAULT-DOMAIN-1",
-		AvailabilityDomain: "TrcQ:US-ASHBURN-AD-2",
+		HPCIslandId:    "fake-island-id",
+		NetworkBlockId: "fake-network-block-id",
+		RackId:         "fake-rack-id",
 	}
 	got := instance.GetDeviceConfig(cloudprovider.DeviceIdentifiers{Name: "dev1"})
 	if got != nil {


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

1. OKE IMDS topology data - updated to match real customer topology information (HPC island, network block, local block, rack, GPU memory fabric) for topology aware scheduling.
2. Add H100 example

#### Which issue(s) this PR is related to:

#111 - doesn't close
#138 - adds a subset of this PR

#### Special notes for your reviewer:

This PR is split from #138 to remove ipv6 and focus on updating OKE to match real topology data. This was tested and validated on our BM.GPU.H100.8 shapes in a single-stack ipv4 RDMA cluster. A follow-up PR will be added to address ipv6 which is relevant for gb200+.

#### Does this PR introduce a user-facing change?
```release-note
Update OKE to expose OCI RDMA topology attributes (HPC island, network block, local block, rack, GPU memory fabric) for topology-aware scheduling.
```