### PR TITLE
helm: default image tag to Chart.AppVersion

### DIFF
--- a/deployments/helm/dranet/templates/daemonset.yaml
+++ b/deployments/helm/dranet/templates/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
         {{- toYaml .Values.tolerations | nindent 8 }}
       containers:
         - name: dranet
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - /dranet

--- a/deployments/helm/dranet/values.yaml
+++ b/deployments/helm/dranet/values.yaml
@@ -3,7 +3,8 @@ fullnameOverride: ""
 
 image:
   repository: registry.k8s.io/networking/dranet
-  tag: stable
+  # tag defaults to .Chart.AppVersion when empty, which is set to the release tag at package time
+  tag: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
helm-package sets `--app-version $(HELM_TAG)` (example v0.1.0) which updates `Chart.appVersion` in the packaged chart. But the DaemonSet template uses `.Values.image.tag`, which is hardcoded to stable in values.yaml so the packaged chart still pulls the stable image. To fix this, use the Helm pattern by making `image.tag` default to  `.Chart.AppVersion` when not explicitly set.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Sorry for missing this earlier. Just came to realize while testing out few other things related to the driver. 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```