### PR TITLE
ci: declare contents: read on bats, helm-lint, periodics, test

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -17,6 +17,9 @@ env:
   IMAGE_NAME: registry.k8s.io/networking/dranet
   KIND_CLUSTER_NAME: kind
 
+permissions:
+  contents: read
+
 jobs:
   bats_tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'deployments/helm/**'
 
+permissions:
+  contents: read
+
 jobs:
   helm-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/periodics.yaml
+++ b/.github/workflows/periodics.yaml
@@ -19,6 +19,9 @@ on:
     # Runs daily at 03:00 UTC
     - cron: '0 3 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   bats_tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Pins the default `GITHUB_TOKEN` to read-only on the four workflows that hadn't declared scope. All four are read-only CI:

- `bats.yml`: bats e2e against a kind cluster.
- `helm-lint.yml`: `make helm-lint`.
- `periodics.yaml`: daily scheduled bats run.
- `test.yaml`: unit tests.

None of them call the GitHub API or write to the repo, so `contents: read` at workflow scope is sufficient. The fifth workflow in this directory (`e2e.yml`) already declares its own `permissions:` block, so this PR brings the rest of the directory in line.

Background: GitHub's default `GITHUB_TOKEN` is `read/write` unless the org/repo policy or the workflow itself restricts it. Declaring the minimum scope per-file limits blast radius if a third-party action is ever compromised (cf. CVE-2025-30066 `tj-actions/changed-files`) and lets the OpenSSF Scorecard `Token-Permissions` check pass per-file. YAML validated locally with `yaml.safe_load`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Three-line diff per file, no logic changes. Workflows still run with the same effective scopes for everything they actually do.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```