### PR TITLE
Fix typos: priviledge, directoy, lenght in docs and Dockerfile

### DIFF
--- a/Dockerfile.perftest
+++ b/Dockerfile.perftest
@@ -80,7 +80,7 @@ RUN apt-get update && \
 # mpi-operator mounts the .ssh folder from a Secret. For that to work, we need
 # https://github.com/kubeflow/mpi-operator/issues/580
 ARG port=2222
-# Add priviledge separation directoy to run sshd as root.
+# Add privilege separation directory to run sshd as root.
 RUN mkdir -p /var/run/sshd
 # Add capability to run sshd as non-root.
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/sshd

--- a/pkg/driver/ebpf.go
+++ b/pkg/driver/ebpf.go
@@ -88,7 +88,7 @@ func unpinBPFPrograms(ifName string) error {
 		if err != nil {
 			klog.Infof("fail to unpin bpf link %v", err)
 		} else {
-			klog.V(2).Infof("succesfully unpin bpf from link %d", linkInfo.ID)
+			klog.V(2).Infof("successfully unpin bpf from link %d", linkInfo.ID)
 		}
 		return nil
 	})

--- a/site/content/docs/concepts/linux-network-interfaces.md
+++ b/site/content/docs/concepts/linux-network-interfaces.md
@@ -205,7 +205,7 @@ As you can see in the list above, I just moved one physical interface to a netwo
 ## Alternative Names
 
 Linux [added in 2019 the capability to set alternative names on network interfaces](https://patchwork.ozlabs.org/project/netdev/cover/20190930094820.11281-1-jiri@resnulli.us/#2269624), mainly to avoid the
-current lenght limitation
+current length limitation
 
 ```sh
  ip link property add dev DEVICE [ altname NAME .. ]


### PR DESCRIPTION
Fixes three doc typos: "priviledge" -> "privilege" and "directoy" -> "directory" in Dockerfile.perftest comment, and "lenght" -> "length" in linux-network-interfaces docs.