### PR TITLE
remove pruning from Synchronize

### DIFF
--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -51,16 +51,10 @@ func (np *NetworkDriver) Synchronize(_ context.Context, pods []*api.PodSandbox, 
 		livePodNetNs[types.UID(pod.Uid)] = getNetworkNamespace(pod)
 	}
 
-	// Process stored pods: update NetNS for live pods, and prune configurations
-	// for pods that no longer exist in the runtime.
+	// Process stored pods: update NetNS for live pods.
 	for _, storedUID := range np.podConfigStore.ListPods() {
-		ns, isLive := livePodNetNs[storedUID]
-
-		if isLive {
+		if ns, isLive := livePodNetNs[storedUID]; isLive {
 			np.podConfigStore.SetPodNetNs(storedUID, ns)
-		} else {
-			klog.Infof("Synchronize: pruning stale config for pod %s", storedUID)
-			np.podConfigStore.DeletePod(storedUID)
 		}
 	}
 

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -189,43 +189,6 @@ func TestRunPodSandboxUsesPersistedConfigAfterRestart(t *testing.T) {
 	}
 }
 
-func TestSynchronizePrunesStaleConfigs(t *testing.T) {
-	store := mustNewPodConfigStore()
-	store.SetDeviceConfig("live-pod", "eth0", DeviceConfig{})   //nolint:errcheck
-	store.SetDeviceConfig("stale-pod", "eth0", DeviceConfig{})  //nolint:errcheck
-	store.SetDeviceConfig("stale-pod2", "eth0", DeviceConfig{}) //nolint:errcheck
-
-	np := &NetworkDriver{
-		podConfigStore: store,
-		netdb:          inventory.New(),
-	}
-
-	// Synchronize with only "live-pod" present in the runtime.
-	pods := []*api.PodSandbox{
-		{
-			Uid:       "live-pod",
-			Name:      "live",
-			Namespace: "default",
-			Linux:     &api.LinuxPodSandbox{},
-		},
-	}
-	_, err := np.Synchronize(context.Background(), pods, nil)
-	if err != nil {
-		t.Fatalf("Synchronize() error: %v", err)
-	}
-
-	// live-pod should still be in the store.
-	if _, found := store.GetPodConfig("live-pod"); !found {
-		t.Error("live-pod should still exist after sync")
-	}
-	// stale pods should be pruned.
-	if _, found := store.GetPodConfig("stale-pod"); found {
-		t.Error("stale-pod should have been pruned")
-	}
-	if _, found := store.GetPodConfig("stale-pod2"); found {
-		t.Error("stale-pod2 should have been pruned")
-	}
-}
 
 func TestSynchronizeStoresNetNSOnlyForConfiguredPods(t *testing.T) {
 	store := mustNewPodConfigStore()

--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -424,6 +424,85 @@ EOF
   kubectl rollout status ds/dranet --namespace=kube-system
 }
 
+@test "unprepare claims on driver restart after pod deletion during driver downtime" {
+  local NODE_NAME="$CLUSTER_NAME"-worker
+  local DUMMY_IFACE="dummy-downtime"
+
+  docker exec "$NODE_NAME" bash -c "ip link add $DUMMY_IFACE type dummy"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev $DUMMY_IFACE"
+
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/deviceclass.yaml
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/resourceclaim.yaml
+  
+  kubectl wait --timeout=30s --for=condition=ready pods -l app=pod
+
+  local POD_NAME
+  POD_NAME=$(kubectl get pods -l app=pod -o name)
+  local POD_UID
+  POD_UID=$(kubectl get "$POD_NAME" -o jsonpath='{.metadata.uid}')
+
+  # Turn down the dranet driver on NODE_NAME by scheduling it off
+  kubectl label node "$NODE_NAME" e2e-test-do-not-schedule=true
+  kubectl patch daemonset dranet -n kube-system --type='merge' --patch-file=<(cat <<EOF
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: e2e-test-do-not-schedule
+                operator: DoesNotExist
+EOF
+)
+  kubectl rollout status ds/dranet --namespace=kube-system
+
+  # Delete the pod forcefully. Verify the pod is immediately removed from the API server.
+  kubectl delete "$POD_NAME" --force
+  run kubectl get "$POD_NAME"
+  assert_failure
+
+  # Inspect the bbolt database for the deleted pod configs. The pod configs should
+  # still exist since driver is offline. Stream the database file using cat, redirect
+  # it to the local test path, and read the keys for the deleted pod using bbolt CLI.
+  docker exec "$NODE_NAME" cat /var/run/dranet/dranet.db > "$BATS_TEST_DIRNAME/../_artifacts/dranet.db"
+  go run go.etcd.io/bbolt/cmd/bbolt@latest keys "$BATS_TEST_DIRNAME/../_artifacts/dranet.db" pod_configs "$POD_UID" > /dev/null 2>&1
+
+  # Restore the dranet driver on NODE_NAME by reverting affinity patch and removing node label.
+  # Verify the driver is restarted sucsessfully on the node.
+  kubectl patch daemonset dranet -n kube-system --type='merge' --patch-file=<(cat <<EOF
+spec:
+  template:
+    spec:
+      affinity: {}
+EOF
+)
+  kubectl label node "$NODE_NAME" e2e-test-do-not-schedule-
+  kubectl wait --namespace=kube-system --for=condition=Ready pod -l app=dranet --field-selector spec.nodeName="$NODE_NAME" --timeout=60s
+
+  # The driver should asynchronously process the cleanup after the restart.
+  # Inspect the bbolt database again to verify the pod configs have been deleted.
+  local retries=10
+  local wait_sec=2
+  local removed=false
+
+  for ((i=1; i<=retries; i++)); do
+    if ! docker exec "$NODE_NAME" cat /var/run/dranet/dranet.db > "$BATS_TEST_DIRNAME/../_artifacts/dranet.db"; then
+      sleep $wait_sec
+      continue
+    fi
+    if ! go run go.etcd.io/bbolt/cmd/bbolt@latest keys "$BATS_TEST_DIRNAME/../_artifacts/dranet.db" pod_configs "$POD_UID" > /dev/null 2>&1; then
+      removed=true
+      break
+    fi
+    sleep $wait_sec
+  done
+
+  [ "$removed" = "true" ]
+}
+
+
 @test "permanent neighbor entry is copied to pod namespace" {
   local NODE_NAME="$CLUSTER_NAME"-worker
   local DUMMY_IFACE="dummy-neigh"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
A race condition occurs when right after driver startup, the NRI `Synchronize` function prunes a pod's device configuration which is just stored for a new pod, before the `RunPodSandbox` hook is actually executed. This causes the network device injection to be skipped.

This change mitigates the issue by removing the pruning step from `Synchronize` NRI hook, because its functionality can be fully handled by Kubelet DRA manager calling to the `UnprepareResourceClaims`.

#### Which issue(s) this PR is related to:
Fixes #232 

#### Special notes for your reviewer:
Key changes:
- Remove startup stale configuration pruning from NRI Synchronize.
- Rely on native Kubelet call to UnprepareResourceClaims for pod device cleanup.
- Add E2E lifecycle test verifying cleanup on driver restart after pod deletion during downtime.

#### Does this PR introduce a user-facing change?
```release-note
This PR fixes a race condition appears in dranet v1.2.0+ that NRI `Synchronize` function prunes the config store for pending pods during driver startup, causing pod interface injection being skipped (#232).
```