### PR TITLE
feat: plumb EventRecorder and emit failure events

### DIFF
--- a/deployments/helm/dranet/templates/rbac.yaml
+++ b/deployments/helm/dranet/templates/rbac.yaml
@@ -13,6 +13,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
       - resource.k8s.io
     resources:
       - resourceslices

--- a/install.yaml
+++ b/install.yaml
@@ -24,6 +24,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
       - "resource.k8s.io"
     resources:
       - resourceslices

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/sys/unix"
 	"sigs.k8s.io/dranet/internal/nlwrap"
 
+	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -440,9 +441,11 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 	}
 
 	if len(errorList) > 0 {
-		klog.Infof("claim %s contain errors: %v", claim.UID, errors.Join(errorList...))
+		joinedErr := errors.Join(errorList...)
+		klog.Infof("claim %s contain errors: %v", claim.UID, joinedErr)
+		np.eventRecorder.Eventf(claim, v1.EventTypeWarning, "ClaimPrepareFailed", "%v", joinedErr)
 		return kubeletplugin.PrepareResult{
-			Err: fmt.Errorf("claim %s contain errors: %w", claim.UID, errors.Join(errorList...)),
+			Err: fmt.Errorf("claim %s contain errors: %w", claim.UID, joinedErr),
 		}
 	}
 	return kubeletplugin.PrepareResult{}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -22,18 +22,20 @@ import (
 	"strings"
 	"testing"
 
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/webhook"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 )
 
 func TestPublishResourcesPrometheusMetrics(t *testing.T) {
@@ -148,8 +150,9 @@ func TestPrepareResourceClaimsMetrics(t *testing.T) {
 		draPluginRequestsLatencySeconds.Reset()
 
 		np := &NetworkDriver{
-			netdb:      newFakeInventoryDB(),
-			driverName: "test.driver",
+			netdb:         newFakeInventoryDB(),
+			driverName:    "test.driver",
+			eventRecorder: record.NewFakeRecorder(100),
 		}
 
 		claims := []*resourcev1.ResourceClaim{
@@ -244,6 +247,57 @@ func TestUnprepareResourceClaimsMetrics(t *testing.T) {
 			t.Fatalf("CollectAndCompare failed: %v", err)
 		}
 	})
+}
+
+func TestClaimPrepareFailedEvent(t *testing.T) {
+	ctx := context.Background()
+	fakeRecorder := record.NewFakeRecorder(10)
+
+	np := &NetworkDriver{
+		netdb:          newFakeInventoryDB(),
+		driverName:     "test.driver",
+		eventRecorder:  fakeRecorder,
+		podConfigStore: mustNewPodConfigStore(),
+	}
+
+	claims := []*resourcev1.ResourceClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-claim",
+				Namespace: "default",
+				UID:       "claim-uid-1",
+			},
+			Status: resourcev1.ResourceClaimStatus{
+				ReservedFor: []resourcev1.ResourceClaimConsumerReference{
+					{APIGroup: "", Resource: "pods", Name: "test-pod", UID: "pod-uid-1"},
+				},
+				Allocation: &resourcev1.AllocationResult{
+					Devices: resourcev1.DeviceAllocationResult{
+						Results: []resourcev1.DeviceRequestAllocationResult{
+							{Driver: "test.driver", Device: "device-does-not-exist"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	res, err := np.PrepareResourceClaims(ctx, claims)
+	if err != nil {
+		t.Fatalf("PrepareResourceClaims returned unexpected error: %v", err)
+	}
+	if res["claim-uid-1"].Err == nil {
+		t.Fatal("expected per-claim error, got none")
+	}
+
+	select {
+	case event := <-fakeRecorder.Events:
+		if !strings.Contains(event, "ClaimPrepareFailed") {
+			t.Errorf("expected ClaimPrepareFailed event, got: %s", event)
+		}
+	default:
+		t.Error("expected a ClaimPrepareFailed event to be emitted, but none was received")
+	}
 }
 
 func TestPublishResourcesMetrics(t *testing.T) {
@@ -405,6 +459,7 @@ func TestDynamicProfiles(t *testing.T) {
 			netdb:          fakeDB,
 			driverName:     "test.driver",
 			podConfigStore: mustNewPodConfigStore(),
+			eventRecorder:  record.NewFakeRecorder(100),
 		}
 
 		claims := []*resourcev1.ResourceClaim{
@@ -454,6 +509,7 @@ func TestDynamicProfiles(t *testing.T) {
 			netdb:          fakeDB,
 			driverName:     "test.driver",
 			podConfigStore: mustNewPodConfigStore(),
+			eventRecorder:  record.NewFakeRecorder(100),
 		}
 
 		claims := []*resourcev1.ResourceClaim{
@@ -549,6 +605,7 @@ func TestDynamicProfiles(t *testing.T) {
 			netdb:          fakeDB,
 			driverName:     "test.driver",
 			podConfigStore: mustNewPodConfigStore(),
+			eventRecorder:  record.NewFakeRecorder(100),
 		}
 
 		claims := []*resourcev1.ResourceClaim{
@@ -594,15 +651,15 @@ func TestGetDeviceNetworkConfigWithWebhook(t *testing.T) {
 	ctx := context.Background()
 
 	testCases := []struct {
-		name               string
-		userConf           *apis.NetworkConfig
-		cloudConfResponse  *apis.NetworkConfig
-		profileResponse    *apis.NetworkConfig
-		profileStatusCode  int
-		expectedError      bool
-		expectedAddresses  []string
-		expectedMTU        int32
-		expectedProfile    string
+		name              string
+		userConf          *apis.NetworkConfig
+		cloudConfResponse *apis.NetworkConfig
+		profileResponse   *apis.NetworkConfig
+		profileStatusCode int
+		expectedError     bool
+		expectedAddresses []string
+		expectedMTU       int32
+		expectedProfile   string
 	}{
 		{
 			name:              "No configurations provided",
@@ -620,7 +677,7 @@ func TestGetDeviceNetworkConfigWithWebhook(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Cloud configuration only",
+			name:     "Cloud configuration only",
 			userConf: &apis.NetworkConfig{},
 			cloudConfResponse: &apis.NetworkConfig{
 				Interface: apis.InterfaceConfig{MTU: ptr.To[int32](1500)},
@@ -640,7 +697,7 @@ func TestGetDeviceNetworkConfigWithWebhook(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Profile configuration adds IP address",
+			name:     "Profile configuration adds IP address",
 			userConf: &apis.NetworkConfig{},
 			cloudConfResponse: &apis.NetworkConfig{
 				Profile: "cloud-profile",
@@ -676,7 +733,7 @@ func TestGetDeviceNetworkConfigWithWebhook(t *testing.T) {
 			expectedError:     false,
 		},
 		{
-			name: "Webhook blocks Profile configuration",
+			name:     "Webhook blocks Profile configuration",
 			userConf: &apis.NetworkConfig{},
 			cloudConfResponse: &apis.NetworkConfig{
 				Profile: "cloud-profile",
@@ -796,4 +853,3 @@ func TestGetDeviceNetworkConfigWithWebhook(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -31,9 +31,13 @@ import (
 	"github.com/containerd/nri/pkg/stub"
 	"sigs.k8s.io/dranet/internal/nlwrap"
 
+	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	"k8s.io/klog/v2"
@@ -93,11 +97,12 @@ func WithDBPath(path string) Option {
 }
 
 type NetworkDriver struct {
-	driverName string
-	nodeName   string
-	kubeClient kubernetes.Interface
-	draPlugin  pluginHelper
-	nriPlugin  stub.Stub
+	draPlugin     pluginHelper
+	driverName    string
+	eventRecorder record.EventRecorder
+	nodeName      string
+	nriPlugin     stub.Stub
+	kubeClient    kubernetes.Interface
 
 	// contains the host interfaces
 	netdb      inventoryDB
@@ -124,12 +129,18 @@ func Start(ctx context.Context, driverName string, kubeClient kubernetes.Interfa
 		klog.Infof("RDMA subsystem in mode: %s", rdmaNetnsMode)
 	}
 
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: driverName, Host: nodeName})
+
 	plugin := &NetworkDriver{
 		driverName:     driverName,
 		nodeName:       nodeName,
 		kubeClient:     kubeClient,
 		rdmaSharedMode: rdmaNetnsMode == apis.RdmaNetnsModeShared,
 		clock:          clock.RealClock{},
+		eventRecorder:  eventRecorder,
 	}
 
 	for _, o := range opts {

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/containerd/nri/pkg/api"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -176,6 +177,8 @@ func (np *NetworkDriver) runPodSandbox(_ context.Context, pod *api.PodSandbox, p
 		// Block 1: netdev operations — only when a network interface is present.
 		if ifName != "" {
 			if err := attachNetdevToNS(pod, ns, deviceName, config, resourceClaimStatusDevice); err != nil {
+				np.eventRecorder.Eventf(podObjectRef(pod), v1.EventTypeWarning, "NetworkDeviceAttachFailed",
+					"failed to attach network device %s to pod %s/%s: %v", deviceName, pod.GetNamespace(), pod.GetName(), err)
 				return err
 			}
 		}
@@ -185,6 +188,8 @@ func (np *NetworkDriver) runPodSandbox(_ context.Context, pod *api.PodSandbox, p
 		// for RoCE (netdev + RDMA) it runs after the netdev block above.
 		if !np.rdmaSharedMode && config.RDMADevice.LinkDev != "" {
 			if err := attachRdmaToNS(config.RDMADevice.LinkDev, ns, resourceClaimStatusDevice); err != nil {
+				np.eventRecorder.Eventf(podObjectRef(pod), v1.EventTypeWarning, "RDMADeviceAttachFailed",
+					"failed to attach RDMA device %s to pod %s/%s: %v", config.RDMADevice.LinkDev, pod.GetNamespace(), pod.GetName(), err)
 				return err
 			}
 		}
@@ -466,4 +471,14 @@ func getNetworkNamespace(pod *api.PodSandbox) string {
 
 func podKey(pod *api.PodSandbox) string {
 	return fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName())
+}
+
+// NRI gives us *api.PodSandbox while we need *v1.Pod for the Eventf.
+// As such, we construct the minimal *v1.Pod object reference needed for the event.
+func podObjectRef(pod *api.PodSandbox) *v1.Pod {
+	p := &v1.Pod{}
+	p.Name = pod.GetName()
+	p.Namespace = pod.GetNamespace()
+	p.UID = types.UID(pod.GetUid())
+	return p
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/nri/pkg/api"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/inventory"
 )
@@ -166,6 +167,7 @@ func TestRunPodSandboxUsesPersistedConfigAfterRestart(t *testing.T) {
 	np := &NetworkDriver{
 		podConfigStore: storeAfterRestart,
 		netdb:          inventory.New(),
+		eventRecorder:  record.NewFakeRecorder(100),
 	}
 	pod := &api.PodSandbox{
 		Uid:       string(podUID),
@@ -407,9 +409,8 @@ func TestRunPodSandboxMetrics(t *testing.T) {
 			np := &NetworkDriver{
 				podConfigStore: tc.podConfigStore,
 				netdb:          inventory.New(),
+				eventRecorder:  record.NewFakeRecorder(100),
 			}
-
-			// For the failure case, a pod config must exist.
 			if !tc.expectSuccess {
 				tc.podConfigStore.SetDeviceConfig(podUIDHostNetwork, "eth0", DeviceConfig{})
 			}
@@ -617,6 +618,7 @@ func TestStopPodSandboxRescanGating(t *testing.T) {
 				podConfigStore: mustNewPodConfigStore(),
 				netdb:          netdb,
 				rdmaSharedMode: tc.rdmaSharedMode,
+				eventRecorder:  record.NewFakeRecorder(100),
 			}
 			podUID := types.UID("test-pod")
 			pod := &api.PodSandbox{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add eventRecorder to the driver and as a starting point we record and publish only the following failure events: ClaimPrepareFailed, NetworkDeviceAttachFailed, RDMADeviceAttachFailed.

One thing I wasn't fully convinced about was the benefit of propagating the event into the driver logs via ...
```go
eventBroadcaster.StartLogging(klog.Infof)
```

This basically replicates the event into the kubectl logs of the driver. In a way I don't see an issue propagating it to the logs and it may help to discovery the failures a bit faster but at the same time I'm thinking that publishing the failure in the events is enough. I don't have a strong opinion on this and would be happy to hear you think on this.
in practice in looks like this

```
I0605 09:29:20.122080       1 db.go:592] Device "dummy0" not found in local store, rescanning.
I0605 09:29:20.271155       1 dra_hooks.go:432] claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get network interface name for device dummy0: device dummy0 not found in store
I0605 09:29:20.271283       1 nonblockinggrpcserver.go:161] "handling request succeeded" logger="dra" requestID=4 method="/k8s.io.kubelet.pkg.apis.dra.v1.DRAPlugin/NodePrepareResources" response="claims:{key:\"c8810e22-6955-4690-911b-3251b027bcd1\" value:{error:\"claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get network interface name for device dummy0: device dummy0 not found in store\"}}"
I0605 09:29:20.271407       1 event.go:377] Event(v1.ObjectReference{Kind:"ResourceClaim", Namespace:"default", Name:"dummy-interface-static-ip", UID:"c8810e22-6955-4690-911b-3251b027bcd1", APIVersion:"resource.k8s.io/v1", ResourceVersion:"897", FieldPath:""}): type: 'Warning' reason: 'ClaimPrepareFailed' failed to get network interface name for device dummy0: device dummy0 not found in store
I0605 09:30:38.120584       1 db.go:592] Device "dummy0" not found in local store, rescanning.
I0605 09:30:38.271555       1 dra_hooks.go:432] claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get network interface name for device dummy0: device dummy0 not found in store
I0605 09:30:38.271710       1 nonblockinggrpcserver.go:161] "handling request succeeded" logger="dra" requestID=5 method="/k8s.io.kubelet.pkg.apis.dra.v1.DRAPlugin/NodePrepareResources" response="claims:{key:\"c8810e22-6955-4690-911b-3251b027bcd1\" value:{error:\"claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get network interface name for device dummy0: device dummy0 not found in store\"}}"
I0605 09:30:38.271879       1 event.go:377] Event(v1.ObjectReference{Kind:"ResourceClaim", Namespace:"default", Name:"dummy-interface-static-ip", UID:"c8810e22-6955-4690-911b-3251b027bcd1", APIVersion:"resource.k8s.io/v1", ResourceVersion:"897", FieldPath:""}): type: 'Warning' reason: 'ClaimPrepareFailed' failed to get network interface name for device dummy0: device dummy0 not found in store
I0605 09:31:40.121683       1 db.go:592] Device "dummy0" not found in local store, rescanning.
I0605 09:31:40.268307       1 dra_hooks.go:432] claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get network interface name for device dummy0: device dummy0 not found in store
I0605 09:31:40.268448       1 nonblockinggrpcserver.go:161] "handling request succeeded" logger="dra" requestID=6 method="/k8s.io.kubelet.pkg.apis.dra.v1.DRAPlugin/NodePrepareResources" response="claims:{key:\"c8810e22-6955-4690-911b-3251b027bcd1\" value:{error:\"claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get network interface name for device dummy0: device dummy0 not found in store\"}}"
I0605 09:31:40.268559       1 event.go:377] Event(v1.ObjectReference{Kind:"ResourceClaim", Namespace:"default", Name:"dummy-interface-static-ip", UID:"c8810e22-6955-4690-911b-3251b027bcd1", APIVersion:"resource.k8s.io/v1", ResourceVersion:"897", FieldPath:""}): type: 'Warning' reason: 'ClaimPrepareFailed' failed to get network interface name for device dummy0: device dummy0 not found in store
```

#### Which issue(s) this PR is related to:
Fixes: https://github.com/kubernetes-sigs/dranet/issues/194

#### Special notes for your reviewer:
I tried to do bare minimum end to end testing and tried to mimic the failure to test at least `ClaimPrepareFailed` event on a resourceClaim when it can not prepare a device. 

The idea was that I create a dummy interface and it is published in the resourceSlice as available device. Then I install the deviceClass and send `SIGSTOP` signal to the driver pod so that it can't process requests, this is basically to kind of break/pause the pod. Then I deleted the dummy interface while the driver can't process any changes. Finally, I created a sort of workload pod with resourceClaim. So at this point schedular tries to allocate dummy interface since it is available on the resourceSlice (driver isn't aware or didn't have a chance to rescan the devices since we broke it intentionally). Now kubelet makes nodePrepareResources call and then I send `SIGCONT` signal to the driver Pod so that it starts handling the request but it fails to find the device now since we deleted the interface and returns an error from which we create an event. Sorry if this was long but I could not come up with better idea of testing.

Below are some snippets from my test if that helps to review:


```
kubectl get pods
NAME   READY   STATUS              RESTARTS   AGE
pod1   0/1     ContainerCreating   0          111s
```
```
kubectl get events -w

8m17s       Normal    NodeAllocatableEnforced         node/dra-worker2                          Updated Node Allocatable limit across pods
8m15s       Normal    Starting                        node/dra-worker2
8m15s       Normal    RegisteredNode                  node/dra-worker2                          Node dra-worker2 event: Registered Node dra-worker2 in Controller
8m2s        Normal    NodeReady                       node/dra-worker2                          Node dra-worker2 status is now: NodeReady
5m19s       Warning   ClaimPrepareFailed              resourceclaim/dummy-interface-static-ip   failed to get netlink to interface dummy0: Link not found
17s         Warning   ClaimPrepareFailed              resourceclaim/dummy-interface-static-ip   failed to get network interface name for device dummy0: device dummy0 not found in store
5m34s       Normal    Scheduled                       pod/pod1                                  Successfully assigned default/pod1 to dra-worker2
5m19s       Warning   FailedPrepareDynamicResources   pod/pod1                                  Failed to prepare dynamic resources: prepare dynamic resources: NodePrepareResources failed for ResourceClaim dummy-interface-static-ip: claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get netlink to interface dummy0: Link not found
17s         Warning   FailedPrepareDynamicResources   pod/pod1                                  Failed to prepare dynamic resources: prepare dynamic resources: NodePrepareResources failed for ResourceClaim dummy-interface-static-ip: claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get network interface name for device dummy0: device dummy0 not found in store
```
```
kubectl describe  resourceClaim dummy-interface-static-ip
...
Events:
  Type     Reason              Age   From     Message
  ----     ------              ----  ----     -------
  Warning  ClaimPrepareFailed  43s   dra.net  failed to get netlink to interface dummy0: Link not found
```
```
kubectl describe pod pod1

Events:
  Type     Reason                         Age    From               Message
  ----     ------                         ----   ----               -------
  Normal   Scheduled                      2m22s  default-scheduler  Successfully assigned default/pod1 to dra-worker2
  Warning  FailedPrepareDynamicResources  2m7s   kubelet            Failed to prepare dynamic resources: prepare dynamic resources: NodePrepareResources failed for ResourceClaim dummy-interface-static-ip: claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get netlink to interface dummy0: Link not found
  Warning  FailedPrepareDynamicResources  43s    kubelet            Failed to prepare dynamic resources: prepare dynamic resources: NodePrepareResources failed for ResourceClaim dummy-interface-static-ip: claim c8810e22-6955-4690-911b-3251b027bcd1 contain errors: failed to get network interface name for device dummy0: device dummy0 not found in store
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```