### PR TITLE
POC: implement IP address allocation based on provided IP range

### DIFF
--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -48,6 +48,10 @@ type InterfaceConfig struct {
 	// to be assigned to the interface.
 	Addresses []string `json:"addresses,omitempty"`
 
+	// IPRange is the IP range (CIDR) from which to allocate an IP address
+	// for this interface.
+	IPRange string `json:"ipRange,omitempty"`
+
 	// DHCP, if true, indicates that the interface should be configured via DHCP.
 	// This is mutually exclusive with the 'addresses' field.
 	DHCP *bool `json:"dhcp,omitempty"`

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -154,6 +154,7 @@ func (g *GCEInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) ma
 // GetDeviceConfig fetches any infrastructure-specific network configuration
 // required by the device. Returning nil means no specific config is needed.
 func (g *GCEInstance) GetDeviceConfig(id cloudprovider.DeviceIdentifiers) *apis.NetworkConfig {
+	// POC TODO: Fetch the actual IP range assigned to this interface and return it in apis.NetworkConfig.Interface.IPRange.
 	return nil
 }
 

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -275,9 +275,15 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			deviceCfg.NetworkInterfaceConfigInPod.Interface.Name = ifName
 		}
 
-		// If DHCP is requested, do a DHCP request to gather the network parameters (IPs and Routes)
-		// ... but we DO NOT apply them in the root namespace
-		if deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP != nil && *deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP {
+		// POC: experimental IPAM takes over IP allocation logic when enabled.
+		const pocIpamEnabled = true
+		podIPs := make(map[types.UID]string)
+
+		if pocIpamEnabled {
+			var ipamErrors []error
+			podIPs, ipamErrors = np.allocateIPsForPods(netconf.Interface.IPRange, podUIDs, result.Device)
+			errorList = append(errorList, ipamErrors...)
+		} else if deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP != nil && *deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP {
 			klog.V(2).Infof("trying to get network configuration via DHCP")
 			contextCancel, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
@@ -398,7 +404,14 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 		// TODO: support for multiple pods sharing the same device
 		// we'll create the subinterface here
 		for _, uid := range podUIDs {
-			if err := np.podConfigStore.SetDeviceConfig(uid, result.Device, deviceCfg); err != nil {
+			// Create a per-pod copy of the device config.
+			// Pods share the base device config but need their own unique IP addresses.
+			podDeviceCfg := deviceCfg
+			if ip, ok := podIPs[uid]; ok {
+				// Assign the pod-specific IP address.
+				podDeviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses = []string{ip}
+			}
+			if err := np.podConfigStore.SetDeviceConfig(uid, result.Device, podDeviceCfg); err != nil {
 				errorList = append(errorList, fmt.Errorf("failed to persist device config for pod %s device %s: %v", uid, result.Device, err))
 			}
 		}
@@ -412,6 +425,33 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 		}
 	}
 	return kubeletplugin.PrepareResult{}
+}
+
+// allocateIPsForPods allocates IPs for a list of pod UIDs from a given IP range.
+func (np *NetworkDriver) allocateIPsForPods(ipRange string, podUIDs []types.UID, deviceName string) (map[types.UID]string, []error) {
+	podIPs := make(map[types.UID]string)
+	var errorList []error
+
+	if ipRange == "" {
+		errorList = append(errorList, fmt.Errorf("POC: IP range is empty for device %s", deviceName))
+		return podIPs, errorList
+	}
+
+	dbPath := np.dbPath
+	if dbPath == "" {
+		dbPath = "ipconf.db"
+	}
+	for _, uid := range podUIDs {
+		ip, err := GetIPFromRange(ipRange, string(uid), dbPath)
+		if err != nil {
+			errorList = append(errorList, fmt.Errorf("POC: failed to allocate IP for pod %s: %v", uid, err))
+			continue
+		}
+		klog.V(2).Infof("POC: Successfully allocated IP %s for pod %s", ip.String(), uid)
+		podIPs[uid] = ip.String()
+	}
+
+	return podIPs, errorList
 }
 
 func (np *NetworkDriver) UnprepareResourceClaims(ctx context.Context, claims []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {

--- a/pkg/driver/dra_hooks_ipconf_test.go
+++ b/pkg/driver/dra_hooks_ipconf_test.go
@@ -1,0 +1,100 @@
+package driver
+
+import (
+	"net/netip"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestAllocateIPsForPods(t *testing.T) {
+	tests := []struct {
+		name       string
+		ipRange    string
+		podUIDs    []types.UID
+		deviceName string
+		wantErr    bool
+		wantCount  int // Expected number of allocated IPs
+	}{
+		{
+			name:       "Valid IPv6 allocation for single pod",
+			ipRange:    "2001:db8::/64",
+			podUIDs:    []types.UID{"pod-1"},
+			deviceName: "device-1",
+			wantErr:    false,
+			wantCount:  1,
+		},
+		{
+			name:       "Valid IPv4 allocation for multiple pods",
+			ipRange:    "192.168.1.0/24",
+			podUIDs:    []types.UID{"pod-2", "pod-3"},
+			deviceName: "device-2",
+			wantErr:    false,
+			wantCount:  2,
+		},
+		{
+			name:       "Empty IP range",
+			ipRange:    "",
+			podUIDs:    []types.UID{"pod-4"},
+			deviceName: "device-3",
+			wantErr:    true,
+			wantCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Initialize the driver with a unique temporary DB to ensure test isolation.
+			np := &NetworkDriver{
+				dbPath: filepath.Join(t.TempDir(), "ipconf_test.db"),
+			}
+
+			// Execute the IP allocation logic for the given pods.
+			podIPs, errors := np.allocateIPsForPods(tt.ipRange, tt.podUIDs, tt.deviceName)
+
+			// Verify that the error status matches the expectation.
+			if (len(errors) > 0) != tt.wantErr {
+				t.Errorf("allocateIPsForPods() errors = %v, wantErr %v", errors, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				// Verify that the number of allocated IPs matches the expected count.
+				if len(podIPs) != tt.wantCount {
+					t.Errorf("Expected %d allocated IPs, got %d", tt.wantCount, len(podIPs))
+				}
+
+				// Parse the CIDR prefix to validate allocated IPs against it.
+				cidr, _ := netip.ParsePrefix(tt.ipRange)
+				seenIPs := make(map[string]bool)
+
+				// Iterate through each pod to validate its allocated IP.
+				for _, uid := range tt.podUIDs {
+					ipStr, ok := podIPs[uid]
+					if !ok {
+						t.Errorf("Expected IP for pod %s, but not found", uid)
+						continue
+					}
+
+					addr, err := netip.ParseAddr(ipStr)
+					if err != nil {
+						t.Errorf("Failed to parse allocated IP %s: %v", ipStr, err)
+						continue
+					}
+
+					// Verify that the allocated IP falls within the expected range.
+					if !cidr.Contains(addr) {
+						t.Errorf("Allocated IP %s is not in range %s", ipStr, tt.ipRange)
+					}
+
+					// Verify isolation: different pods should get different IPs
+					if seenIPs[ipStr] {
+						t.Errorf("Duplicate IP allocated: %s", ipStr)
+					}
+					seenIPs[ipStr] = true
+				}
+			}
+		})
+	}
+}

--- a/pkg/driver/ipconf.go
+++ b/pkg/driver/ipconf.go
@@ -1,0 +1,234 @@
+// This file implements a stateful IPAM allocator backed by bbolt.
+// The core allocation logic is adapted from the kindnet project:
+// https://github.com/kubernetes-sigs/kindnet/blob/main/cmd/cni-kindnet/netconf.go
+//
+// This file also introduces GetIPFromRange to provide a simplified "one-key" allocation
+// interface for the DRANET driver.
+
+package driver
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"net/netip"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+var (
+	ipconfBucketName = []byte("ip_allocations")
+)
+
+// Allocator manages IP address allocation from a given CIDR range,
+// persisting state in a bbolt database.
+type Allocator struct {
+	cidr     netip.Prefix
+	ipFirst  netip.Addr
+	ipLast   netip.Addr
+	size     uint64
+	reserved int
+	db       *bolt.DB
+}
+
+// NewAllocator creates a new Allocator for the given CIDR and DB path.
+func NewAllocator(cidr netip.Prefix, dbPath string) (*Allocator, error) {
+	var size uint64
+	hostsBits := cidr.Addr().BitLen() - cidr.Bits()
+	if hostsBits >= 64 {
+		size = math.MaxInt64
+	} else {
+		size = uint64(1) << uint(hostsBits)
+	}
+	size = size - 1 // skip network address
+
+	reserved := 6
+	if size <= 64 {
+		reserved = 2
+	} else if size <= 128 {
+		reserved = 4
+	}
+
+	ipFirst := cidr.Masked().Addr().Next()
+	ipFirst, err := addOffsetAddress(ipFirst, uint64(reserved))
+	if err != nil {
+		return nil, err
+	}
+
+	ipLast, err := broadcastAddress(cidr)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		return nil, fmt.Errorf("open ipconf db: %w", err)
+	}
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(ipconfBucketName)
+		return err
+	})
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("initialize ipconf db bucket: %w", err)
+	}
+
+	return &Allocator{
+		cidr:     cidr,
+		size:     size,
+		reserved: reserved,
+		ipFirst:  ipFirst,
+		ipLast:   ipLast,
+		db:       db,
+	}, nil
+}
+
+// Close closes the underlying database.
+func (a *Allocator) Close() error {
+	return a.db.Close()
+}
+
+func (a *Allocator) ipExists(tx *bolt.Tx, ip netip.Addr) bool {
+	bucket := tx.Bucket(ipconfBucketName)
+	if bucket == nil {
+		return false
+	}
+	return bucket.Get([]byte(ip.String())) != nil
+}
+
+func (a *Allocator) ipInsert(tx *bolt.Tx, ip netip.Addr, id string) error {
+	bucket := tx.Bucket(ipconfBucketName)
+	if bucket == nil {
+		return fmt.Errorf("bucket not found")
+	}
+	return bucket.Put([]byte(ip.String()), []byte(id))
+}
+
+// Allocate finds and allocates a free IP address for the given ID.
+func (a *Allocator) Allocate(id string) (netip.Addr, error) {
+	rangeSize := a.size - uint64(a.reserved)
+	var offset uint64
+	switch {
+	case rangeSize >= math.MaxInt64:
+		offset = rand.Uint64()
+	case rangeSize == 0:
+		return netip.Addr{}, fmt.Errorf("not available addresses")
+	default:
+		offset = uint64(rand.Int63n(int64(rangeSize)))
+	}
+
+	var allocatedIP netip.Addr
+	err := a.db.Update(func(tx *bolt.Tx) error {
+		iterator := ipIterator(a.ipFirst, a.ipLast, offset)
+		for {
+			ip := iterator()
+			if !ip.IsValid() {
+				break
+			}
+			if a.ipExists(tx, ip) {
+				continue
+			}
+			err := a.ipInsert(tx, ip, id)
+			if err != nil {
+				return err
+			}
+			allocatedIP = ip
+			return nil
+		}
+		return fmt.Errorf("allocator full")
+	})
+
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	return allocatedIP, nil
+}
+
+// ipIterator allows to iterate over all the IP addresses
+// in a range defined by the start and last address.
+func ipIterator(first netip.Addr, last netip.Addr, offset uint64) func() netip.Addr {
+	modulo := func(addr netip.Addr) netip.Addr {
+		if addr.Compare(last) == 1 {
+			return first
+		}
+		return addr
+	}
+	next := func(addr netip.Addr) netip.Addr {
+		return modulo(addr.Next())
+	}
+	start, err := addOffsetAddress(first, offset)
+	if err != nil {
+		return func() netip.Addr { return netip.Addr{} }
+	}
+	start = modulo(start)
+	ip := start
+	seen := false
+	return func() netip.Addr {
+		value := ip
+		if value == start {
+			if seen {
+				return netip.Addr{}
+			}
+			seen = true
+		}
+		ip = next(ip)
+		return value
+	}
+}
+
+func broadcastAddress(subnet netip.Prefix) (netip.Addr, error) {
+	base := subnet.Masked().Addr()
+	bytes := base.AsSlice()
+	n := 8*len(bytes) - subnet.Bits()
+	for i := len(bytes) - 1; i >= 0 && n > 0; i-- {
+		if n >= 8 {
+			bytes[i] = 0xff
+			n -= 8
+		} else {
+			mask := ^uint8(0) >> (8 - n)
+			bytes[i] |= mask
+			break
+		}
+	}
+	addr, ok := netip.AddrFromSlice(bytes)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", bytes)
+	}
+	return addr, nil
+}
+
+func addOffsetAddress(address netip.Addr, offset uint64) (netip.Addr, error) {
+	addressBytes := address.AsSlice()
+	addressBig := big.NewInt(0).SetBytes(addressBytes)
+	r := big.NewInt(0).Add(addressBig, big.NewInt(int64(offset))).Bytes()
+	lenDiff := len(addressBytes) - len(r)
+	if lenDiff > 0 {
+		r = append(make([]byte, lenDiff), r...)
+	} else if lenDiff < 0 {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", r)
+	}
+	addr, ok := netip.AddrFromSlice(r)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", r)
+	}
+	return addr, nil
+}
+
+// GetIPFromRange is a wrapper function that achieves "one-key" IP allocation from a specified range.
+func GetIPFromRange(cidrStr string, id string, dbPath string) (netip.Addr, error) {
+	cidr, err := netip.ParsePrefix(cidrStr)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("invalid cidr %s: %w", cidrStr, err)
+	}
+
+	alloc, err := NewAllocator(cidr, dbPath)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	defer alloc.Close()
+
+	return alloc.Allocate(id)
+}


### PR DESCRIPTION
## Summary
This POC introduces a stateful IP allocator for the DRANET IPVLAN implementation POC. It showcases the overall structure for assigning IP addresses to pods in a given IP range, which provides a baseline of IP allocation for IPVLAN implementation and NIC sharing.

## Key Changes
- **`pkg/apis/types.go`**: Introduces new field `IPRange` in struct `InterfaceConfig`.
- **`pkg/driver/ipconf.go`**: Core logic for IP allocator. It generates a valid IP address in a given range.
  -  It's mostly adapted from [kindnet project](https://github.com/kubernetes-sigs/kindnet/blob/main/cmd/cni-kindnet/netconf.go). 
  - It uses `bbolt` for IP tracking.
  - The `GetIPFromRange` method wraps the allocation process for `dra_hook` to call.
- **`pkg/driver/dra_hooks.go`**: Integrates new IPAM logic into `prepareResourceClaim` as POC.
  - It extracts the IPAM logic into `allocateIPsForPods` to allocate IPs for pods in the claim.
  - It generates `podDeviceCfg` for each pod, with shared device config and unique IP address.
- **`pkg/driver/dra_hooks_ipconf_test.go`**: Unit tests covering IPv4/IPv6 allocation, error handling, and isolation verification for `allocateIPsForPods`. 
- **`pkg/cloudprovider/gce/gce.go`**: Added placeholder TODO for retrieving IP range from GCE.

