### PR TITLE
accurately detect default gateways

### DIFF
--- a/internal/testutils/userns.go
+++ b/internal/testutils/userns.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+var (
+	isSupported bool
+	checkOnce   sync.Once
+)
+
+// IsSupported checks if unprivileged user namespaces are enabled on the host system.
+// It caches the result after the first check.
+func IsSupported() bool {
+	checkOnce.Do(func() {
+		cmd := exec.Command("sleep", "1")
+
+		// Attempt to map ourselves to root inside the userns.
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Cloneflags:  syscall.CLONE_NEWUSER,
+			UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getuid(), Size: 1}},
+			GidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getgid(), Size: 1}},
+		}
+
+		if err := cmd.Start(); err != nil {
+			return // User namespaces are likely restricted or not supported
+		}
+
+		defer func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}()
+
+		isSupported = true
+	})
+
+	return isSupported
+}
+
+// Run executes the given test function inside a user namespace where the
+// current user is mapped to root. This provides capabilities to create network
+// namespaces and netfilter rules without running as actual root on the host.
+//
+// extraCloneflags can be used to request additional namespace types
+// (e.g., syscall.CLONE_NEWNET).
+func Run(t *testing.T, f func(t *testing.T), extraCloneflags ...uintptr) {
+	const subprocessEnvKey = "GO_USERNS_SUBPROCESS_KEY"
+
+	// 1. If we are already inside the subprocess, run the actual test logic.
+	if testIDString, ok := os.LookupEnv(subprocessEnvKey); ok && testIDString == "1" {
+		t.Run("subprocess", f)
+		return
+	}
+
+	// 2. If we are on the host, verify support before attempting to spawn.
+	if !IsSupported() {
+		t.Skip("Unprivileged user namespaces are not supported on this system")
+	}
+
+	// 3. Prepare the command to re-execute the current test binary.
+	cmd := exec.Command(os.Args[0])
+	cmd.Args = []string{os.Args[0], "-test.run=" + t.Name() + "$", "-test.v=true"}
+
+	for _, arg := range os.Args {
+		if strings.HasPrefix(arg, "-test.testlogfile=") {
+			cmd.Args = append(cmd.Args, arg)
+		}
+	}
+
+	cmd.Env = append(os.Environ(), subprocessEnvKey+"=1")
+	// Include sbin in PATH, as some networking commands are not found otherwise.
+	cmd.Env = append(cmd.Env, "PATH=/usr/local/sbin:/usr/sbin:/sbin:"+os.Getenv("PATH"))
+	cmd.Stdin = os.Stdin
+
+	// 4. Configure the namespace clone flags.
+	cloneflags := uintptr(syscall.CLONE_NEWUSER)
+	for _, flag := range extraCloneflags {
+		cloneflags |= flag
+	}
+
+	// Map ourselves to root inside the new user namespace.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags:  cloneflags,
+		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getuid(), Size: 1}},
+		GidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getgid(), Size: 1}},
+	}
+
+	// 5. Execute and capture output.
+	out, err := cmd.CombinedOutput()
+
+	// Prepending a newline makes the nested test output much easier to read
+	// in the standard `go test` log format.
+	t.Logf("\n%s", out)
+	if err != nil {
+		t.Fatalf("Subprocess execution failed: %v", err)
+	}
+}

--- a/pkg/inventory/net.go
+++ b/pkg/inventory/net.go
@@ -17,6 +17,8 @@ limitations under the License.
 package inventory
 
 import (
+	"math"
+
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/vishvananda/netlink"
@@ -28,53 +30,88 @@ import (
 )
 
 // getDefaultGwInterfaces returns a set of interface names that are configured
-// as default gateways in the main routing table. It identifies these by querying
-// the main routing table for routes with an unspecified destination (0.0.0.0/0
-// for IPv4 or ::/0 for IPv6).
+// as active default gateways in the main routing table, respecting route metrics.
+// It identifies defaults as routes where Dst is nil (kernel default) or where
+// Dst is exactly 0.0.0.0/0 (IPv4) or ::/0 (IPv6).
 func getDefaultGwInterfaces() sets.Set[string] {
-	interfaces := sets.Set[string]{}
+	interfaces := make(sets.Set[string])
+
 	filter := &netlink.Route{
 		Table: unix.RT_TABLE_MAIN,
 	}
 	routes, err := nlwrap.RouteListFiltered(netlink.FAMILY_ALL, filter, netlink.RT_FILTER_TABLE)
 	if err != nil {
+		klog.Errorf("Failed to list routes: %v", err)
 		return interfaces
 	}
+
+	minMetricV4 := math.MaxInt32
+	minMetricV6 := math.MaxInt32
+
+	v4Interfaces := make(sets.Set[string])
+	v6Interfaces := make(sets.Set[string])
 
 	for _, r := range routes {
 		if r.Family != netlink.FAMILY_V4 && r.Family != netlink.FAMILY_V6 {
 			continue
 		}
 
-		if r.Dst != nil && !r.Dst.IP.IsUnspecified() {
-			continue
+		if r.Dst != nil {
+			ones, bits := r.Dst.Mask.Size()
+			if !r.Dst.IP.IsUnspecified() || ones != 0 || (bits != 32 && bits != 128) {
+				continue
+			}
 		}
 
-		// no multipath
-		if len(r.MultiPath) == 0 {
-			if r.Gw == nil {
-				continue
+		metric := r.Priority
+
+		// 1. Gather all relevant link indices for this route
+		var linkIndices []int
+		if len(r.MultiPath) > 0 {
+			for _, nh := range r.MultiPath {
+				linkIndices = append(linkIndices, nh.LinkIndex)
 			}
-			intfLink, err := netlink.LinkByIndex(r.LinkIndex)
-			if err != nil {
-				klog.Infof("Failed to get interface link for route %v : %v", r, err)
-				continue
-			}
-			interfaces.Insert(intfLink.Attrs().Name)
+		} else {
+			linkIndices = append(linkIndices, r.LinkIndex)
 		}
 
-		for _, nh := range r.MultiPath {
-			if nh.Gw == nil {
-				continue
-			}
-			intfLink, err := netlink.LinkByIndex(r.LinkIndex)
+		// 2. Evaluate each link index against our metric trackers
+		for _, linkIndex := range linkIndices {
+			intfLink, err := netlink.LinkByIndex(linkIndex)
 			if err != nil {
-				klog.Infof("Failed to get interface link for route %v : %v", r, err)
+				klog.Infof("Failed to get interface link for index %d: %v", linkIndex, err)
 				continue
 			}
-			interfaces.Insert(intfLink.Attrs().Name)
+			name := intfLink.Attrs().Name
+
+			if r.Family == netlink.FAMILY_V4 {
+				if metric < minMetricV4 {
+					minMetricV4 = metric
+					v4Interfaces = make(sets.Set[string]) // Clear previous losers
+					v4Interfaces.Insert(name)
+				} else if metric == minMetricV4 {
+					v4Interfaces.Insert(name) // ECMP tie: keep both
+				}
+			} else {
+				if metric < minMetricV6 {
+					minMetricV6 = metric
+					v6Interfaces = make(sets.Set[string]) // Clear previous losers
+					v6Interfaces.Insert(name)
+				} else if metric == minMetricV6 {
+					v6Interfaces.Insert(name) // ECMP tie: keep both
+				}
+			}
 		}
 	}
+
+	// Merge the winning IPv4 and IPv6 interfaces into the final set
+	for k := range v4Interfaces {
+		interfaces.Insert(k)
+	}
+	for k := range v6Interfaces {
+		interfaces.Insert(k)
+	}
+
 	return interfaces
 }
 

--- a/pkg/inventory/net_test.go
+++ b/pkg/inventory/net_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	userns "sigs.k8s.io/dranet/internal/testutils"
+)
+
+func TestGetDefaultGwInterfaces(t *testing.T) {
+	userns.Run(t, testGetDefaultGwInterfaces_Namespaced, syscall.CLONE_NEWNET)
+}
+
+func testGetDefaultGwInterfaces_Namespaced(t *testing.T) {
+	if err := netlink.LinkSetUp(&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "lo"}}); err != nil {
+		t.Fatalf("failed to bring lo up: %v", err)
+	}
+
+	interfaceNames := []string{"eth0", "eth1", "eth2", "wg0"}
+	links := make(map[string]netlink.Link)
+
+	// Standardize the subnets so the kernel knows the Gateways are reachable
+	ipv4Subnet, _ := netlink.ParseAddr("192.168.1.2/24")
+	ipv6Subnet, _ := netlink.ParseAddr("fd00::2/64")
+
+	for _, name := range interfaceNames {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			t.Fatalf("failed to add dummy %s: %v", name, err)
+		}
+		if err := netlink.LinkSetUp(dummy); err != nil {
+			t.Fatalf("failed to set %s up: %v", name, err)
+		}
+
+		link, _ := netlink.LinkByName(name)
+
+		// Assign IPs to the dummy interfaces to satisfy the kernel's subnet reachability checks
+		if err := netlink.AddrAdd(link, ipv4Subnet); err != nil {
+			t.Fatalf("failed to add IPv4 address to %s: %v", name, err)
+		}
+		if err := netlink.AddrAdd(link, ipv6Subnet); err != nil {
+			t.Fatalf("failed to add IPv6 address to %s: %v", name, err)
+		}
+
+		links[name] = link
+	}
+
+	_, defaultIPv4, _ := net.ParseCIDR("0.0.0.0/0")
+	_, defaultIPv6, _ := net.ParseCIDR("::/0")
+	_, nonDefaultUnspecifiedIPv4, _ := net.ParseCIDR("0.0.0.0/8")
+	_, nonDefaultUnspecifiedIPv6, _ := net.ParseCIDR("::/8")
+	_, specificNetwork, _ := net.ParseCIDR("10.0.0.0/8")
+
+	// Define Mock Gateway IPs in the same subnets we just assigned to the interfaces
+	gwIPv4 := net.ParseIP("192.168.1.1")
+	gwIPv6 := net.ParseIP("fd00::1")
+
+	tests := []struct {
+		name           string
+		setupRoutes    func() error
+		expectedResult sets.Set[string]
+	}{
+		{
+			name:           "Empty routing table",
+			setupRoutes:    func() error { return nil },
+			expectedResult: sets.New[string](),
+		},
+		{
+			name: "Single IPv4 default route",
+			setupRoutes: func() error {
+				return netlink.RouteAdd(&netlink.Route{
+					Family:    netlink.FAMILY_V4,
+					Dst:       defaultIPv4,
+					Gw:        gwIPv4, // Added Gateway
+					LinkIndex: links["eth0"].Attrs().Index,
+					Priority:  100,
+					Table:     unix.RT_TABLE_MAIN,
+				})
+			},
+			expectedResult: sets.New[string]("eth0"),
+		},
+		{
+			name: "Lower metric wins (IPv4)",
+			setupRoutes: func() error {
+				if err := netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, Gw: gwIPv4, LinkIndex: links["eth0"].Attrs().Index, Priority: 200, Table: unix.RT_TABLE_MAIN}); err != nil {
+					return err
+				}
+				return netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, Gw: gwIPv4, LinkIndex: links["eth1"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string]("eth1"),
+		},
+		{
+			name: "Lower metric wins (IPv6)",
+			setupRoutes: func() error {
+				if err := netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V6, Dst: defaultIPv6, Gw: gwIPv6, LinkIndex: links["eth1"].Attrs().Index, Priority: 200, Table: unix.RT_TABLE_MAIN}); err != nil {
+					return err
+				}
+				return netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V6, Dst: defaultIPv6, Gw: gwIPv6, LinkIndex: links["eth2"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string]("eth2"),
+		},
+		{
+			name: "Independent families (IPv4 and IPv6 on different interfaces)",
+			setupRoutes: func() error {
+				if err := netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, Gw: gwIPv4, LinkIndex: links["eth0"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN}); err != nil {
+					return err
+				}
+				return netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V6, Dst: defaultIPv6, Gw: gwIPv6, LinkIndex: links["eth2"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string]("eth0", "eth2"),
+		},
+		{
+			name: "Same interface wins both families",
+			setupRoutes: func() error {
+				if err := netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, Gw: gwIPv4, LinkIndex: links["eth0"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN}); err != nil {
+					return err
+				}
+				return netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V6, Dst: defaultIPv6, Gw: gwIPv6, LinkIndex: links["eth0"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string]("eth0"),
+		},
+		{
+			name: "ECMP: Multiple standard routes with the same metric",
+			setupRoutes: func() error {
+				if err := netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, Gw: gwIPv4, LinkIndex: links["eth0"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN}); err != nil {
+					return err
+				}
+				return netlink.RouteAppend(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, Gw: gwIPv4, LinkIndex: links["eth1"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string]("eth0", "eth1"),
+		},
+		{
+			name: "Multipath: Single route with multiple nexthops",
+			setupRoutes: func() error {
+				return netlink.RouteAdd(&netlink.Route{
+					Family:   netlink.FAMILY_V4,
+					Dst:      defaultIPv4,
+					Priority: 100,
+					Table:    unix.RT_TABLE_MAIN,
+					MultiPath: []*netlink.NexthopInfo{
+						// Removed Weight, Added Gw
+						{LinkIndex: links["eth1"].Attrs().Index, Gw: gwIPv4},
+						{LinkIndex: links["eth2"].Attrs().Index, Gw: gwIPv4},
+					},
+				})
+			},
+			expectedResult: sets.New[string]("eth1", "eth2"),
+		},
+		{
+			name: "Point-to-Point Interface (No Gateway IP)",
+			setupRoutes: func() error {
+				// Intentionally leaving Gw == nil here because Point-to-Point links don't have gateways
+				if err := netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, LinkIndex: links["wg0"].Attrs().Index, Priority: 50, Scope: netlink.SCOPE_LINK, Table: unix.RT_TABLE_MAIN}); err != nil {
+					return err
+				}
+				return netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, Gw: gwIPv4, LinkIndex: links["eth0"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string]("wg0"),
+		},
+		{
+			name: "P2P default with Priority 0 wins over gateway default",
+			setupRoutes: func() error {
+				if err := netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, LinkIndex: links["wg0"].Attrs().Index, Priority: 0, Scope: netlink.SCOPE_LINK, Table: unix.RT_TABLE_MAIN}); err != nil {
+					return err
+				}
+				return netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, Gw: gwIPv4, LinkIndex: links["eth0"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string]("wg0"),
+		},
+		{
+			name: "Ignores non-default routes",
+			setupRoutes: func() error {
+				return netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: specificNetwork, Gw: gwIPv4, LinkIndex: links["eth0"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string](),
+		},
+		{
+			name: "Ignores 0.0.0.0/8 even when metric is lower",
+			setupRoutes: func() error {
+				if err := netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: nonDefaultUnspecifiedIPv4, Gw: gwIPv4, LinkIndex: links["eth1"].Attrs().Index, Priority: 10, Table: unix.RT_TABLE_MAIN}); err != nil {
+					return err
+				}
+				return netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V4, Dst: defaultIPv4, Gw: gwIPv4, LinkIndex: links["eth0"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string]("eth0"),
+		},
+		{
+			name: "Ignores ::/8 even when metric is lower",
+			setupRoutes: func() error {
+				if err := netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V6, Dst: nonDefaultUnspecifiedIPv6, Gw: gwIPv6, LinkIndex: links["eth1"].Attrs().Index, Priority: 10, Table: unix.RT_TABLE_MAIN}); err != nil {
+					return err
+				}
+				return netlink.RouteAdd(&netlink.Route{Family: netlink.FAMILY_V6, Dst: defaultIPv6, Gw: gwIPv6, LinkIndex: links["eth2"].Attrs().Index, Priority: 100, Table: unix.RT_TABLE_MAIN})
+			},
+			expectedResult: sets.New[string]("eth2"),
+		},
+		{
+			name: "Ignores default routes in custom routing tables",
+			setupRoutes: func() error {
+				return netlink.RouteAdd(&netlink.Route{
+					Family:    netlink.FAMILY_V4,
+					Dst:       defaultIPv4,
+					Gw:        gwIPv4,
+					LinkIndex: links["eth0"].Attrs().Index,
+					Priority:  100,
+					Table:     123,
+				})
+			},
+			expectedResult: sets.New[string](),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Flush the main routing table to guarantee a clean slate
+			routes, _ := netlink.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{Table: unix.RT_TABLE_MAIN}, netlink.RT_FILTER_TABLE)
+			for _, r := range routes {
+				if r.Dst == nil || r.Dst.IP.IsUnspecified() {
+					netlink.RouteDel(&r)
+				}
+			}
+
+			// Apply the test-specific topology
+			if err := tt.setupRoutes(); err != nil {
+				t.Fatalf("setupRoutes failed: %v", err)
+			}
+
+			got := getDefaultGwInterfaces()
+			if diff := cmp.Diff(tt.expectedResult, got); diff != "" {
+				t.Errorf("getDefaultGwInterfaces() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Address several critical edge cases in default interface detection and introduces a robust, rootless networking test framework.

1. Point-to-Point Interfaces: Removed the `r.Gw == nil` check. Previously, this caused the agent to completely ignore active VPNs and tunnels (like Wireguard or tun/tap) because P2P links route directly out of the device without a Gateway IP.
2. Route Metrics: The kernel relies on metrics (Priority) to determine the active route in a multi-WAN setup. The old code ignored this, returning all interfaces. It now correctly isolates the lowest metric for IPv4 and IPv6 independently, while preserving ECMP support.
3. Multipath Link Lookup: Fixed a bug where multipath routes were queried using the parent route's link index (which is often 0) rather than the nexthop's link index.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

/kind bug

```release-note
Address several critical edge cases in default interface detection
```

Fixes: https://github.com/kubernetes-sigs/dranet/issues/152