### PR TITLE
Group non-k8s dependency for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,15 @@ updates:
       k8s-deps:
         patterns:
           - "*k8s.io*"
+      non-k8s-deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "*k8s.io*"
     labels:
       - "area/dependency"
       - "ok-to-test"
+      - "release-note-none"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,6 +25,7 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+      - "release-note-none"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -27,3 +34,4 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+      - "release-note-none"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR makes dependabot group gomod dependency bumps for non-k8s libraries into a single PR, thereby reducing PR noise. This should be preferable for now. If need for having a different grouping shows up in the future, we can switch then.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```