### PR TITLE
Remove multiple pods sharing one claim in prepareResourceClaim

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -144,19 +144,25 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 	defer func() {
 		klog.V(2).Infof("PrepareResourceClaim Claim %s/%s  took %v", claim.Namespace, claim.Name, time.Since(start))
 	}()
-	// TODO: shared devices may allocate the same device to multiple pods, i.e. macvlan, ipvlan, ...
-	podUIDs := []types.UID{}
-	for _, reserved := range claim.Status.ReservedFor {
-		if reserved.Resource != "pods" || reserved.APIGroup != "" {
-			klog.Infof("Driver only supports Pods, unsupported reference %#v", reserved)
-			continue
-		}
-		podUIDs = append(podUIDs, reserved.UID)
-	}
-	if len(podUIDs) == 0 {
+	if len(claim.Status.ReservedFor) == 0 {
 		klog.Infof("no pods allocated to claim %s/%s", claim.Namespace, claim.Name)
 		return kubeletplugin.PrepareResult{}
 	}
+	if len(claim.Status.ReservedFor) > 1 {
+		return kubeletplugin.PrepareResult{
+			Err: fmt.Errorf("driver only supports one pod per claim, got %d", len(claim.Status.ReservedFor)),
+		}
+	}
+
+	// One ResourceClaim is consumed by a single pod, regardless of whether the device is allocated in
+	// exclusive or shared (e.g., ipvlan, macvlan) way, so we process the first and only consumer in ReservedFor.
+	reserved := claim.Status.ReservedFor[0]
+	if reserved.Resource != "pods" || reserved.APIGroup != "" {
+		return kubeletplugin.PrepareResult{
+			Err: fmt.Errorf("driver only supports Pods, unsupported reference %#v", reserved),
+		}
+	}
+	podUID := reserved.UID
 
 	nlHandle, err := nlwrap.NewHandle()
 	if err != nil {
@@ -247,12 +253,10 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 				continue
 			}
 			deviceCfg.RDMADevice = buildRDMAConfig(rdmaDevName, charDevices)
-			for _, uid := range podUIDs {
-				if err := np.podConfigStore.SetDeviceConfig(uid, result.Device, deviceCfg); err != nil {
-					errorList = append(errorList, fmt.Errorf("failed to persist device config for pod %s device %s: %v", uid, result.Device, err))
-				}
+			if err := np.podConfigStore.SetDeviceConfig(podUID, result.Device, deviceCfg); err != nil {
+				errorList = append(errorList, fmt.Errorf("failed to persist device config for pod %s device %s: %v", podUID, result.Device, err))
 			}
-			klog.V(4).Infof("IB-only claim resources for pods %v : %#v", podUIDs, deviceCfg)
+			klog.V(4).Infof("IB-only claim resources for pod %s : %#v", podUID, deviceCfg)
 			continue
 		}
 
@@ -395,14 +399,10 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			}
 		}
 
-		// TODO: support for multiple pods sharing the same device
-		// we'll create the subinterface here
-		for _, uid := range podUIDs {
-			if err := np.podConfigStore.SetDeviceConfig(uid, result.Device, deviceCfg); err != nil {
-				errorList = append(errorList, fmt.Errorf("failed to persist device config for pod %s device %s: %v", uid, result.Device, err))
-			}
+		if err := np.podConfigStore.SetDeviceConfig(podUID, result.Device, deviceCfg); err != nil {
+			errorList = append(errorList, fmt.Errorf("failed to persist device config for pod %s device %s: %v", podUID, result.Device, err))
 		}
-		klog.V(4).Infof("Claim Resources for pods %v : %#v", podUIDs, deviceCfg)
+		klog.V(4).Infof("Claim Resources for pod %s : %#v", podUID, deviceCfg)
 	}
 
 	if len(errorList) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Previously `prepareResourceClaim` implements the iteration over pods reserved for a single claim. This is a preparation work for the scenario where a single claim could be shared among multiple pods, when they're claiming a shared device. Currently this logic is never used since shared device hasn't been introduced yet.

Our finalized design came out that even in shared device scenarios, each pod will get its own distinct ResourceClaim, and the driver handles subinterface creation per claim. Therefore this iteration over multiple pods becomes redundant.

This change removes this logic to simply the preparation logic given this design. 

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
- Add 1:1 pod-to-claim enforcement
  - Previously the driver allows preparing resource for a claim reserved by multiple pods (in rare and anti-pattern case when they are created simultaneously with the same claim).
  - Now it fails the preparation if the reserved reference is larger than one.
- Non-pod fail-fast
  - Previously a claim containing single non-pod reference would succeed silently.
  - Now it fails resourceClaim preparation with the validation error.
```