### PR TITLE
Mark NICs with shared IOMMU groups or default routes as vfio-unsafe

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -60,6 +60,7 @@ func (np *NetworkDriver) PublishResources(ctx context.Context) {
 		case devices := <-np.netdb.GetResources(ctx):
 			klog.V(3).Infof("Got %d devices from inventory: %s", len(devices), formatDeviceNames(devices, 15))
 			devices = filter.FilterDevices(np.celProgram, devices)
+			devices = filter.MarkVFIOUnsafe(devices)
 			klog.V(3).Infof("After filtering, publishing %d devices in ResourceSlice(s): %s", len(devices), formatDeviceNames(devices, 15))
 
 			np.publishResourcesPrometheusMetrics(devices)

--- a/pkg/filter/vfio_safety.go
+++ b/pkg/filter/vfio_safety.go
@@ -1,0 +1,171 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/klog/v2"
+)
+
+// MarkVFIOUnsafe annotates devices that cannot safely be used for VFIO
+// passthrough by setting dra.net/vfioUnsafe=true. This allows the
+// scheduler to still allocate them for non-VFIO use (bridge, macvlan)
+// while enabling claims to exclude them with a CEL selector.
+//
+// A device is marked unsafe if:
+//   - Its IOMMU group contains devices bound to different drivers
+//   - Its network interface carries the host's default route
+func MarkVFIOUnsafe(devices []resourcev1.Device) []resourcev1.Device {
+	defaultGW := defaultGatewayInterfaces()
+	for i := range devices {
+		pciAddr := getPCIAddr(&devices[i])
+		if pciAddr == "" {
+			continue
+		}
+		ifName := getIfName(&devices[i])
+
+		unsafe := false
+		reason := ""
+
+		if hasSharedIommuGroup(pciAddr) {
+			unsafe = true
+			reason = "shared IOMMU group"
+		} else if ifName != "" && defaultGW[ifName] {
+			unsafe = true
+			reason = "default gateway interface"
+		}
+
+		if unsafe {
+			klog.V(2).Infof("Marking %s (pci=%s, if=%s) as vfio-unsafe: %s",
+				devices[i].Name, pciAddr, ifName, reason)
+			val := true
+			if devices[i].Attributes == nil {
+				devices[i].Attributes = make(map[resourcev1.QualifiedName]resourcev1.DeviceAttribute)
+			}
+			devices[i].Attributes["dra.net/vfioUnsafe"] = resourcev1.DeviceAttribute{BoolValue: &val}
+			devices[i].Attributes["dra.net/vfioUnsafeReason"] = resourcev1.DeviceAttribute{StringValue: &reason}
+		}
+	}
+	return devices
+}
+
+func getPCIAddr(dev *resourcev1.Device) string {
+	if dev.Attributes == nil {
+		return ""
+	}
+	for _, key := range []resourcev1.QualifiedName{
+		"resource.kubernetes.io/pciBusID",
+		"dra.net/pciAddress",
+	} {
+		if attr, ok := dev.Attributes[key]; ok && attr.StringValue != nil {
+			return *attr.StringValue
+		}
+	}
+	return ""
+}
+
+func getIfName(dev *resourcev1.Device) string {
+	if dev.Attributes == nil {
+		return ""
+	}
+	if attr, ok := dev.Attributes["dra.net/ifName"]; ok && attr.StringValue != nil {
+		return *attr.StringValue
+	}
+	return ""
+}
+
+// hasSharedIommuGroup returns true if the PCI device's IOMMU group
+// contains other devices bound to a different kernel driver.
+func hasSharedIommuGroup(pciAddr string) bool {
+	groupLink := filepath.Join("/sys/bus/pci/devices", pciAddr, "iommu_group", "devices")
+	entries, err := os.ReadDir(groupLink)
+	if err != nil {
+		return false
+	}
+	if len(entries) <= 1 {
+		return false
+	}
+	for _, e := range entries {
+		if e.Name() == pciAddr {
+			continue
+		}
+		siblingDriver := filepath.Join("/sys/bus/pci/devices", e.Name(), "driver")
+		if target, err := os.Readlink(siblingDriver); err == nil {
+			driver := filepath.Base(target)
+			if driver != "vfio-pci" {
+				klog.V(4).Infof("IOMMU group sibling %s bound to %s (not vfio-pci)", e.Name(), driver)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// defaultGatewayInterfaces returns the set of interface names that carry
+// a default route (0.0.0.0/0 or ::/0). Reads /proc/1/net/route to access
+// the host's routing table when running inside a container.
+func defaultGatewayInterfaces() map[string]bool {
+	result := make(map[string]bool)
+
+	for _, path := range []string{"/proc/1/net/route", "/proc/net/route"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 8 {
+				continue
+			}
+			if fields[1] == "00000000" && fields[7] == "00000000" {
+				result[fields[0]] = true
+			}
+		}
+		break
+	}
+
+	for _, path := range []string{"/proc/1/net/ipv6_route", "/proc/net/ipv6_route"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 10 {
+				continue
+			}
+			if fields[0] == "00000000000000000000000000000000" && fields[1] == "00" {
+				result[fields[len(fields)-1]] = true
+			}
+		}
+		break
+	}
+
+	if len(result) > 0 {
+		names := make([]string, 0, len(result))
+		for k := range result {
+			names = append(names, k)
+		}
+		klog.V(2).Infof("Default gateway interfaces: %v", names)
+	}
+
+	return result
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `dra.net/vfioUnsafe` and `dra.net/vfioUnsafeReason` device attributes to NICs that cannot safely be used for VFIO passthrough:

- **Shared IOMMU group** — a sibling PCI device in the same IOMMU group is bound to a different driver. VFIO requires all devices in the group to be on vfio-pci, otherwise the kernel rejects the bind ("group is not viable").
- **Default gateway interface** — unbinding the NIC carrying the host's default route kills host connectivity.

Devices are annotated rather than removed so non-VFIO use cases (bridge, macvlan) still work. VM claims can exclude unsafe devices with a CEL selector:

```
!(has(device.attributes["dra.net"].vfioUnsafe) && device.attributes["dra.net"].vfioUnsafe)
```

Reads `/proc/1/net/route` for default gateway detection (accesses host PID 1's network namespace when running inside a container).

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes-sigs/dranet/issues/186

#### Special notes for your reviewer:

Observed on Dell XE8640: Broadcom `0000:02:00.1` shares IOMMU group 75 with management port `0000:02:00.0` (tg3 driver). Without this filter, the scheduler allocates the NIC, dranet binds it to vfio-pci, and QEMU fails with "vfio 0000:02:00.1: group 75 is not viable."

The annotation approach was chosen over filtering (removing devices) because the same NIC may be perfectly usable for non-VFIO modes like bridge or macvlan.

#### Does this PR introduce a user-facing change?

```release-note
Add dra.net/vfioUnsafe attribute to mark NICs with shared IOMMU groups or default gateway routes as unsafe for VFIO passthrough.
```