### PR TITLE
prevent uplink child virtual function injected into pods

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -190,8 +190,8 @@ func (db *DB) Run(ctx context.Context) error {
 		db.cloudProviderHint = discoverCloudProvider(ctx)
 	}
 	db.instance = getInstanceProperties(ctx, db.cloudProviderHint)
-	db.gwInterfaces = getDefaultGwInterfaces()
-	klog.V(2).Infof("Default gateway interfaces: %v", db.gwInterfaces.UnsortedList())
+	db.gwInterfaces = getExcludedUplinkInterfaces()
+	klog.V(2).Infof("Excluded uplink interfaces and children: %v", db.gwInterfaces.UnsortedList())
 
 	for {
 		err := db.rateLimiter.Wait(ctx)
@@ -233,7 +233,7 @@ func (db *DB) scan() []resourceapi.Device {
 	for _, device := range devices {
 		ifName := device.Attributes[apis.AttrInterfaceName].StringValue
 		if ifName != nil && db.gwInterfaces.Has(string(*ifName)) {
-			klog.V(4).Infof("Ignoring interface %s from discovery since it is an uplink interface", *ifName)
+			klog.V(4).Infof("Ignoring interface %s from discovery since it is an uplink interface or a child of one", *ifName)
 			continue
 		}
 		filteredDevices = append(filteredDevices, device)

--- a/pkg/inventory/net.go
+++ b/pkg/inventory/net.go
@@ -127,44 +127,34 @@ func getExcludedUplinkInterfaces() sets.Set[string] {
 		return excluded
 	}
 
-	// Index links by their interface index so we can resolve MasterIndex
-	// lookups in O(1) and walk the hierarchy without re-querying netlink.
-	linksByIndex := make(map[int]netlink.Link, len(links))
-	nameByIndex := make(map[int]string, len(links))
+	// Build a parent-index -> children adjacency map in a single pass so we
+	// can cull whole families in one mutating walk instead of re-scanning the
+	// link list per level of nesting.
+	childrenOf := make(map[int][]netlink.Link)
+	var seeds []int
 	for _, l := range links {
-		idx := l.Attrs().Index
-		linksByIndex[idx] = l
-		nameByIndex[idx] = l.Attrs().Name
-	}
-
-	excludedIndices := sets.New[int]()
-	for idx, name := range nameByIndex {
-		if excluded.Has(name) {
-			excludedIndices.Insert(idx)
+		attrs := l.Attrs()
+		if attrs.MasterIndex != 0 {
+			childrenOf[attrs.MasterIndex] = append(childrenOf[attrs.MasterIndex], l)
+		}
+		if excluded.Has(attrs.Name) {
+			seeds = append(seeds, attrs.Index)
 		}
 	}
 
-	// Expand the excluded set by repeatedly walking the link list and adding
-	// any link whose master is already excluded. Stop once a full pass adds
-	// nothing new (handles nested hierarchies like vf -> vf-child -> uplink).
-	for {
-		added := false
-		for _, l := range links {
-			attrs := l.Attrs()
-			if excluded.Has(attrs.Name) {
-				continue
-			}
-			if attrs.MasterIndex == 0 {
-				continue
-			}
-			if excludedIndices.Has(attrs.MasterIndex) {
-				excluded.Insert(attrs.Name)
-				excludedIndices.Insert(attrs.Index)
-				added = true
-			}
+	// BFS from each excluded uplink through the adjacency map. Deleting the
+	// entry after visiting guarantees each child is processed at most once
+	// even if the hierarchy is deep (vf -> vf-child -> uplink).
+	for i := 0; i < len(seeds); i++ {
+		children, found := childrenOf[seeds[i]]
+		if !found {
+			continue
 		}
-		if !added {
-			break
+		delete(childrenOf, seeds[i])
+		for _, child := range children {
+			attrs := child.Attrs()
+			excluded.Insert(attrs.Name)
+			seeds = append(seeds, attrs.Index)
 		}
 	}
 

--- a/pkg/inventory/net.go
+++ b/pkg/inventory/net.go
@@ -117,7 +117,14 @@ func getDefaultGwInterfaces() sets.Set[string] {
 
 // getExcludedUplinkInterfaces returns the set of interface names that must be
 // excluded from the inventory: the active default-gateway uplinks plus every
-// netdev that is a descendant of one of those uplinks in the link hierarchy.
+// netdev that is a descendant of one of those uplinks. A child tied to a
+// parent through MasterIndex (bond/team slave, bridge port, VF enslaved to
+// its PF, ...) shares its forwarding state with that parent, so moving just
+// the child into a pod netns strands it from the parent that owns that
+// state; when the parent is the host's default-gw uplink this also degrades
+// host connectivity. There is no scenario where relocating only the child of
+// a default-gw uplink is correct, so the entire MasterIndex-linked subtree
+// rooted at each uplink should be excluded.
 func getExcludedUplinkInterfaces() sets.Set[string] {
 	excluded := getDefaultGwInterfaces()
 

--- a/pkg/inventory/net.go
+++ b/pkg/inventory/net.go
@@ -115,6 +115,62 @@ func getDefaultGwInterfaces() sets.Set[string] {
 	return interfaces
 }
 
+// getExcludedUplinkInterfaces returns the set of interface names that must be
+// excluded from the inventory: the active default-gateway uplinks plus every
+// netdev that is a descendant of one of those uplinks in the link hierarchy.
+func getExcludedUplinkInterfaces() sets.Set[string] {
+	excluded := getDefaultGwInterfaces()
+
+	links, err := nlwrap.LinkList()
+	if err != nil {
+		klog.Errorf("Failed to list links for uplink child exclusion: %v", err)
+		return excluded
+	}
+
+	// Index links by their interface index so we can resolve MasterIndex
+	// lookups in O(1) and walk the hierarchy without re-querying netlink.
+	linksByIndex := make(map[int]netlink.Link, len(links))
+	nameByIndex := make(map[int]string, len(links))
+	for _, l := range links {
+		idx := l.Attrs().Index
+		linksByIndex[idx] = l
+		nameByIndex[idx] = l.Attrs().Name
+	}
+
+	excludedIndices := sets.New[int]()
+	for idx, name := range nameByIndex {
+		if excluded.Has(name) {
+			excludedIndices.Insert(idx)
+		}
+	}
+
+	// Expand the excluded set by repeatedly walking the link list and adding
+	// any link whose master is already excluded. Stop once a full pass adds
+	// nothing new (handles nested hierarchies like vf -> vf-child -> uplink).
+	for {
+		added := false
+		for _, l := range links {
+			attrs := l.Attrs()
+			if excluded.Has(attrs.Name) {
+				continue
+			}
+			if attrs.MasterIndex == 0 {
+				continue
+			}
+			if excludedIndices.Has(attrs.MasterIndex) {
+				excluded.Insert(attrs.Name)
+				excludedIndices.Insert(attrs.Index)
+				added = true
+			}
+		}
+		if !added {
+			break
+		}
+	}
+
+	return excluded
+}
+
 func getTcFilters(link netlink.Link) ([]string, bool) {
 	isTcEBPF := false
 	filterNames := sets.Set[string]{}

--- a/pkg/inventory/net_test.go
+++ b/pkg/inventory/net_test.go
@@ -317,6 +317,30 @@ func testGetExcludedUplinkInterfaces_Namespaced(t *testing.T) {
 			},
 			expectedResult: sets.New[string]("br0"),
 		},
+		{
+			// macvlan links to its lower device through ParentIndex, not
+			// MasterIndex. It carries its own forwarding state and can be
+			// relocated into a pod netns without stranding the host uplink,
+			// so the exclusion walk (which follows MasterIndex) must leave
+			// it allocatable even when the parent is the default-gw uplink.
+			name: "Macvlan child of uplink stays allocatable",
+			setup: func(t *testing.T) {
+				uplink := addDummyUplink(t, "eth0", bridgeAddr, defaultIPv4, gwIPv4)
+				addMacvlanChild(t, "mv0", uplink.Attrs().Index)
+			},
+			expectedResult: sets.New[string]("eth0"),
+		},
+		{
+			// Same reasoning as the macvlan case. ipvlan is split into its
+			// own subtest because the kernel refuses to host both a macvlan
+			// and an ipvlan on the same lower device simultaneously.
+			name: "IPVlan child of uplink stays allocatable",
+			setup: func(t *testing.T) {
+				uplink := addDummyUplink(t, "eth0", bridgeAddr, defaultIPv4, gwIPv4)
+				addIPVlanChild(t, "iv0", uplink.Attrs().Index)
+			},
+			expectedResult: sets.New[string]("eth0"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -375,6 +399,82 @@ func addBridgeUplink(t *testing.T, name string, addr *netlink.Addr, defaultDst *
 		Table:     unix.RT_TABLE_MAIN,
 	}); err != nil {
 		t.Fatalf("failed to install default route via %s: %v", name, err)
+	}
+	return link
+}
+
+// addDummyUplink creates a dummy interface, assigns it an address, brings it
+// up, and installs an IPv4 default route through it so it looks like the
+// active default-gateway uplink. Used when we need a parent that can host
+// macvlan/ipvlan children (which attach via ParentIndex, not MasterIndex).
+func addDummyUplink(t *testing.T, name string, addr *netlink.Addr, defaultDst *net.IPNet, gw net.IP) netlink.Link {
+	t.Helper()
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		t.Fatalf("failed to add dummy uplink %s: %v", name, err)
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		t.Fatalf("failed to look up dummy uplink %s: %v", name, err)
+	}
+	if err := netlink.AddrAdd(link, addr); err != nil {
+		t.Fatalf("failed to add address to %s: %v", name, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("failed to set %s up: %v", name, err)
+	}
+	if err := netlink.RouteAdd(&netlink.Route{
+		Family:    netlink.FAMILY_V4,
+		Dst:       defaultDst,
+		Gw:        gw,
+		LinkIndex: link.Attrs().Index,
+		Priority:  100,
+		Table:     unix.RT_TABLE_MAIN,
+	}); err != nil {
+		t.Fatalf("failed to install default route via %s: %v", name, err)
+	}
+	return link
+}
+
+// addMacvlanChild creates a macvlan attached to parentIndex via ParentIndex.
+// MasterIndex stays zero, which is the distinction the exclusion walk relies
+// on to leave these children in the inventory.
+func addMacvlanChild(t *testing.T, name string, parentIndex int) netlink.Link {
+	t.Helper()
+	mv := &netlink.Macvlan{
+		LinkAttrs: netlink.LinkAttrs{Name: name, ParentIndex: parentIndex},
+		Mode:      netlink.MACVLAN_MODE_BRIDGE,
+	}
+	if err := netlink.LinkAdd(mv); err != nil {
+		t.Fatalf("failed to add macvlan %s: %v", name, err)
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		t.Fatalf("failed to look up macvlan %s: %v", name, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("failed to set %s up: %v", name, err)
+	}
+	return link
+}
+
+// addIPVlanChild creates an ipvlan attached to parentIndex via ParentIndex,
+// with MasterIndex left at zero for the same reason as addMacvlanChild.
+func addIPVlanChild(t *testing.T, name string, parentIndex int) netlink.Link {
+	t.Helper()
+	iv := &netlink.IPVlan{
+		LinkAttrs: netlink.LinkAttrs{Name: name, ParentIndex: parentIndex},
+		Mode:      netlink.IPVLAN_MODE_L2,
+	}
+	if err := netlink.LinkAdd(iv); err != nil {
+		t.Fatalf("failed to add ipvlan %s: %v", name, err)
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		t.Fatalf("failed to look up ipvlan %s: %v", name, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("failed to set %s up: %v", name, err)
 	}
 	return link
 }

--- a/pkg/inventory/net_test.go
+++ b/pkg/inventory/net_test.go
@@ -259,15 +259,6 @@ func TestGetExcludedUplinkInterfaces(t *testing.T) {
 	userns.Run(t, testGetExcludedUplinkInterfaces_Namespaced, syscall.CLONE_NEWNET)
 }
 
-// testGetExcludedUplinkInterfaces_Namespaced exercises getExcludedUplinkInterfaces
-// across the scenarios called out in UPLINK_CHILD_FILTERING_PLAN.md. Each
-// scenario creates a fresh topology inside the test-local netns and verifies
-// both the default-route uplink and any descendants are excluded.
-//
-// Bridges are used in place of the real Azure synthetic uplink because
-// netlink's MasterIndex relationship is what the helper keys on, and a bridge
-// master / dummy slave is the simplest way to reproduce that relationship
-// inside a netns test.
 func testGetExcludedUplinkInterfaces_Namespaced(t *testing.T) {
 	if err := netlink.LinkSetUp(&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "lo"}}); err != nil {
 		t.Fatalf("failed to bring lo up: %v", err)

--- a/pkg/inventory/net_test.go
+++ b/pkg/inventory/net_test.go
@@ -254,3 +254,180 @@ func testGetDefaultGwInterfaces_Namespaced(t *testing.T) {
 		})
 	}
 }
+
+func TestGetExcludedUplinkInterfaces(t *testing.T) {
+	userns.Run(t, testGetExcludedUplinkInterfaces_Namespaced, syscall.CLONE_NEWNET)
+}
+
+// testGetExcludedUplinkInterfaces_Namespaced exercises getExcludedUplinkInterfaces
+// across the scenarios called out in UPLINK_CHILD_FILTERING_PLAN.md. Each
+// scenario creates a fresh topology inside the test-local netns and verifies
+// both the default-route uplink and any descendants are excluded.
+//
+// Bridges are used in place of the real Azure synthetic uplink because
+// netlink's MasterIndex relationship is what the helper keys on, and a bridge
+// master / dummy slave is the simplest way to reproduce that relationship
+// inside a netns test.
+func testGetExcludedUplinkInterfaces_Namespaced(t *testing.T) {
+	if err := netlink.LinkSetUp(&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "lo"}}); err != nil {
+		t.Fatalf("failed to bring lo up: %v", err)
+	}
+
+	_, defaultIPv4, _ := net.ParseCIDR("0.0.0.0/0")
+	gwIPv4 := net.ParseIP("192.168.1.1")
+	bridgeAddr, _ := netlink.ParseAddr("192.168.1.2/24")
+
+	tests := []struct {
+		name           string
+		setup          func(t *testing.T)
+		expectedResult sets.Set[string]
+	}{
+		{
+			name: "Default-route uplink only",
+			setup: func(t *testing.T) {
+				addBridgeUplink(t, "br0", bridgeAddr, defaultIPv4, gwIPv4)
+			},
+			expectedResult: sets.New[string]("br0"),
+		},
+		{
+			name: "Uplink with one child VF",
+			setup: func(t *testing.T) {
+				br := addBridgeUplink(t, "br0", bridgeAddr, defaultIPv4, gwIPv4)
+				addChildDummy(t, "vf0", br.Attrs().Index)
+			},
+			expectedResult: sets.New[string]("br0", "vf0"),
+		},
+		{
+			name: "Recursive child relationship",
+			setup: func(t *testing.T) {
+				br := addBridgeUplink(t, "br0", bridgeAddr, defaultIPv4, gwIPv4)
+				// bond attached to the uplink bridge, then a dummy attached
+				// to the bond. This reproduces the vf -> vf-child -> uplink
+				// chain described in the plan. A bond is used as the
+				// intermediate link because the kernel rejects bridge-in-
+				// bridge nesting (ELOOP).
+				vf0 := addChildBond(t, "vf0", br.Attrs().Index)
+				addChildDummy(t, "vf0child", vf0.Attrs().Index)
+			},
+			expectedResult: sets.New[string]("br0", "vf0", "vf0child"),
+		},
+		{
+			name: "Unrelated secondary NIC is not excluded",
+			setup: func(t *testing.T) {
+				addBridgeUplink(t, "br0", bridgeAddr, defaultIPv4, gwIPv4)
+				// Standalone dummy with no master - must remain allocatable.
+				eth1 := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth1"}}
+				if err := netlink.LinkAdd(eth1); err != nil {
+					t.Fatalf("failed to add eth1: %v", err)
+				}
+				if err := netlink.LinkSetUp(eth1); err != nil {
+					t.Fatalf("failed to set eth1 up: %v", err)
+				}
+			},
+			expectedResult: sets.New[string]("br0"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Flush the main routing table and tear down any links from the
+			// previous subtest so each scenario starts from a clean netns.
+			routes, _ := netlink.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{Table: unix.RT_TABLE_MAIN}, netlink.RT_FILTER_TABLE)
+			for _, r := range routes {
+				if r.Dst == nil || r.Dst.IP.IsUnspecified() {
+					netlink.RouteDel(&r)
+				}
+			}
+			links, _ := netlink.LinkList()
+			for _, l := range links {
+				if l.Attrs().Name == "lo" {
+					continue
+				}
+				_ = netlink.LinkDel(l)
+			}
+
+			tt.setup(t)
+
+			got := getExcludedUplinkInterfaces()
+			if diff := cmp.Diff(tt.expectedResult, got); diff != "" {
+				t.Errorf("getExcludedUplinkInterfaces() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// addBridgeUplink creates a bridge, assigns it an address, brings it up, and
+// installs an IPv4 default route through it so it looks like the active
+// default-gateway uplink.
+func addBridgeUplink(t *testing.T, name string, addr *netlink.Addr, defaultDst *net.IPNet, gw net.IP) netlink.Link {
+	t.Helper()
+	br := &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: name}}
+	if err := netlink.LinkAdd(br); err != nil {
+		t.Fatalf("failed to add bridge %s: %v", name, err)
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		t.Fatalf("failed to look up bridge %s: %v", name, err)
+	}
+	if err := netlink.AddrAdd(link, addr); err != nil {
+		t.Fatalf("failed to add address to %s: %v", name, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("failed to set %s up: %v", name, err)
+	}
+	if err := netlink.RouteAdd(&netlink.Route{
+		Family:    netlink.FAMILY_V4,
+		Dst:       defaultDst,
+		Gw:        gw,
+		LinkIndex: link.Attrs().Index,
+		Priority:  100,
+		Table:     unix.RT_TABLE_MAIN,
+	}); err != nil {
+		t.Fatalf("failed to install default route via %s: %v", name, err)
+	}
+	return link
+}
+
+// addChildDummy creates a dummy interface and attaches it to the link at
+// masterIndex so it shows up with MasterIndex == masterIndex.
+func addChildDummy(t *testing.T, name string, masterIndex int) netlink.Link {
+	t.Helper()
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		t.Fatalf("failed to add dummy %s: %v", name, err)
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		t.Fatalf("failed to look up dummy %s: %v", name, err)
+	}
+	if err := netlink.LinkSetMasterByIndex(link, masterIndex); err != nil {
+		t.Fatalf("failed to attach %s to index %d: %v", name, masterIndex, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("failed to set %s up: %v", name, err)
+	}
+	return link
+}
+
+// addChildBond creates a bond attached to masterIndex so it can itself act
+// as a parent for a further descendant link. A bond is used here (rather
+// than a bridge) because the kernel refuses to nest a bridge inside another
+// bridge (ELOOP), but a bond can be enrolled as a bridge port.
+func addChildBond(t *testing.T, name string, masterIndex int) netlink.Link {
+	t.Helper()
+	bond := netlink.NewLinkBond(netlink.LinkAttrs{Name: name})
+	if err := netlink.LinkAdd(bond); err != nil {
+		t.Fatalf("failed to add bond %s: %v", name, err)
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		t.Fatalf("failed to look up bond %s: %v", name, err)
+	}
+	if err := netlink.LinkSetMasterByIndex(link, masterIndex); err != nil {
+		t.Fatalf("failed to attach bond %s to index %d: %v", name, masterIndex, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("failed to set %s up: %v", name, err)
+	}
+	return link
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug. 

#### What this PR does / why we need it:
This PR prevents `dranet` from treating RDMA-capable child interfaces of excluded uplinks as movable pod network devices.

On AKS, the default-route uplink (`eth0`) is excluded today, but its child VF (`enP63016s1`) can still be published in the `ResourceSlice`. When a pod claims that device, `dranet` tries to move the VF into the pod netns and pod sandbox creation fails.

#### Which issue(s) this PR is related to:
Fixes #175

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
dranet no longer injects child VFs attached to an excluded uplink as pod network interfaces.
```