### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/cmd/dranetctl/app.go
+++ b/cmd/dranetctl/app.go
@@ -51,7 +51,17 @@ func main() {
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("v"))
 	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("logtostderr"))
+	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("legacy_stderr_threshold_behavior"))
+	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("stderrthreshold"))
 	err := pflag.CommandLine.Set("logtostderr", "true")
+	if err != nil {
+		klog.Fatal(err)
+	}
+	err = pflag.CommandLine.Set("legacy_stderr_threshold_behavior", "false")
+	if err != nil {
+		klog.Fatal(err)
+	}
+	err = pflag.CommandLine.Set("stderrthreshold", "INFO")
 	if err != nil {
 		klog.Fatal(err)
 	}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When `logtostderr` is set to `true` via `pflag`, klog's `stderrthreshold` flag is ignored due to a legacy default behavior in klog v2. This means all log levels (including INFO and DEBUG) are written to stderr, regardless of the `stderrthreshold` setting.

This PR opts into the fixed behavior introduced in [klog PR #432](https://github.com/kubernetes/klog/pull/432) by:
1. Exposing the `legacy_stderr_threshold_behavior` flag via pflag
2. Setting it to `false` to honor `stderrthreshold` when `logtostderr` is enabled

## Which issue(s) this PR fixes

Fixes a logging behavior issue where `stderrthreshold` was silently ignored.

## Special notes for your reviewer

The `legacy_stderr_threshold_behavior` flag was introduced in klog v2.140.0, which is already the version used by this project. Setting it to `false` opts into the corrected behavior where `stderrthreshold` is respected even when `logtostderr=true`.

Reference: https://github.com/kubernetes/klog/pull/432

> I have read the [contributing guidelines](https://github.com/kubernetes-sigs/dranet/blob/main/CONTRIBUTING.md) and this PR is compliant.
> This contribution is AI-assisted.