### PR TITLE
Azure: generate per-device network config from IMDS metadata

### DIFF
--- a/pkg/cloudprovider/azure/azure.go
+++ b/pkg/cloudprovider/azure/azure.go
@@ -21,13 +21,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
+	"strings"
 	"time"
 
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	resourceapi "k8s.io/api/resource/v1"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
 )
@@ -42,6 +48,10 @@ const (
 	imdsEndpoint = "http://169.254.169.254/metadata/instance"
 	// imdsAPIVersion is the API version used for IMDS queries.
 	imdsAPIVersion = "2021-02-01"
+	// imdsPathCompute is the IMDS path for compute metadata.
+	imdsPathCompute = "compute"
+	// imdsPathNetwork is the IMDS path for network metadata.
+	imdsPathNetwork = "network"
 )
 
 // imdsComputeMetadata contains the fields we care about from the Azure IMDS
@@ -56,12 +66,53 @@ type imdsResponse struct {
 	Compute imdsComputeMetadata `json:"compute"`
 }
 
+// imdsNetworkResponse represents the IMDS network metadata response.
+type imdsNetworkResponse struct {
+	Interface []networkInterface `json:"interface"`
+}
+
+// networkInterface represents a single network interface from IMDS.
+type networkInterface struct {
+	IPv4       ipv4Config `json:"ipv4"`
+	IPv6       ipv6Config `json:"ipv6"`
+	MacAddress string     `json:"macAddress"`
+}
+
+// ipv4Config represents the IPv4 configuration from IMDS.
+type ipv4Config struct {
+	IPAddress []ipv4Address `json:"ipAddress"`
+	Subnet    []subnet      `json:"subnet"`
+}
+
+// ipv6Config represents the IPv6 configuration from IMDS.
+type ipv6Config struct {
+	IPAddress []ipv6Address `json:"ipAddress"`
+}
+
+// ipv4Address represents a single IPv4 address from IMDS.
+type ipv4Address struct {
+	PrivateIPAddress string `json:"privateIpAddress"`
+	PublicIPAddress  string `json:"publicIpAddress"`
+}
+
+// ipv6Address represents a single IPv6 address from IMDS.
+type ipv6Address struct {
+	PrivateIPAddress string `json:"privateIpAddress"`
+}
+
+// subnet represents a subnet from IMDS.
+type subnet struct {
+	Address string `json:"address"`
+	Prefix  string `json:"prefix"`
+}
+
 var _ cloudprovider.CloudInstance = (*AzureInstance)(nil)
 
 // AzureInstance holds Azure-specific instance data retrieved from IMDS.
 type AzureInstance struct {
 	PlacementGroupID string
 	VMSize           string
+	Interfaces       []networkInterface
 }
 
 // GetDeviceAttributes returns Azure-specific attributes for a device.
@@ -81,10 +132,151 @@ func (a *AzureInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) 
 	return attributes
 }
 
-// GetDeviceConfig returns nil as Azure does not currently provide
-// device-specific network configuration via IMDS.
+const (
+	// routingTableBase is the base routing table ID for policy routing.
+	// Each NIC gets its own table: routingTableBase + nicIndex.
+	routingTableBase = 100
+)
+
+// GetDeviceConfig returns Azure-specific network configuration (rules and routes)
+// for a device identified by its MAC address. It reads subnet info from IMDS
+// and computes policy routing rules and routes for both IPv4 and IPv6.
 func (a *AzureInstance) GetDeviceConfig(id cloudprovider.DeviceIdentifiers) *apis.NetworkConfig {
-	return nil
+	if id.MAC == "" {
+		return nil
+	}
+
+	normalizedMAC := normalizeMAC(id.MAC)
+
+	var iface *networkInterface
+	var nicIndex int
+	for i := range a.Interfaces {
+		if normalizeMAC(a.Interfaces[i].MacAddress) == normalizedMAC {
+			iface = &a.Interfaces[i]
+			nicIndex = i
+			break
+		}
+	}
+	if iface == nil {
+		klog.V(4).Infof("No Azure IMDS network interface found for MAC %q", id.MAC)
+		return nil
+	}
+
+	config := &apis.NetworkConfig{}
+	tableID := routingTableBase + nicIndex
+
+	// IPv4 rules and routes
+	if len(iface.IPv4.Subnet) > 0 {
+		subnet := iface.IPv4.Subnet[0]
+		gateway, err := subnetFirstAddress(subnet.Address, subnet.Prefix)
+		if err != nil {
+			klog.Warningf("Could not compute gateway for subnet %s/%s: %v", subnet.Address, subnet.Prefix, err)
+		} else {
+			config.Rules = append(config.Rules, apis.RuleConfig{
+				Source: subnet.Address + "/" + subnet.Prefix,
+				Table:  tableID,
+			})
+			config.Routes = append(config.Routes, apis.RouteConfig{
+				Destination: "0.0.0.0/0",
+				Gateway:     gateway,
+				Table:       tableID,
+			})
+		}
+	}
+
+	// IPv6 rules and routes (only if non-link-local IPv6 addresses are configured)
+	ipv6Gw := getIPv6DefaultGateway(id.Name)
+	if ipv6Gw != "" && len(iface.IPv6.IPAddress) > 0 && iface.IPv6.IPAddress[0].PrivateIPAddress != "" &&
+		!isIPv6LinkLocal(iface.IPv6.IPAddress[0].PrivateIPAddress) {
+		ipv6Addr := iface.IPv6.IPAddress[0].PrivateIPAddress
+		config.Rules = append(config.Rules, apis.RuleConfig{
+			Source: ipv6Addr + "/128",
+			Table:  tableID,
+		})
+		config.Routes = append(config.Routes, apis.RouteConfig{
+			Destination: "::/0",
+			Gateway:     ipv6Gw,
+			Table:       tableID,
+		})
+	}
+
+	// Return nil if no rules/routes were generated
+	if len(config.Rules) == 0 && len(config.Routes) == 0 {
+		return nil
+	}
+
+	return config
+}
+
+// normalizeMAC converts a MAC address to a consistent lowercase, colon-free format
+// for comparison. Azure IMDS returns MACs like "0011AAFFBB22" while Linux uses
+// "00:11:aa:ff:bb:22".
+func normalizeMAC(mac string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(mac, ":", ""), "-", ""))
+}
+
+// getIPv6DefaultGateway returns the IPv6 default gateway for the given
+// interface name by inspecting IPv6 default routes in the main routing table,
+// or an empty string if none is found.
+func getIPv6DefaultGateway(ifName string) string {
+	link, err := nlwrap.LinkByName(ifName)
+	if err != nil {
+		klog.V(4).Infof("Failed to look up link %s for IPv6 gateway discovery: %v", ifName, err)
+		return ""
+	}
+	filter := &netlink.Route{
+		Table:     unix.RT_TABLE_MAIN,
+		LinkIndex: link.Attrs().Index,
+	}
+	routes, err := nlwrap.RouteListFiltered(netlink.FAMILY_V6, filter, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF)
+	if err != nil {
+		klog.Warningf("Failed to list IPv6 routes for %s: %v", ifName, err)
+		return ""
+	}
+	for _, r := range routes {
+		// Default route: Dst is nil or ::/0
+		if r.Dst != nil {
+			ones, bits := r.Dst.Mask.Size()
+			if !r.Dst.IP.IsUnspecified() || ones != 0 || bits != 128 {
+				continue
+			}
+		}
+		if r.Gw != nil {
+			return r.Gw.String()
+		}
+	}
+	return ""
+}
+
+// isIPv6LinkLocal returns true if the given address is an IPv6 link-local
+// address (fe80::/10).
+func isIPv6LinkLocal(addr string) bool {
+	ip := net.ParseIP(addr)
+	return ip != nil && ip.IsLinkLocalUnicast()
+}
+
+// subnetFirstAddress returns the first usable IP address in a subnet
+// (the subnet address + 1). For example, for ("10.9.255.0", "24") it returns "10.9.255.1".
+// It validates that the address and prefix form a valid IPv4 CIDR, that the
+// address is the actual network base, and that the gateway falls within the subnet.
+func subnetFirstAddress(subnetAddr, prefix string) (string, error) {
+	ipPrefix, err := netip.ParsePrefix(subnetAddr + "/" + prefix)
+	if err != nil {
+		return "", fmt.Errorf("invalid CIDR %s/%s: %w", subnetAddr, prefix, err)
+	}
+	if !ipPrefix.Addr().Is4() {
+		return "", fmt.Errorf("%s is not an IPv4 address", subnetAddr)
+	}
+	maskedPrefix := ipPrefix.Masked()
+	// Verify the address is the network base (e.g., reject 10.0.0.5/24)
+	if maskedPrefix.Addr().String() != subnetAddr {
+		return "", fmt.Errorf("%s is not the network base for /%s (expected %s)", subnetAddr, prefix, maskedPrefix.Addr().String())
+	}
+	ipFirst := maskedPrefix.Addr().Next()
+	if !maskedPrefix.Contains(ipFirst) {
+		return "", fmt.Errorf("gateway %s falls outside subnet %s/%s", ipFirst, subnetAddr, prefix)
+	}
+	return ipFirst.String(), nil
 }
 
 // OnAzure returns true if the code is running on an Azure VM by probing the
@@ -111,56 +303,69 @@ func OnAzure(ctx context.Context) bool {
 	return err == nil
 }
 
-// GetInstance retrieves Azure instance properties by querying IMDS.
-func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
-	var instance *AzureInstance
-
-	client := &http.Client{Timeout: 5 * time.Second}
-
-	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		url := fmt.Sprintf("%s/compute?api-version=%s&format=json", imdsEndpoint, imdsAPIVersion)
+// queryIMDS performs a GET request to the given Azure IMDS URL
+// with retry logic and unmarshals the JSON response into result.
+func queryIMDS(ctx context.Context, client *http.Client, url string, result interface{}) error {
+	return wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
-			klog.Infof("could not create Azure IMDS request ... retrying: %v", err)
+			klog.Infof("could not create Azure IMDS request for %s ... retrying: %v", url, err)
 			return false, nil
 		}
 		req.Header.Set("Metadata", "true")
 
 		resp, err := client.Do(req)
 		if err != nil {
-			klog.Infof("could not query Azure IMDS ... retrying: %v", err)
+			klog.Infof("could not query Azure IMDS %s ... retrying: %v", url, err)
 			return false, nil
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			klog.Infof("Azure IMDS returned status %d ... retrying", resp.StatusCode)
+			klog.Infof("Azure IMDS %s returned status %d ... retrying", url, resp.StatusCode)
 			return false, nil
 		}
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			klog.Infof("could not read Azure IMDS response ... retrying: %v", err)
+			klog.Infof("could not read Azure IMDS response from %s ... retrying: %v", url, err)
 			return false, nil
 		}
 
-		var computeMetadata imdsComputeMetadata
-		if err := json.Unmarshal(body, &computeMetadata); err != nil {
-			klog.Infof("could not parse Azure IMDS compute metadata ... retrying: %v", err)
+		if err := json.Unmarshal(body, result); err != nil {
+			klog.Infof("could not parse Azure IMDS response from %s ... retrying: %v", url, err)
 			return false, nil
 		}
 
-		instance = &AzureInstance{
-			PlacementGroupID: computeMetadata.PlacementGroupID,
-			VMSize:           computeMetadata.VMSize,
-		}
-
-		klog.Infof("Azure IMDS: vmSize=%s, placementGroupId=%s", instance.VMSize, instance.PlacementGroupID)
 		return true, nil
 	})
+}
 
-	if err != nil {
+// GetInstance retrieves Azure instance properties by querying IMDS.
+func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	var computeMetadata imdsComputeMetadata
+	computeURL := fmt.Sprintf("%s/%s?api-version=%s&format=json", imdsEndpoint, imdsPathCompute, imdsAPIVersion)
+	if err := queryIMDS(ctx, client, computeURL, &computeMetadata); err != nil {
 		return nil, err
 	}
+
+	instance := &AzureInstance{
+		PlacementGroupID: computeMetadata.PlacementGroupID,
+		VMSize:           computeMetadata.VMSize,
+	}
+	klog.Infof("Azure IMDS: vmSize=%s, placementGroupId=%s", instance.VMSize, instance.PlacementGroupID)
+
+	// Fetch network interface metadata in a separate call.
+	var networkResp imdsNetworkResponse
+	networkURL := fmt.Sprintf("%s/%s?api-version=%s&format=json", imdsEndpoint, imdsPathNetwork, imdsAPIVersion)
+	if err := queryIMDS(ctx, client, networkURL, &networkResp); err != nil {
+		klog.Warningf("Failed to retrieve Azure IMDS network metadata: %v", err)
+	} else {
+		instance.Interfaces = networkResp.Interface
+		klog.Infof("Azure IMDS: retrieved %d network interfaces", len(instance.Interfaces))
+	}
+
 	return instance, nil
 }

--- a/pkg/cloudprovider/azure/azure_test.go
+++ b/pkg/cloudprovider/azure/azure_test.go
@@ -17,8 +17,14 @@ limitations under the License.
 package azure
 
 import (
+	"net"
+	"syscall"
 	"testing"
 
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	userns "sigs.k8s.io/dranet/internal/testutils"
+	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
 
 	"github.com/google/go-cmp/cmp"
@@ -95,12 +101,309 @@ func TestGetDeviceAttributes(t *testing.T) {
 }
 
 func TestGetDeviceConfig(t *testing.T) {
-	instance := &AzureInstance{
-		PlacementGroupID: "test-group",
-		VMSize:           "Standard_D4s_v3",
+	userns.Run(t, testGetDeviceConfig_Namespaced, syscall.CLONE_NEWNET)
+}
+
+func testGetDeviceConfig_Namespaced(t *testing.T) {
+	// Bring up loopback.
+	if err := netlink.LinkSetUp(&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "lo"}}); err != nil {
+		t.Fatalf("failed to bring lo up: %v", err)
 	}
-	got := instance.GetDeviceConfig(cloudprovider.DeviceIdentifiers{Name: "dev1"})
-	if got != nil {
-		t.Errorf("GetDeviceConfig() = %v, want nil", got)
+
+	// Create a dummy interface with a known MAC for the IPv6 test case.
+	mac, _ := net.ParseMAC("00:0d:3a:f8:06:ec")
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth1", HardwareAddr: mac}}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		t.Fatalf("failed to add dummy eth1: %v", err)
+	}
+	link, err := netlink.LinkByName("eth1")
+	if err != nil {
+		t.Fatalf("failed to look up eth1: %v", err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("failed to bring eth1 up: %v", err)
+	}
+
+	// Add an IPv6 address so the kernel accepts the route.
+	v6Addr, _ := netlink.ParseAddr("fda0:ad0a:cdcb:2000::5/64")
+	if err := netlink.AddrAdd(link, v6Addr); err != nil {
+		t.Fatalf("failed to add IPv6 address to eth1: %v", err)
+	}
+
+	// Install an IPv6 default route via a link-local gateway on eth1.
+	_, v6Default, _ := net.ParseCIDR("::/0")
+	gw := net.ParseIP("fe80::1234:5678:9abc")
+	if err := netlink.RouteAdd(&netlink.Route{
+		Family:    netlink.FAMILY_V6,
+		Dst:       v6Default,
+		Gw:        gw,
+		LinkIndex: link.Attrs().Index,
+		Table:     unix.RT_TABLE_MAIN,
+	}); err != nil {
+		t.Fatalf("failed to add IPv6 default route: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		instance *AzureInstance
+		id       cloudprovider.DeviceIdentifiers
+		want     *apis.NetworkConfig
+	}{
+		{
+			name: "no MAC returns nil",
+			instance: &AzureInstance{
+				PlacementGroupID: "test-group",
+				VMSize:           "Standard_D4s_v3",
+			},
+			id:   cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want: nil,
+		},
+		{
+			name: "MAC not found in interfaces returns nil",
+			instance: &AzureInstance{
+				VMSize: "Standard_D4s_v3",
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "001122334455",
+						IPv4: ipv4Config{
+							Subnet: []subnet{{Address: "10.0.0.0", Prefix: "24"}},
+						},
+					},
+				},
+			},
+			id:   cloudprovider.DeviceIdentifiers{MAC: "aa:bb:cc:dd:ee:ff"},
+			want: nil,
+		},
+		{
+			name: "IPv4 only - generates rules and routes",
+			instance: &AzureInstance{
+				VMSize: "Standard_D4s_v3",
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "001122334455",
+						IPv4: ipv4Config{
+							IPAddress: []ipv4Address{{PrivateIPAddress: "10.9.255.5"}},
+							Subnet:    []subnet{{Address: "10.9.255.0", Prefix: "24"}},
+						},
+					},
+				},
+			},
+			id: cloudprovider.DeviceIdentifiers{MAC: "00:11:22:33:44:55"},
+			want: &apis.NetworkConfig{
+				Rules: []apis.RuleConfig{
+					{Source: "10.9.255.0/24", Table: 100},
+				},
+				Routes: []apis.RouteConfig{
+					{Destination: "0.0.0.0/0", Gateway: "10.9.255.1", Table: 100},
+				},
+			},
+		},
+		{
+			name: "IPv4 and IPv6 - generates rules and routes for both",
+			instance: &AzureInstance{
+				VMSize: "Standard_ND128isr_GB300_v6",
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "000D3AF806EC",
+						IPv4: ipv4Config{
+							IPAddress: []ipv4Address{{PrivateIPAddress: "10.144.133.132"}},
+							Subnet:    []subnet{{Address: "10.144.133.128", Prefix: "26"}},
+						},
+						IPv6: ipv6Config{
+							IPAddress: []ipv6Address{{PrivateIPAddress: "fda0:ad0a:cdcb:2000::5"}},
+						},
+					},
+				},
+			},
+			id: cloudprovider.DeviceIdentifiers{Name: "eth1", MAC: "00:0d:3a:f8:06:ec"},
+			want: &apis.NetworkConfig{
+				Rules: []apis.RuleConfig{
+					{Source: "10.144.133.128/26", Table: 100},
+					{Source: "fda0:ad0a:cdcb:2000::5/128", Table: 100},
+				},
+				Routes: []apis.RouteConfig{
+					{Destination: "0.0.0.0/0", Gateway: "10.144.133.129", Table: 100},
+					{Destination: "::/0", Gateway: "fe80::1234:5678:9abc", Table: 100},
+				},
+			},
+		},
+		{
+			name: "second NIC gets table 101",
+			instance: &AzureInstance{
+				VMSize: "Standard_ND128isr_GB300_v6",
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "AABBCCDDEEFF",
+						IPv4: ipv4Config{
+							IPAddress: []ipv4Address{{PrivateIPAddress: "10.0.0.5"}},
+							Subnet:    []subnet{{Address: "10.0.0.0", Prefix: "24"}},
+						},
+					},
+					{
+						MacAddress: "000D3AF806EC",
+						IPv4: ipv4Config{
+							IPAddress: []ipv4Address{{PrivateIPAddress: "10.144.133.132"}},
+							Subnet:    []subnet{{Address: "10.144.133.128", Prefix: "26"}},
+						},
+					},
+				},
+			},
+			id: cloudprovider.DeviceIdentifiers{MAC: "00:0d:3a:f8:06:ec"},
+			want: &apis.NetworkConfig{
+				Rules: []apis.RuleConfig{
+					{Source: "10.144.133.128/26", Table: 101},
+				},
+				Routes: []apis.RouteConfig{
+					{Destination: "0.0.0.0/0", Gateway: "10.144.133.129", Table: 101},
+				},
+			},
+		},
+		{
+			name: "IPv6 with empty address is ignored",
+			instance: &AzureInstance{
+				VMSize: "Standard_D4s_v3",
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "001122334455",
+						IPv4: ipv4Config{
+							IPAddress: []ipv4Address{{PrivateIPAddress: "10.0.0.5"}},
+							Subnet:    []subnet{{Address: "10.0.0.0", Prefix: "24"}},
+						},
+						IPv6: ipv6Config{
+							IPAddress: []ipv6Address{{PrivateIPAddress: ""}},
+						},
+					},
+				},
+			},
+			id: cloudprovider.DeviceIdentifiers{MAC: "00:11:22:33:44:55"},
+			want: &apis.NetworkConfig{
+				Rules: []apis.RuleConfig{
+					{Source: "10.0.0.0/24", Table: 100},
+				},
+				Routes: []apis.RouteConfig{
+					{Destination: "0.0.0.0/0", Gateway: "10.0.0.1", Table: 100},
+				},
+			},
+		},
+		{
+			name: "MAC comparison is case-insensitive and separator-agnostic",
+			instance: &AzureInstance{
+				VMSize: "Standard_D4s_v3",
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "AABBCCDDEEFF",
+						IPv4: ipv4Config{
+							IPAddress: []ipv4Address{{PrivateIPAddress: "192.168.1.10"}},
+							Subnet:    []subnet{{Address: "192.168.1.0", Prefix: "24"}},
+						},
+					},
+				},
+			},
+			id: cloudprovider.DeviceIdentifiers{MAC: "aa:bb:cc:dd:ee:ff"},
+			want: &apis.NetworkConfig{
+				Rules: []apis.RuleConfig{
+					{Source: "192.168.1.0/24", Table: 100},
+				},
+				Routes: []apis.RouteConfig{
+					{Destination: "0.0.0.0/0", Gateway: "192.168.1.1", Table: 100},
+				},
+			},
+		},
+		{
+			name: "IPv6 link-local address is ignored",
+			instance: &AzureInstance{
+				VMSize: "Standard_D4s_v3",
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "001122334455",
+						IPv4: ipv4Config{
+							IPAddress: []ipv4Address{{PrivateIPAddress: "10.0.0.5"}},
+							Subnet:    []subnet{{Address: "10.0.0.0", Prefix: "24"}},
+						},
+						IPv6: ipv6Config{
+							IPAddress: []ipv6Address{{PrivateIPAddress: "fe80::1"}},
+						},
+					},
+				},
+			},
+			id: cloudprovider.DeviceIdentifiers{MAC: "00:11:22:33:44:55"},
+			want: &apis.NetworkConfig{
+				Rules: []apis.RuleConfig{
+					{Source: "10.0.0.0/24", Table: 100},
+				},
+				Routes: []apis.RouteConfig{
+					{Destination: "0.0.0.0/0", Gateway: "10.0.0.1", Table: 100},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.instance.GetDeviceConfig(tt.id)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("GetDeviceConfig() returned unexpected diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNormalizeMAC(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"00:11:22:33:44:55", "001122334455"},
+		{"001122334455", "001122334455"},
+		{"00-11-22-33-44-55", "001122334455"},
+		{"AA:BB:CC:DD:EE:FF", "aabbccddeeff"},
+		{"AABBCCDDEEFF", "aabbccddeeff"},
+	}
+	for _, tt := range tests {
+		got := normalizeMAC(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeMAC(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSubnetFirstAddress(t *testing.T) {
+	tests := []struct {
+		addr    string
+		prefix  string
+		want    string
+		wantErr bool
+	}{
+		{"10.9.255.0", "24", "10.9.255.1", false},
+		{"10.144.133.128", "26", "10.144.133.129", false},
+		{"192.168.0.0", "24", "192.168.0.1", false},
+		{"10.0.0.0", "8", "10.0.0.1", false},
+		{"10.0.2.0", "23", "10.0.2.1", false},
+		{"10.0.0.32", "27", "10.0.0.33", false},
+		// overflow
+		{"255.255.255.255", "32", "", true},
+		// subnet too small for gateway
+		{"10.4.5.6", "32", "", true},
+		// invalid: not a network base address
+		{"10.0.0.255", "24", "", true},
+		{"10.0.0.21", "27", "", true},
+		// non-IPv4
+		{"::1", "128", "", true},
+		// invalid inputs
+		{"invalid", "24", "", true},
+		{"", "24", "", true},
+		{"10.0.0.0", "", "", true},
+		{"", "", "", true},
+		{"10.0.0.0", "bad", "", true},
+	}
+	for _, tt := range tests {
+		got, err := subnetFirstAddress(tt.addr, tt.prefix)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("subnetFirstAddress(%q, %q) error = %v, wantErr %v", tt.addr, tt.prefix, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("subnetFirstAddress(%q, %q) = %q, want %q", tt.addr, tt.prefix, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
Implements `GetDeviceConfig` for the Azure cloud provider by fetching
network interface metadata from IMDS and generating policy routing
rules and routes for each device based on its MAC address.

## Changes

- Fetch network interface metadata from Azure IMDS (`/metadata/instance/network`)
  during instance initialization via `fetchNetworkInterfaces()`
- Implement `GetDeviceConfig()` to generate per-device `NetworkConfig` with
  IPv4 and IPv6 policy routing rules and routes derived from IMDS subnet info
- Match devices to IMDS interfaces using MAC address (case-insensitive,
  separator-agnostic)
- Skip IPv6 link-local addresses (fe80::/10) when generating IPv6 routes
- Add helper functions: `normalizeMAC`, `subnetFirstAddress`, `isIPv6LinkLocal`
- Add unit tests for changes introduced by this PR


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

```release-note
Add azure specific rules and routes to be configured for secondary nic.
```
