### PR TITLE
Fix postsubmit failure caused by Bats tests for metric server

### DIFF
--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -179,14 +179,17 @@ setup_tcx_filter() {
 }
 
 @test "test metric server is up and operating on host" {
-  output=$(kubectl \
-    run -i test-metrics \
+  # Run a temporary pod to access metrics
+  kubectl run test-metrics \
     --image registry.k8s.io/e2e-test-images/agnhost:2.54 \
     --overrides='{"spec": {"hostNetwork": true}}' \
     --restart=Never \
     --command \
-    -- sh -c "curl --silent localhost:9177/metrics | grep process_start_time_seconds >/dev/null && echo ok || echo fail")
-  assert_equal "$output" "ok"
+    -- sh -c "curl --silent localhost:9177/metrics | grep process_start_time_seconds >/dev/null && echo ok || echo fail"
+
+  # Wait for completion and verify output
+  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/test-metrics --timeout=5s
+  assert_equal "$(kubectl logs test-metrics)" "ok"
 }
 
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The [periodic postsubmit test](https://github.com/kubernetes-sigs/dranet/actions/workflows/periodics.yaml) has been failing for the Bats test [test metric server is up and operating on host](https://github.com/kubernetes-sigs/dranet/blob/main/tests/e2e.bats#L181). It is caused by a race condition where kubectl run -i terminates before streaming the output. This PR fixes it by replacing `kubectl run -i` with wait and log.

#### Which issue(s) this PR is related to:

N/A
