### PR TITLE
Bump golang version to 1.26

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
   K8S_VERSION: "v1.34.0"
   KIND_VERSION: "v0.30.0"
   IMAGE_NAME: registry.k8s.io/networking/dranet

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
   K8S_VERSION: "v1.34.0"
   KIND_VERSION: "v0.30.0"
   IMAGE_NAME: registry.k8s.io/networking/dranet

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/dranet
 
-go 1.25.6
+go 1.26
 
 require (
 	cloud.google.com/go/compute v1.60.0

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -21,4 +21,4 @@ set -o pipefail
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 cd $REPO_ROOT
-docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.8.0 golangci-lint run -v
+docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.9.0 golangci-lint run -v


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency

#### What this PR does / why we need it:

Bumps Golang version to 1.26 in `go.mod` and GitHub workflows to prepare for Kubernetes 1.36 dependencies.

#### Which issue(s) this PR is related to:

Fixes #183