### PR TITLE
address illegal SR-IOV VF MTU configuration

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -275,6 +275,24 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			deviceCfg.NetworkInterfaceConfigInPod.Interface.Name = ifName
 		}
 
+		// For SR-IOV VFs, check that the requested MTU does not exceed the parent PF's MTU.
+		// If it does, log an error and fail the Pod creation to avoid silent misconfiguration.
+		if deviceCfg.NetworkInterfaceConfigInPod.Interface.MTU != nil {
+			if pfName, err := inventory.GetPFInterfaceName(ifName); err == nil {
+				if pfLink, err := nlHandle.LinkByName(pfName); err == nil {
+					pfMTU := pfLink.Attrs().MTU
+					requestedMTU := int(*deviceCfg.NetworkInterfaceConfigInPod.Interface.MTU)
+					if requestedMTU > pfMTU {
+						klog.Errorf("requested MTU %d for SR-IOV VF %s exceeds parent PF %s MTU %d",
+							requestedMTU, ifName, pfName, pfMTU)
+						errorList = append(errorList, fmt.Errorf("requested MTU %d for SR-IOV VF %s exceeds parent PF %s MTU %d",
+							requestedMTU, ifName, pfName, pfMTU))
+						continue
+					}
+				}
+			}
+		}
+
 		// If DHCP is requested, do a DHCP request to gather the network parameters (IPs and Routes)
 		// ... but we DO NOT apply them in the root namespace
 		if deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP != nil && *deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP {

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -275,20 +275,25 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			deviceCfg.NetworkInterfaceConfigInPod.Interface.Name = ifName
 		}
 
-		// For SR-IOV VFs, check that the requested MTU does not exceed the parent PF's MTU.
-		// If it does, log an error and fail the Pod creation to avoid silent misconfiguration.
+		// For SR-IOV VFs, the requested MTU must not exceed the parent PF's MTU.
+		// Otherwise the claim is rejected so the Pod fails fast instead of being
+		// created with an illegal MTU configuration.
 		if deviceCfg.NetworkInterfaceConfigInPod.Interface.MTU != nil {
-			if pfName, err := inventory.GetPFInterfaceName(ifName); err == nil {
-				if pfLink, err := nlHandle.LinkByName(pfName); err == nil {
-					pfMTU := pfLink.Attrs().MTU
-					requestedMTU := int(*deviceCfg.NetworkInterfaceConfigInPod.Interface.MTU)
-					if requestedMTU > pfMTU {
-						klog.Errorf("requested MTU %d for SR-IOV VF %s exceeds parent PF %s MTU %d",
-							requestedMTU, ifName, pfName, pfMTU)
-						errorList = append(errorList, fmt.Errorf("requested MTU %d for SR-IOV VF %s exceeds parent PF %s MTU %d",
-							requestedMTU, ifName, pfName, pfMTU))
-						continue
-					}
+			pfName, err := inventory.GetPFInterfaceName(ifName)
+			if err != nil {
+				// Not an SR-IOV VF, or the parent PF cannot be determined. This is
+				// expected for regular interfaces, so skip the check and only log it.
+				klog.V(4).Infof("skipping SR-IOV VF MTU check for interface %s: %v", ifName, err)
+			} else {
+				pfLink, err := nlHandle.LinkByName(pfName)
+				if err != nil {
+					errorList = append(errorList, fmt.Errorf("failed to get netlink to parent PF %s of VF %s: %v", pfName, ifName, err))
+					continue
+				}
+				requestedMTU := int(*deviceCfg.NetworkInterfaceConfigInPod.Interface.MTU)
+				if err := validateVFMTU(ifName, pfName, requestedMTU, pfLink.Attrs().MTU); err != nil {
+					errorList = append(errorList, err)
+					continue
 				}
 			}
 		}
@@ -515,6 +520,17 @@ func buildRDMAConfig(rdmaDevName string, charDevices sets.Set[string]) RDMAConfi
 		}
 	}
 	return cfg
+}
+
+// validateVFMTU returns an error if the MTU requested for an SR-IOV VF exceeds
+// the parent PF's MTU, which is an illegal configuration. vfName and pfName are
+// only used to build a descriptive error message.
+func validateVFMTU(vfName, pfName string, requestedMTU, pfMTU int) error {
+	if requestedMTU > pfMTU {
+		return fmt.Errorf("requested MTU %d for SR-IOV VF %s exceeds parent PF %s MTU %d",
+			requestedMTU, vfName, pfName, pfMTU)
+	}
+	return nil
 }
 
 // getRuleInfo lists all IP rules in the host network namespace and groups them

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -278,23 +278,21 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 		// For SR-IOV VFs, the requested MTU must not exceed the parent PF's MTU.
 		// Otherwise the claim is rejected so the Pod fails fast instead of being
 		// created with an illegal MTU configuration.
-		if deviceCfg.NetworkInterfaceConfigInPod.Interface.MTU != nil {
+		if deviceCfg.NetworkInterfaceConfigInPod.Interface.MTU != nil && inventory.IsSriovVf(ifName) {
 			pfName, err := inventory.GetPFInterfaceName(ifName)
 			if err != nil {
-				// Not an SR-IOV VF, or the parent PF cannot be determined. This is
-				// expected for regular interfaces, so skip the check and only log it.
-				klog.V(4).Infof("skipping SR-IOV VF MTU check for interface %s: %v", ifName, err)
-			} else {
-				pfLink, err := nlHandle.LinkByName(pfName)
-				if err != nil {
-					errorList = append(errorList, fmt.Errorf("failed to get netlink to parent PF %s of VF %s: %v", pfName, ifName, err))
-					continue
-				}
-				requestedMTU := int(*deviceCfg.NetworkInterfaceConfigInPod.Interface.MTU)
-				if err := validateVFMTU(ifName, pfName, requestedMTU, pfLink.Attrs().MTU); err != nil {
-					errorList = append(errorList, err)
-					continue
-				}
+				errorList = append(errorList, fmt.Errorf("failed to determine parent PF for SR-IOV VF %s: %v", ifName, err))
+				continue
+			}
+			pfLink, err := nlHandle.LinkByName(pfName)
+			if err != nil {
+				errorList = append(errorList, fmt.Errorf("failed to get netlink to parent PF %s of VF %s: %v", pfName, ifName, err))
+				continue
+			}
+			requestedMTU := int(*deviceCfg.NetworkInterfaceConfigInPod.Interface.MTU)
+			if err := validateVFMTU(ifName, pfName, requestedMTU, pfLink.Attrs().MTU); err != nil {
+				errorList = append(errorList, err)
+				continue
 			}
 		}
 

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -307,18 +307,8 @@ func TestValidateVFMTU(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := validateVFMTU("eth1", "eth0", tc.requestedMTU, tc.pfMTU)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("validateVFMTU() expected error, got nil")
-				}
-				want := fmt.Sprintf("requested MTU %d for SR-IOV VF eth1 exceeds parent PF eth0 MTU %d", tc.requestedMTU, tc.pfMTU)
-				if err.Error() != want {
-					t.Errorf("validateVFMTU() error = %q, want %q", err.Error(), want)
-				}
-				return
-			}
-			if err != nil {
-				t.Errorf("validateVFMTU() unexpected error: %v", err)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateVFMTU() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
 	}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -276,3 +276,50 @@ func TestPublishResourcesMetrics(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateVFMTU(t *testing.T) {
+	testCases := []struct {
+		name         string
+		requestedMTU int
+		pfMTU        int
+		wantErr      bool
+	}{
+		{
+			name:         "requested MTU below PF MTU is allowed",
+			requestedMTU: 1500,
+			pfMTU:        9000,
+			wantErr:      false,
+		},
+		{
+			name:         "requested MTU equal to PF MTU is allowed",
+			requestedMTU: 9000,
+			pfMTU:        9000,
+			wantErr:      false,
+		},
+		{
+			name:         "requested MTU above PF MTU is rejected",
+			requestedMTU: 9000,
+			pfMTU:        1500,
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateVFMTU("eth1", "eth0", tc.requestedMTU, tc.pfMTU)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("validateVFMTU() expected error, got nil")
+				}
+				want := fmt.Sprintf("requested MTU %d for SR-IOV VF eth1 exceeds parent PF eth0 MTU %d", tc.requestedMTU, tc.pfMTU)
+				if err.Error() != want {
+					t.Errorf("validateVFMTU() error = %q, want %q", err.Error(), want)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("validateVFMTU() unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/inventory/sysfs.go
+++ b/pkg/inventory/sysfs.go
@@ -112,6 +112,29 @@ func isSriovVf(name string, syspath string) bool {
 	return info.Mode()&os.ModeSymlink != 0
 }
 
+// getPFInterfaceNameFromSysfs returns the name of the Physical Function (PF) network
+// interface for a given SR-IOV Virtual Function (VF) interface, using basePath as the
+// root of the sysfs net directory (e.g. /sys/class/net). It returns an error if the
+// interface is not a VF or if the PF interface cannot be determined.
+func getPFInterfaceNameFromSysfs(basePath, vfName string) (string, error) {
+	pfNetPath := filepath.Join(basePath, vfName, "device", "physfn", "net")
+	entries, err := os.ReadDir(pfNetPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read PF net directory for VF %s: %w", vfName, err)
+	}
+	if len(entries) == 0 {
+		return "", fmt.Errorf("no PF interface found for VF %s", vfName)
+	}
+	return entries[0].Name(), nil
+}
+
+// GetPFInterfaceName returns the name of the Physical Function (PF) network interface
+// for a given SR-IOV Virtual Function (VF) interface. It returns an error if the
+// interface is not a VF or if the PF interface cannot be determined.
+func GetPFInterfaceName(vfName string) (string, error) {
+	return getPFInterfaceNameFromSysfs(sysnetPath, vfName)
+}
+
 // GetRdmaDevice returns the RDMA device name for a given network interface by
 // first checking GetRdmaDeviceForNetdevice. If rdmamap fails, it falls back to
 // checking the sysfs infiniband directory. This serves as a workaround for

--- a/pkg/inventory/sysfs.go
+++ b/pkg/inventory/sysfs.go
@@ -112,6 +112,11 @@ func isSriovVf(name string, syspath string) bool {
 	return info.Mode()&os.ModeSymlink != 0
 }
 
+// IsSriovVf reports whether a network interface is a SR-IOV Virtual Function.
+func IsSriovVf(name string) bool {
+	return isSriovVf(name, sysnetPath)
+}
+
 // getPFInterfaceNameFromSysfs returns the name of the Physical Function (PF) network
 // interface for a given SR-IOV Virtual Function (VF) interface, using basePath as the
 // root of the sysfs net directory (e.g. /sys/class/net). It returns an error if the

--- a/pkg/inventory/sysfs_test.go
+++ b/pkg/inventory/sysfs_test.go
@@ -190,6 +190,93 @@ func TestIsSriovVf(t *testing.T) {
 	})
 }
 
+func TestGetPFInterfaceNameFromSysfs(t *testing.T) {
+	testCases := []struct {
+		name        string
+		vfName      string
+		setupFunc   func(t *testing.T, baseDir string)
+		want        string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "VF with single PF interface",
+			vfName: "eth1",
+			setupFunc: func(t *testing.T, baseDir string) {
+				t.Helper()
+				pfNetDir := filepath.Join(baseDir, "eth1", "device", "physfn", "net", "eth0")
+				if err := os.MkdirAll(pfNetDir, 0o755); err != nil {
+					t.Fatalf("failed to create PF net directory: %v", err)
+				}
+			},
+			want:    "eth0",
+			wantErr: false,
+		},
+		{
+			name:   "not a VF - physfn directory missing",
+			vfName: "eth2",
+			setupFunc: func(t *testing.T, baseDir string) {
+				t.Helper()
+				deviceDir := filepath.Join(baseDir, "eth2", "device")
+				if err := os.MkdirAll(deviceDir, 0o755); err != nil {
+					t.Fatalf("failed to create device directory: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: "failed to read PF net directory for VF eth2",
+		},
+		{
+			name:   "physfn net directory exists but is empty",
+			vfName: "eth3",
+			setupFunc: func(t *testing.T, baseDir string) {
+				t.Helper()
+				pfNetDir := filepath.Join(baseDir, "eth3", "device", "physfn", "net")
+				if err := os.MkdirAll(pfNetDir, 0o755); err != nil {
+					t.Fatalf("failed to create PF net directory: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: "no PF interface found for VF eth3",
+		},
+		{
+			name:   "interface does not exist",
+			vfName: "nonexistent",
+			setupFunc: func(t *testing.T, baseDir string) {
+				// Do not create anything
+			},
+			wantErr:     true,
+			errContains: "failed to read PF net directory for VF nonexistent",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tc.setupFunc(t, tmpDir)
+
+			got, err := getPFInterfaceNameFromSysfs(tmpDir, tc.vfName)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("getPFInterfaceNameFromSysfs() expected error, got nil")
+					return
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("getPFInterfaceNameFromSysfs() error = %v, want error containing %q", err, tc.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("getPFInterfaceNameFromSysfs() unexpected error: %v", err)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("getPFInterfaceNameFromSysfs() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestGetRdmaDeviceFromSysfs tests the getRdmaDeviceFromSysfs function
 func TestGetRdmaDeviceFromSysfs(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

MTU can be configured via opaque.parameters.interface.mtu.
However, for SR-IOV VFs, it is currently possible to set an MTU larger than the parent PF’s MTU due to the lack of validation.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #178 

#### Special notes for your reviewer:

The example output below shows the case where validation fails. An error is logged, and the Pod remains in the ContainerCreating state.

```
Events:
  Type     Reason                         Age   From               Message
  ----     ------                         ----  ----               -------
  Normal   Scheduled                      8s    default-scheduler  Successfully assigned default/pod-a-2-mlnx-nomac to eagle04
  Warning  FailedPrepareDynamicResources  7s    kubelet            Failed to prepare dynamic resources: prepare dynamic resources: NodePrepareResources failed for ResourceClaim vf-rc-a-2: claim 21c6d996-0dfe-43d7-a88d-846db605d4d8 contain errors: requested MTU 1600 for SR-IOV VF ens1f0v1 exceeds parent PF ens1f0np0 MTU 1500
kanda-masaharu@eagle04:~/work/repo/dci-community-team/k8s_demo/sriov_vf_test_dranet/pods$ k get pod pod-a-2-mlnx-nomac
NAME                 READY   STATUS              RESTARTS   AGE
pod-a-2-mlnx-nomac   0/1     ContainerCreating   0          55s
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an issue where SR-IOV VF MTU could be configured larger than the MTU of its parent PF. Such configurations are now rejected.
```