### PR TITLE
docs: update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ Install the latest stable version of DRANET using the provided manifest:
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/dranet/refs/heads/main/install.yaml
 ```
 
-To install using the Helm chart from a local tree:
+or using the Helm chart:
 
 ```sh
-helm upgrade --install dranet ./deployments/helm/dranet -n kube-system
+helm install -n kube-system dranet oci://registry.k8s.io/networking/charts/dranet --version v1.3.0
 ```
 
 For available configuration options, see the [chart README](deployments/helm/dranet/README.md).


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Promote latest (and first) published Helm chart as the primary install method and move the raw manifest to a legacy fallback.

The chart is already in the production registry:
```
skopeo list-tags docker://registry.k8s.io/networking/dranet
[9:37 AM]skopeo list-tags docker://registry.k8s.io/networking/charts/dranet
{
    "Repository": "[registry.k8s.io/networking/charts/dranet](http://registry.k8s.io/networking/charts/dranet)",
    "Tags": [
        "v1.3.0"
    ]
}
```
and quick installation test passed to test artifact pulling worked fine

```
helm install dranet oci://registry.k8s.io/networking/charts/dranet --version v1.3.0
Pulled: [registry.k8s.io/networking/charts/dranet:v1.3.0](http://registry.k8s.io/networking/charts/dranet:v1.3.0)
Digest: sha256:762b9725c1dc45727741372b2c6188ef145f5809785500a1d575c6950891fec3
NAME: dranet
LAST DEPLOYED: Fri May 29 06:38:53 2026
NAMESPACE: default
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
```

#### Which issue(s) this PR is related to:
"N/A".

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```