### PR TITLE
fix invalid ifname and add a test for webhook-whereabouts

### DIFF
--- a/cmd/webhook-whereabouts/go.mod
+++ b/cmd/webhook-whereabouts/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.36.1 // indirect

--- a/cmd/webhook-whereabouts/go.sum
+++ b/cmd/webhook-whereabouts/go.sum
@@ -53,8 +53,8 @@ golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 h1:fQsdNF2N+/YewlRZiricy4P1i
 golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93/go.mod h1:EPRbTFwzwjXj9NpYyyrvenVh9Y+GFeEvMNh7Xuz7xgU=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=

--- a/cmd/webhook-whereabouts/main.go
+++ b/cmd/webhook-whereabouts/main.go
@@ -58,11 +58,6 @@ func (s *Server) GetDeviceConfig(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("{}"))
 }
 
-// maxCNIIfnameLen is the maximum interface-name length accepted by the CNI
-// runtime (IFNAMSIZ-1). Names longer than this are rejected by CNI's
-// interface-name validation.
-const maxCNIIfnameLen = 15
-
 // pciNamePrefix is the prefix dranet prepends to a normalized PCI address
 // (pkg/names.NormalizePCIAddress: "0000:8a:00.0" -> "pci-0000-8a-00-0").
 const pciNamePrefix = "pci-"
@@ -103,7 +98,7 @@ func cniIfname(req webhook.ProfileRequest) string {
 // interface-name validation. It mirrors github.com/containernetworking/cni
 // pkg/utils.ValidateInterfaceName.
 func isValidCNIIfname(s string) bool {
-	if len(s) == 0 || len(s) > maxCNIIfnameLen {
+	if len(s) == 0 || len(s) > apis.MaxInterfaceNameLen {
 		return false
 	}
 	if s == "." || s == ".." {

--- a/cmd/webhook-whereabouts/main.go
+++ b/cmd/webhook-whereabouts/main.go
@@ -21,11 +21,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"hash/fnv"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"unicode"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	types100 "github.com/containernetworking/cni/pkg/types/100"
@@ -55,6 +58,65 @@ func (s *Server) GetDeviceConfig(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("{}"))
 }
 
+// maxCNIIfnameLen is the maximum interface-name length accepted by the CNI
+// runtime (IFNAMSIZ-1). Names longer than this are rejected by CNI's
+// interface-name validation.
+const maxCNIIfnameLen = 15
+
+// pciNamePrefix is the prefix dranet prepends to a normalized PCI address
+// (pkg/names.NormalizePCIAddress: "0000:8a:00.0" -> "pci-0000-8a-00-0").
+const pciNamePrefix = "pci-"
+
+// cniIfname returns the CNI_IFNAME to pass to the whereabouts IPAM plugin.
+//
+// whereabouts matches a reservation for release on (CNI_CONTAINERID, CNI_IFNAME)
+// but never creates an interface from it, so the value just needs to be (1) a
+// valid CNI interface name and (2) identical at ADD and DEL, else the DEL fails
+// to match and the IP leaks. We derive it from the stable Device.Name rather
+// than the kernel ifName (which is mutable across netns moves) so (2) holds by
+// construction, and keep it human-readable so leaked reservations can be traced
+// back during manual pool cleanup:
+//
+//   - already valid (short, non-PCI names): used verbatim;
+//   - PCI names exceed IFNAMSIZ only due to the "pci-" prefix, so we strip it
+//     ("pci-0000-27-00-2" -> "0000-27-00-2"), re-validating the result;
+//   - anything still invalid (e.g. base32-encoded names, already unreadable):
+//     a deterministic hash.
+func cniIfname(req webhook.ProfileRequest) string {
+	name := req.Device.Name
+	if isValidCNIIfname(name) {
+		return name
+	}
+	// Re-validate after stripping: never emit an over-length name on the
+	// assumption that dropping the prefix made it fit.
+	if trimmed := strings.TrimPrefix(name, pciNamePrefix); trimmed != name && isValidCNIIfname(trimmed) {
+		return trimmed
+	}
+	// "dra" + 8 hex digits (FNV-1a/32) = 11 bytes: always valid, deterministic
+	// for a given device identifier, and distinct per device within a claim.
+	h := fnv.New32a()
+	h.Write([]byte(name))
+	return fmt.Sprintf("dra%08x", h.Sum32())
+}
+
+// isValidCNIIfname reports whether s would be accepted by the CNI runtime's
+// interface-name validation. It mirrors github.com/containernetworking/cni
+// pkg/utils.ValidateInterfaceName.
+func isValidCNIIfname(s string) bool {
+	if len(s) == 0 || len(s) > maxCNIIfnameLen {
+		return false
+	}
+	if s == "." || s == ".." {
+		return false
+	}
+	for _, r := range s {
+		if r == '/' || r == ':' || unicode.IsSpace(r) {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *Server) GetProfileConfig(w http.ResponseWriter, r *http.Request) {
 	var req webhook.ProfileRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -78,7 +140,7 @@ func (s *Server) GetProfileConfig(w http.ResponseWriter, r *http.Request) {
 		"CNI_COMMAND=ADD",
 		"CNI_CONTAINERID=" + string(req.ClaimUID),
 		"CNI_NETNS=/dev/null", // IPAM plugins don't need network namespaces
-		"CNI_IFNAME=" + req.Device.Name,
+		"CNI_IFNAME=" + cniIfname(req),
 		"CNI_PATH=" + s.binDir,
 		"CNI_ARGS=IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=pod-whereabouts;K8S_POD_INFRA_CONTAINER_ID=" + string(req.ClaimUID),
 	}
@@ -145,7 +207,7 @@ func (s *Server) ReleaseProfileConfig(w http.ResponseWriter, r *http.Request) {
 		"CNI_COMMAND=DEL",
 		"CNI_CONTAINERID=" + string(req.ClaimUID),
 		"CNI_NETNS=/dev/null",
-		"CNI_IFNAME=" + req.Device.Name,
+		"CNI_IFNAME=" + cniIfname(req),
 		"CNI_PATH=" + s.binDir,
 		"CNI_ARGS=IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=pod-whereabouts;K8S_POD_INFRA_CONTAINER_ID=" + string(req.ClaimUID),
 	}

--- a/cmd/webhook-whereabouts/main_test.go
+++ b/cmd/webhook-whereabouts/main_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"testing"
+
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
+	"sigs.k8s.io/dranet/pkg/cloudprovider/webhook"
+)
+
+func ifname(name string) string {
+	return cniIfname(webhook.ProfileRequest{
+		Device: cloudprovider.DeviceIdentifiers{Name: name},
+	})
+}
+
+func TestCniIfname(t *testing.T) {
+	tests := []struct {
+		name    string
+		devName string
+		want    string // exact expected ifname ("" => assert invariants only)
+	}{
+		{
+			name:    "short valid name passes through verbatim",
+			devName: "eth0",
+			want:    "eth0",
+		},
+		{
+			name:    "15-char name is at the limit and passes through",
+			devName: "abcdefghijklmno", // exactly 15
+			want:    "abcdefghijklmno",
+		},
+		{
+			name:    "PCI-derived 16-char name keeps the readable BDF (prefix stripped)",
+			devName: "pci-0000-27-00-2", // 16 chars, over IFNAMSIZ
+			want:    "0000-27-00-2",     // 12 chars, valid, still reads as PCI BDF
+		},
+		{
+			name:    "longest PCI address still fits after stripping",
+			devName: "pci-ffff-ff-1f-7",
+			want:    "ffff-ff-1f-7",
+		},
+		{
+			name:    "non-PCI over-length name falls back to deterministic hash",
+			devName: "net-aaaaaaaaaaaaaaaaaaaa", // base32-style, no "pci-" prefix
+			want:    "",                          // opaque hash; checked via invariants
+		},
+		{
+			// Standard Linux PCI addresses never reach this, but a hypothetical
+			// over-length PCI name (still >15 after stripping "pci-") must stay
+			// correct by degrading to the hash rather than emitting a long name.
+			name:    "over-length PCI name still degrades to hash, not an invalid name",
+			devName: "pci-00000000-27-00-2", // >15 even after "pci-" is stripped
+			want:    "",                      // opaque hash; checked via invariants
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ifname(tt.devName)
+
+			if !isValidCNIIfname(got) {
+				t.Fatalf("cniIfname(%q) = %q, which is not a valid CNI ifname", tt.devName, got)
+			}
+			if tt.want != "" && got != tt.want {
+				t.Errorf("cniIfname(%q) = %q, want %q", tt.devName, got, tt.want)
+			}
+			if tt.want == "" && got == tt.devName {
+				t.Errorf("cniIfname(%q) returned the (invalid) name verbatim instead of deriving", tt.devName)
+			}
+		})
+	}
+}
+
+// TestCniIfnameDeterministic is the property that actually protects against IP
+// leaks: whereabouts matches release on (containerID, ifname), so the same
+// device identifier MUST always yield the same CNI_IFNAME (ADD == DEL).
+func TestCniIfnameDeterministic(t *testing.T) {
+	const dev = "pci-0000-27-00-2"
+	first := ifname(dev)
+	for i := 0; i < 100; i++ {
+		if got := ifname(dev); got != first {
+			t.Fatalf("cniIfname(%q) not deterministic: %q != %q", dev, got, first)
+		}
+	}
+}
+
+// TestCniIfnameDistinct ensures different devices in the same claim (same
+// containerID, distinct deviceName) do not collide on the derived ifname,
+// which would otherwise alias their whereabouts reservations.
+func TestCniIfnameDistinct(t *testing.T) {
+	names := []string{
+		"pci-0000-27-00-2",
+		"pci-0000-27-00-3",
+		"pci-0000-27-00-4",
+		"pci-0000-3b-00-0",
+	}
+	seen := map[string]string{}
+	for _, n := range names {
+		got := ifname(n)
+		if prev, dup := seen[got]; dup {
+			t.Errorf("ifname collision: %q and %q both derive to %q", prev, n, got)
+		}
+		seen[got] = n
+	}
+}
+
+func TestIsValidCNIIfname(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"eth0", true},
+		{"abcdefghijklmno", true},  // 15 chars
+		{"abcdefghijklmnop", false}, // 16 chars
+		{"", false},
+		{".", false},
+		{"..", false},
+		{"a/b", false},
+		{"a:b", false},
+		{"a b", false},
+		{"pci-0000-27-00-2", false}, // 16 chars
+		{"dra1a2b3c4d", true},
+	}
+	for _, tt := range tests {
+		if got := isValidCNIIfname(tt.in); got != tt.want {
+			t.Errorf("isValidCNIIfname(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

webhook-whereabouts passes req.Device.Name verbatim as CNI_IFNAME when invoking the whereabouts IPAM plugin.
For PCI devices such as SR-IOV VFs, Device.Name is PCI-derived (pkg/names.NormalizePCIAddress: 0000:27:00.2 → pci-0000-27-00-2, 16 chars). This exceeds the CNI interface-name limit (IFNAMSIZ - 1 = 15), so CNI's interface-name validation rejects it and the IPAM ADD fails — IP allocation does not work for these devices.

This PR fixes the bug using the following approach:
* Device.Name already valid (short, non-PCI names) → used verbatim;
* PCI name → strip the pci- prefix (pci-0000-27-00-2 → 0000-27-00-2), re-validating the result so we never emit an over-length name on the assumption it fit;
* anything still invalid after the above (e.g. base32-encoded non-DNS-1123 names, already unreadable upstream) → a deterministic hash as a last resort.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #225 

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NOTE
```