### PR TITLE
chore: drop unnecessary helm installation during workflow

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -4,15 +4,13 @@ on:
     branches: [ main ]
     paths:
       - 'deployments/helm/**'
+      - '.github/workflows/helm-lint.yml'
 
 jobs:
   helm-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: Run Helm lint
         run: make helm-lint


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
According to https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md, Helm is already pre baked into the image. Thus, drop unnecessary step of Helm binary installation.

#### Which issue(s) this PR is related to:
"N/A".

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
"NONE"
```