### PR TITLE
Add azure interconnect group support

### DIFF
--- a/examples/azure_aks_examples/README.md
+++ b/examples/azure_aks_examples/README.md
@@ -53,6 +53,32 @@ attaches Azure-specific attributes to every device it publishes in the node's
 |---|---|---|
 | `azure.dra.net/placementGroupId` | IMDS `compute/placementGroupId` | `c6c749e8-a38b-470e-8c94-2a7d00001bf0` |
 | `azure.dra.net/vmSize` | IMDS `compute/vmSize` | `Standard_ND128isr_GB300_v6` |
+| `azure.dra.net/interconnectGroupId` | IMDS `compute/interconnectGroupId` | `2deed8b4-d1e9-42be-a40a-9882201aa9f5` |
+| `azure.dra.net/interconnectSubgroupId` | IMDS `compute/interconnectSubgroupId` | `0f0ba375-aaf1-4ac8-a579-a3b180d47de5` |
+
+### InterconnectGroup (ICG) and InterconnectBlock (ICB)
+
+Azure organizes GPU VMs with InfiniBand into a two-level topology:
+
+- **InterconnectGroup (ICG)** (`Microsoft.Network/interconnectGroups`) —
+  defines the overall IB connectivity scope and contains one or more
+  subgroups. Its `resourceGuid` is exposed via IMDS as
+  `compute/interconnectGroupId`.
+- **Subgroup** — each subgroup maps to a single InterconnectBlock. VMs in the
+  same subgroup share the same physical IB fabric. The subgroup's
+  `internalSubgroupId` is exposed via IMDS as `compute/interconnectSubgroupId`.
+- **InterconnectBlock (ICB)** (`Microsoft.Compute/interconnectBlocks`) — the
+  Compute-side resource representing a fixed-capacity block of VMs (e.g. 18
+  for `Standard_ND128isr_GB300_v6`) wired to the same IB fabric.
+
+Use `interconnectSubgroupId` in CEL selectors to pin a multi-node job to a
+single IB fabric:
+
+```yaml
+- cel:
+    expression: >-
+      device.attributes["azure.dra.net"]["interconnectSubgroupId"] == "0f0ba375-aaf1-4ac8-a579-a3b180d47de5"
+```
 
 VMs in **different placement groups do not share an InfiniBand fabric** —
 cross-placement-group RDMA traffic fails with transport errors. This is not

--- a/pkg/cloudprovider/azure/azure.go
+++ b/pkg/cloudprovider/azure/azure.go
@@ -46,7 +46,6 @@ const (
 	AttrAzureInterconnectGroupID    = AzureAttrPrefix + "/" + "interconnectGroupId"
 	AttrAzureInterconnectSubgroupID = AzureAttrPrefix + "/" + "interconnectSubgroupId"
 
-
 	// imdsEndpoint is the Azure Instance Metadata Service endpoint.
 	imdsEndpoint = "http://169.254.169.254/metadata/instance"
 	// imdsAPIVersion is the API version used for IMDS queries.
@@ -60,9 +59,9 @@ const (
 // imdsComputeMetadata contains the fields we care about from the Azure IMDS
 // compute metadata response.
 type imdsComputeMetadata struct {
-	PlacementGroupID      string `json:"placementGroupId"`
-	VMSize                string `json:"vmSize"`
-	InterconnectGroupID   string `json:"interconnectGroupId"`
+	PlacementGroupID       string `json:"placementGroupId"`
+	VMSize                 string `json:"vmSize"`
+	InterconnectGroupID    string `json:"interconnectGroupId"`
 	InterconnectSubgroupID string `json:"interconnectSubgroupId"`
 }
 

--- a/pkg/cloudprovider/azure/azure.go
+++ b/pkg/cloudprovider/azure/azure.go
@@ -49,7 +49,7 @@ const (
 	// imdsEndpoint is the Azure Instance Metadata Service endpoint.
 	imdsEndpoint = "http://169.254.169.254/metadata/instance"
 	// imdsAPIVersion is the API version used for IMDS queries.
-	imdsAPIVersion = "2024-03-15"
+	imdsAPIVersion = "2025-11-11"
 	// imdsPathCompute is the IMDS path for compute metadata.
 	imdsPathCompute = "compute"
 	// imdsPathNetwork is the IMDS path for network metadata.

--- a/pkg/cloudprovider/azure/azure.go
+++ b/pkg/cloudprovider/azure/azure.go
@@ -41,13 +41,16 @@ import (
 const (
 	AzureAttrPrefix = "azure.dra.net"
 
-	AttrAzurePlacementGroupID = AzureAttrPrefix + "/" + "placementGroupId"
-	AttrAzureVMSize           = AzureAttrPrefix + "/" + "vmSize"
+	AttrAzurePlacementGroupID       = AzureAttrPrefix + "/" + "placementGroupId"
+	AttrAzureVMSize                 = AzureAttrPrefix + "/" + "vmSize"
+	AttrAzureInterconnectGroupID    = AzureAttrPrefix + "/" + "interconnectGroupId"
+	AttrAzureInterconnectSubgroupID = AzureAttrPrefix + "/" + "interconnectSubgroupId"
+
 
 	// imdsEndpoint is the Azure Instance Metadata Service endpoint.
 	imdsEndpoint = "http://169.254.169.254/metadata/instance"
 	// imdsAPIVersion is the API version used for IMDS queries.
-	imdsAPIVersion = "2021-02-01"
+	imdsAPIVersion = "2024-03-15"
 	// imdsPathCompute is the IMDS path for compute metadata.
 	imdsPathCompute = "compute"
 	// imdsPathNetwork is the IMDS path for network metadata.
@@ -57,8 +60,10 @@ const (
 // imdsComputeMetadata contains the fields we care about from the Azure IMDS
 // compute metadata response.
 type imdsComputeMetadata struct {
-	PlacementGroupID string `json:"placementGroupId"`
-	VMSize           string `json:"vmSize"`
+	PlacementGroupID      string `json:"placementGroupId"`
+	VMSize                string `json:"vmSize"`
+	InterconnectGroupID   string `json:"interconnectGroupId"`
+	InterconnectSubgroupID string `json:"interconnectSubgroupId"`
 }
 
 // imdsResponse represents the top-level IMDS response structure.
@@ -110,9 +115,11 @@ var _ cloudprovider.CloudInstance = (*AzureInstance)(nil)
 
 // AzureInstance holds Azure-specific instance data retrieved from IMDS.
 type AzureInstance struct {
-	PlacementGroupID string
-	VMSize           string
-	Interfaces       []networkInterface
+	PlacementGroupID       string
+	VMSize                 string
+	InterconnectGroupID    string
+	InterconnectSubgroupID string
+	Interfaces             []networkInterface
 }
 
 // GetDeviceAttributes returns Azure-specific attributes for a device.
@@ -127,6 +134,14 @@ func (a *AzureInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) 
 
 	if a.PlacementGroupID != "" {
 		attributes[AttrAzurePlacementGroupID] = resourceapi.DeviceAttribute{StringValue: &a.PlacementGroupID}
+	}
+
+	if a.InterconnectGroupID != "" {
+		attributes[AttrAzureInterconnectGroupID] = resourceapi.DeviceAttribute{StringValue: &a.InterconnectGroupID}
+	}
+
+	if a.InterconnectSubgroupID != "" {
+		attributes[AttrAzureInterconnectSubgroupID] = resourceapi.DeviceAttribute{StringValue: &a.InterconnectSubgroupID}
 	}
 
 	return attributes
@@ -352,10 +367,13 @@ func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
 	}
 
 	instance := &AzureInstance{
-		PlacementGroupID: computeMetadata.PlacementGroupID,
-		VMSize:           computeMetadata.VMSize,
+		PlacementGroupID:       computeMetadata.PlacementGroupID,
+		VMSize:                 computeMetadata.VMSize,
+		InterconnectGroupID:    computeMetadata.InterconnectGroupID,
+		InterconnectSubgroupID: computeMetadata.InterconnectSubgroupID,
 	}
-	klog.Infof("Azure IMDS: vmSize=%s, placementGroupId=%s", instance.VMSize, instance.PlacementGroupID)
+	klog.Infof("Azure IMDS: vmSize=%s, placementGroupId=%s, interconnectGroupId=%s, interconnectSubgroupId=%s",
+		instance.VMSize, instance.PlacementGroupID, instance.InterconnectGroupID, instance.InterconnectSubgroupID)
 
 	// Fetch network interface metadata in a separate call.
 	var networkResp imdsNetworkResponse

--- a/pkg/cloudprovider/azure/azure_test.go
+++ b/pkg/cloudprovider/azure/azure_test.go
@@ -88,6 +88,34 @@ func TestGetDeviceAttributes(t *testing.T) {
 				AttrAzureVMSize:           {StringValue: ptr.To("Standard_ND128isr_GB300_v6")},
 			},
 		},
+		{
+			name: "instance with interconnect group and block IDs",
+			instance: &AzureInstance{
+				PlacementGroupID:    "739e6cfb-2607-462e-9e2b-21d24b31f5ed",
+				VMSize:              "Standard_ND128isr_GB300_v6",
+				InterconnectGroupID: "b41a62f6-5e53-4999-bae9-aa6006e406e7",
+				InterconnectSubgroupID: "c52b73g7-6f64-5000-cbf0-bb7117f517f8",
+			},
+			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttrAzurePlacementGroupID:    {StringValue: ptr.To("739e6cfb-2607-462e-9e2b-21d24b31f5ed")},
+				AttrAzureVMSize:              {StringValue: ptr.To("Standard_ND128isr_GB300_v6")},
+				AttrAzureInterconnectGroupID: {StringValue: ptr.To("b41a62f6-5e53-4999-bae9-aa6006e406e7")},
+				AttrAzureInterconnectSubgroupID: {StringValue: ptr.To("c52b73g7-6f64-5000-cbf0-bb7117f517f8")},
+			},
+		},
+		{
+			name: "instance with only interconnect group, no block",
+			instance: &AzureInstance{
+				VMSize:              "Standard_ND128isr_GB300_v6",
+				InterconnectGroupID: "b41a62f6-5e53-4999-bae9-aa6006e406e7",
+			},
+			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttrAzureVMSize:              {StringValue: ptr.To("Standard_ND128isr_GB300_v6")},
+				AttrAzureInterconnectGroupID: {StringValue: ptr.To("b41a62f6-5e53-4999-bae9-aa6006e406e7")},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cloudprovider/azure/azure_test.go
+++ b/pkg/cloudprovider/azure/azure_test.go
@@ -89,31 +89,31 @@ func TestGetDeviceAttributes(t *testing.T) {
 			},
 		},
 		{
-			name: "instance with interconnect group and block IDs",
+			name: "instance with interconnect group and subgroup IDs",
 			instance: &AzureInstance{
-				PlacementGroupID:    "739e6cfb-2607-462e-9e2b-21d24b31f5ed",
-				VMSize:              "Standard_ND128isr_GB300_v6",
-				InterconnectGroupID: "b41a62f6-5e53-4999-bae9-aa6006e406e7",
-				InterconnectSubgroupID: "c52b73g7-6f64-5000-cbf0-bb7117f517f8",
+				PlacementGroupID:       "42d64506-b0a6-4308-911e-38982951ce42",
+				VMSize:                 "Standard_ND128isr_GB300_v6",
+				InterconnectGroupID:    "2deed8b4-d1e9-42be-a40a-9882201aa9f5",
+				InterconnectSubgroupID: "0f0ba375-aaf1-4ac8-a579-a3b180d47de5",
 			},
 			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
 			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttrAzurePlacementGroupID:    {StringValue: ptr.To("739e6cfb-2607-462e-9e2b-21d24b31f5ed")},
-				AttrAzureVMSize:              {StringValue: ptr.To("Standard_ND128isr_GB300_v6")},
-				AttrAzureInterconnectGroupID: {StringValue: ptr.To("b41a62f6-5e53-4999-bae9-aa6006e406e7")},
-				AttrAzureInterconnectSubgroupID: {StringValue: ptr.To("c52b73g7-6f64-5000-cbf0-bb7117f517f8")},
+				AttrAzurePlacementGroupID:       {StringValue: ptr.To("42d64506-b0a6-4308-911e-38982951ce42")},
+				AttrAzureVMSize:                 {StringValue: ptr.To("Standard_ND128isr_GB300_v6")},
+				AttrAzureInterconnectGroupID:    {StringValue: ptr.To("2deed8b4-d1e9-42be-a40a-9882201aa9f5")},
+				AttrAzureInterconnectSubgroupID: {StringValue: ptr.To("0f0ba375-aaf1-4ac8-a579-a3b180d47de5")},
 			},
 		},
 		{
-			name: "instance with only interconnect group, no block",
+			name: "instance with only interconnect group, no subgroup",
 			instance: &AzureInstance{
 				VMSize:              "Standard_ND128isr_GB300_v6",
-				InterconnectGroupID: "b41a62f6-5e53-4999-bae9-aa6006e406e7",
+				InterconnectGroupID: "2deed8b4-d1e9-42be-a40a-9882201aa9f5",
 			},
 			id: cloudprovider.DeviceIdentifiers{Name: "dev1"},
 			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 				AttrAzureVMSize:              {StringValue: ptr.To("Standard_ND128isr_GB300_v6")},
-				AttrAzureInterconnectGroupID: {StringValue: ptr.To("b41a62f6-5e53-4999-bae9-aa6006e406e7")},
+				AttrAzureInterconnectGroupID: {StringValue: ptr.To("2deed8b4-d1e9-42be-a40a-9882201aa9f5")},
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
this PR adds azure support of interconnect group - nodes within interconnect subgroup are connected with NVLink/NVSwitch, and nodes cross interconnect subgroup but within interconnect group are connected with Infiniband. This feature enabled fine grained scheduling and alignment in addition to the existing placement group. 

#### Which issue(s) this PR is related to:
#85 

#### Special notes for your reviewer:
This change has been tested on Azure GB300 hardware, and ensure dranet propagate the correct attributed on resource slice, specifically `azure.dra.net/interconnectGroupId` and `azure.dra.net/interconnectSubgroupId`

#### Does this PR introduce a user-facing change?
```release-note
add azure interconnect group support
```