### PR TITLE
fix: Skip PCI network devices whose kernel driver is unbound

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -59,6 +59,12 @@ var (
 	// ignoredInterfaceNames is a set of network interface names that are typically
 	// created by CNI plugins or are otherwise not relevant for DRA resource exposure.
 	ignoredInterfaceNames = sets.New("cilium_net", "cilium_host", "docker0")
+
+	// nonNetdevDrivers is the set of well-known kernel drivers that bind
+	// to PCI network devices without creating a kernel netdev or RDMA link
+	// (userspace I/O and passthrough drivers). See
+	// isAllocatableNetworkDevice for why this list is used.
+	nonNetdevDrivers = sets.New("vfio-pci", "uio_pci_generic", "igb_uio", "pci-stub")
 )
 
 type DB struct {
@@ -280,6 +286,10 @@ func (db *DB) discoverPCIDevices() []resourceapi.Device {
 
 	for _, pciDev := range pci.Devices {
 		if !isNetworkDevice(pciDev) {
+			continue
+		}
+		if !isAllocatableNetworkDevice(pciDev) {
+			klog.Warningf("PCI network device %s is bound to driver %q which does not provide a netdev; not publishing it", pciDev.Address, pciDev.Driver)
 			continue
 		}
 		device := resourceapi.Device{
@@ -605,4 +615,32 @@ func (db *DB) GetRDMADeviceName(deviceName string) (string, error) {
 // https://pcisig.com/sites/default/files/files/PCI_Code-ID_r_1_11__v24_Jan_2019.pdf
 func isNetworkDevice(dev *ghw.PCIDevice) bool {
 	return dev.Class.ID == "02"
+}
+
+// isAllocatableNetworkDevice reports whether dranet can ever prepare this
+// PCI network device for a pod. A device that is allocatable is either
+// providing a kernel netdev or RDMA link in some namespace; a device that is
+// not has nothing dranet can move and would trap any pod allocated to it in
+// FailedPrepareDynamicResources.
+//
+// The natural test would be "does /sys/bus/pci/devices/$BDF/net have any
+// entries", but those entries are netns-tagged and only visible from the
+// namespace the netdev currently lives in (see the kernel's
+// Documentation/networking/sysfs-tagging.rst). A device whose netdev has
+// already been moved into a pod's namespace therefore looks identical from
+// the host to a device whose driver creates no netdev at all, and we must
+// keep publishing the former so Cluster Autoscaler can size new nodes from
+// the running ResourceSlice.
+//
+// The kernel driver bound at /sys/bus/pci/devices/$BDF/driver is the one
+// signal that distinguishes the two: it is not namespaced and stays bound
+// while the netdev is in another namespace. We treat the device as not
+// allocatable if no driver is bound, or if the bound driver is one of the
+// well-known userspace/passthrough drivers that never create a netdev or
+// RDMA link.
+func isAllocatableNetworkDevice(dev *ghw.PCIDevice) bool {
+	if dev.Driver == "" {
+		return false
+	}
+	return !nonNetdevDrivers.Has(dev.Driver)
 }

--- a/pkg/inventory/db_test.go
+++ b/pkg/inventory/db_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"testing"
+
+	"github.com/jaypipes/ghw"
+)
+
+func TestIsAllocatableNetworkDevice(t *testing.T) {
+	cases := []struct {
+		name   string
+		driver string
+		want   bool
+	}{
+		{name: "unbound", driver: "", want: false},
+		{name: "vfio passthrough", driver: "vfio-pci", want: false},
+		{name: "uio generic", driver: "uio_pci_generic", want: false},
+		{name: "dpdk uio", driver: "igb_uio", want: false},
+		{name: "pci stub", driver: "pci-stub", want: false},
+		{name: "gve", driver: "gve", want: true},
+		{name: "mlx5", driver: "mlx5_core", want: true},
+		{name: "virtio", driver: "virtio_net", want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dev := &ghw.PCIDevice{Driver: tc.driver}
+			if got := isAllocatableNetworkDevice(dev); got != tc.want {
+				t.Errorf("isAllocatableNetworkDevice(driver=%q) = %v, want %v", tc.driver, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

**Symptom**

If a privileged workload unbinds a secondary NIC from its kernel driver while the device is allocated to it, dranet enters a permanent pod-trap on that node:

* `discoverPCIDevices()` still sees the PCI device (it never left the bus) and publishes it in the ResourceSlice with PCI-only attributes.
* The scheduler keeps allocating the device to new pods.
* `NodePrepareResources` for those pods fails every time with `device pci-… has no interface name in local store`, because there is no netdev for `GetNetInterfaceName()` to return.
* Pods sit forever in `Init` with `FailedPrepareDynamicResources`. Only a node reboot recovers.

**Minimal repro**

1. Schedule a privileged pod that holds a `dra.net` / `netdev.google.com` device claim.
2. Inside that pod: `echo 0000:00:09.0 > /sys/bus/pci/drivers/gve/unbind` (substitute the claimed device's BDF).
3. Delete the pod.
4. Schedule another pod with the same device class.

The new pod is permanently stuck:

```
Warning  FailedPrepareDynamicResources  ...  claim default/...: device pci-0000-00-09-0 has no interface name in local store
```

while the ResourceSlice still lists `pci-0000-00-09-0`:

```
dra_hooks.go:60] Got 4 devices from inventory: ..., pci-0000-00-09-0, pci-0000-00-0a-0
dra_hooks.go:62] After filtering, publishing 2 devices in ResourceSlice(s): pci-0000-00-09-0, pci-0000-00-0a-0
```

**Fix**

`ghw` already reports the bound kernel driver for each PCI device (via `readlink /sys/bus/pci/devices/$BDF/driver`). In `discoverPCIDevices()`, skip devices whose driver is either unbound (`""`) or one of the well-known non-netdev drivers (`vfio-pci`, `uio_pci_generic`, `igb_uio`, `pci-stub`). Those devices have no kernel netdev or RDMA link anywhere and can never be prepared, so they should not be advertised.

This changes the failure mode from "pod trap" to "device unschedulable": the bad device drops out of the ResourceSlice, the scheduler routes new claims to remaining devices on this or other nodes, and the node degrades by one NIC instead of becoming a black hole.

A device that has merely been moved into a pod's network namespace is **not** affected: its original NIC driver (`gve`, `mlx5_core`, …) stays bound, so it continues to be published with PCI-only attributes exactly as today. The Cluster Autoscaler template behaviour from https://github.com/google/dranet/issues/178 / https://github.com/google/dranet/pull/194 is preserved. IB-only RDMA devices likewise keep their NIC driver bound and are unaffected.

**Manual recovery (workaround for current releases)**

For anyone hitting this on an existing release, a privileged `hostNetwork` pod can rebind the driver without a reboot:

```sh
BDF=0000:00:09.0
echo gve > /sys/bus/pci/devices/$BDF/driver_override
echo $BDF > /sys/bus/pci/drivers_probe
echo ""  > /sys/bus/pci/devices/$BDF/driver_override
```

dranet's next inventory scan then republishes the device with its `ifName` attribute and pods schedule normally.

#### Which issue(s) this PR is related to:

Observed on GKE image `dranet:v1.0.1-gke.0`, git `bb7e8b7af0c571b9e474981064e26ad9dc85c21f` from the now-archived `google/dranet`; the relevant code is unchanged on `kubernetes-sigs/dranet@main`.

Related design discussion: https://github.com/google/dranet/issues/97, https://github.com/google/dranet/issues/178

#### Special notes for your reviewer:

Things deliberately left out of this PR as follow-ups:

* **Self-heal in `GetNetInterfaceName`**: when a BDF is found with the wrong/no driver, write `driver_override` + `drivers_probe` to recover automatically before failing the prepare. Left out because it writes to host sysfs and is a policy decision (a workload may have unbound the driver intentionally for the lifetime of the node).
* **Kubernetes Event on lost device**: dranet has no `EventRecorder` plumbed today; wiring one is a separate change.
* **Re-key the local store by BDF instead of `ifName`**: after a `gve` rebind the kernel can hand out a different interface name (`eth1` ↔ `eth2` swap observed), so even a workload that correctly rebinds on exit can confuse the interface-name-keyed cleanup. Larger refactor; noted here as a known limitation.

**Downstream**: the affected build (`v1.0.1-gke.0`) is a GKE-shipped image built from the archived `google/dranet`. If GKE builds from a separate branch, this fix will need backporting there in addition to `main` here.

**Testing**: `GOOS=linux go build ./...`, `go vet ./...`, and `golangci-lint run ./...` (v2) pass. Added `TestIsAllocatableNetworkDevice` for the new helper. The remaining `inventory` tests require Linux to execute (netlink); deferring to CI.

#### Does this PR introduce a user-facing change?

```release-note
PCI network devices whose kernel driver has been unbound or replaced with a userspace driver (vfio-pci, uio_pci_generic, igb_uio, pci-stub) are no longer published in the ResourceSlice. Previously such devices were published but every NodePrepareResources call for them failed, trapping pods in FailedPrepareDynamicResources.
```
