### PR TITLE
docs: surface examples on the DRANET website

### DIFF
--- a/examples/demo_gke_multinetwork/resourceclaim.yaml
+++ b/examples/demo_gke_multinetwork/resourceclaim.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: resource.k8s.io/v1
 kind:  ResourceClaim
 metadata:
   name: dranet-network
@@ -20,10 +20,11 @@ spec:
   devices:
     requests:
     - name: req-phy-interface
-      deviceClassName: multinic
-      selectors:
-        - cel:
-            expression: device.attributes["dra.net"].cloudNetwork.contains("dranet-net")
+      exactly:
+        deviceClassName: multinic
+        selectors:
+          - cel:
+              expression: device.attributes["dra.net"].cloudNetwork.contains("dranet-net")
 ---
 apiVersion: v1
 kind: Pod

--- a/site/content/docs/user/aws-eks-efa.md
+++ b/site/content/docs/user/aws-eks-efa.md
@@ -1,0 +1,118 @@
+---
+title: "AWS EKS with GPUDirect and EFA"
+date: 2026-06-25T00:00:00Z
+---
+
+This page walks through topology-aware GPU + EFA allocation on Amazon EKS using [Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/). The example targets `p4d.24xlarge` instances (8 NVIDIA A100 GPUs and 4 Elastic Fabric Adapters spread across 4 PCIe root complexes), and the same pattern applies to other EKS nodes with NVIDIA GPUs and EFA devices.
+
+The full source for this example lives at [examples/aws_eks_examples/gpu-efa](https://github.com/kubernetes-sigs/dranet/tree/main/examples/aws_eks_examples/gpu-efa).
+
+## How it works
+
+Both the NVIDIA GPU DRA driver (`gpu.nvidia.com`) and dranet (`dra.net`) publish the `resource.kubernetes.io/pcieRoot` attribute for the devices they manage. Because both drivers expose the same attribute, a `ResourceClaimTemplate` can use a CEL constraint to co-locate a GPU and an EFA adapter on the same PCIe root complex. That direct PCIe path enables GPU Direct RDMA (GDRDMA) and avoids cross-root traffic over the CPU/PCIe switch fabric.
+
+## Prerequisites
+
+EKS 1.34+ with EFA-enabled worker nodes (see [Manage EFA devices on Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/device-management-efa.html)).
+
+Install the MPI Operator:
+
+```sh
+kubectl apply --server-side -k "https://github.com/kubeflow/mpi-operator/manifests/overlays/standalone?ref=v0.7.0"
+```
+
+Install the NVIDIA GPU DRA driver and the EFA DRA driver (dranet). The AWS-supported `aws-dranet` Helm chart provisions the `efa.networking.k8s.aws` `DeviceClass` and a DaemonSet that publishes only EFA devices:
+
+```sh
+helm repo add eks https://aws.github.io/eks-charts
+helm repo update
+helm install aws-dranet eks/aws-dranet --namespace kube-system
+```
+
+See the [example README](https://github.com/kubernetes-sigs/dranet/blob/main/examples/aws_eks_examples/gpu-efa/README.md) for the full NVIDIA DRA driver install command and node labeling.
+
+## DeviceClass
+
+The `aws-dranet` chart creates the `efa.networking.k8s.aws` `DeviceClass` automatically; it is shown here for reference:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: efa.networking.k8s.aws
+spec:
+  selectors:
+  - cel:
+      expression: |
+        device.driver == "dra.net" &&
+        device.attributes["dra.net"].pciDevice == 'Elastic Fabric Adapter (EFA)'
+```
+
+The GPU and EFA `ResourceSlice` objects are published by the drivers on each node (not applied by users); they expose `pciBusID`, `rdmaDevice`, and `resource.kubernetes.io/pcieRoot`, which is what enables cross-driver topology-aware co-selection.
+
+## Request a GPU + EFA device
+
+`resource-claim-template.yaml` defines two templates. `gpu-efa-aligned` requests 1 GPU + 1 EFA and constrains both to the same `resource.kubernetes.io/pcieRoot`; `gpu-efa-unaligned` requests the same devices without the constraint, for comparison.
+
+```yaml
+# Unaligned: GPU and EFA may be allocated on different PCIe root complexes
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-efa-unaligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+      - name: efa
+        exactly:
+          deviceClassName: efa.networking.k8s.aws
+          count: 1
+---
+# Aligned: GPU and EFA are co-located on the same PCIe root complex
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-efa-aligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+      - name: efa
+        exactly:
+          deviceClassName: efa.networking.k8s.aws
+          count: 1
+      constraints:
+      - requests: [gpu, efa]
+        matchAttribute: resource.kubernetes.io/pcieRoot
+```
+
+## Run the workload
+
+The `mpi-job.yaml` `MPIJob` runs NCCL `all_reduce_perf` across 2 workers, each requesting a `gpu-efa-aligned` claim. Apply the templates and the job:
+
+```sh
+kubectl apply -f resource-claim-template.yaml
+kubectl apply -f mpi-job.yaml
+```
+
+The full `MPIJob` manifest, including the NCCL/EFA environment variables, is in the [example directory](https://github.com/kubernetes-sigs/dranet/tree/main/examples/aws_eks_examples/gpu-efa).
+
+## Benchmark results
+
+2-node `all_reduce_perf`, 1 GPU per worker, EFA transport via `aws-ofi-nccl`. Full results are in the [example README](https://github.com/kubernetes-sigs/dranet/blob/main/examples/aws_eks_examples/gpu-efa/README.md).
+
+| Template | GPU (PCIe root) | EFA (PCIe root) | GDR | Avg busbw |
+|---|---|---|---|---:|
+| `gpu-efa-aligned` | gpu-0 (`pci0000:10`) | rdmap16s27 (`pci0000:10`) | Yes | ~11.35 GB/s |
+| `gpu-efa-unaligned` | gpu-0 (`pci0000:10`) | rdmap160s27 (`pci0000:a0`) | No | ~6.04 GB/s |
+
+Cross-PCIe-root placement degrades performance by roughly 1.9x with the same GPU and EFA count: GDR is disabled when the EFA adapter has no direct PCIe path to the GPU, and data must traverse the CPU/PCIe switch fabric. DRA enables the topology-aware placement because `resource.kubernetes.io/pcieRoot` is published by both drivers, so CEL selectors co-locate GPU and EFA without hardcoding device names.

--- a/site/content/docs/user/azure-aks.md
+++ b/site/content/docs/user/azure-aks.md
@@ -1,0 +1,100 @@
+---
+title: "Azure AKS with DRANET"
+date: 2026-06-25T00:00:00Z
+---
+
+DRANET allocates GPUs and RDMA NICs together on Azure Kubernetes Service (AKS) using [Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/). This page covers two end-to-end AKS examples, NVIDIA GB300 and AMD MI300X, where both the GPUs and the ConnectX VFs are scheduled through DRA, with topology-aware NIC selection expressed as CEL in the `ResourceClaimTemplate`.
+
+The full source lives under [examples/azure_aks_examples](https://github.com/kubernetes-sigs/dranet/tree/main/examples/azure_aks_examples).
+
+| Example | GPU | NIC | DRA drivers |
+|---|---|---|---|
+| GB300 | 4 x NVIDIA GB300 | 4 x ConnectX VF (IB-only) | `gpu.nvidia.com` + `dra.net` |
+| MI300X | 8 x AMD Instinct MI300X | 8 x ConnectX-7 VF | `gpu.amd.com` + `dra.net` |
+
+## Shared setup
+
+Both examples assume the dranet DaemonSet runs on the GPU nodes, a GPU DRA driver publishes the GPUs as DRA devices, and the MPI Operator v0.7.0 is installed:
+
+```bash
+kubectl apply --server-side -k "https://github.com/kubeflow/mpi-operator/manifests/overlays/standalone?ref=v0.7.0"
+```
+
+Scheduling is driven entirely by the `ResourceSlice` objects each driver publishes; verify they are present with `kubectl get resourceslices`.
+
+### dranet on Azure
+
+dranet queries the Azure Instance Metadata Service (IMDS) at startup and attaches Azure-specific attributes to every device it publishes, including `azure.dra.net/placementGroupId` and `azure.dra.net/vmSize`. VMs in **different placement groups do not share an InfiniBand fabric**, and this is not visible from node labels or GPU-driver attributes. The `placementGroupId` attribute lets a CEL selector constrain a multi-node job to a single IB fabric.
+
+On Azure GPU SKUs the ConnectX VFs are often in **InfiniBand mode** with no Ethernet netdev. dranet discovers them by recording the RDMA link name (`rdmaDevice`) on the PCI device (a device is IB-only when it has a non-empty `rdmaDevice` and no `ifName`), and at pod start injects exactly the allocated `/dev/infiniband/uverbsN` character devices into the container. This enforces per-workload NIC isolation without `privileged: true`.
+
+### Usage pattern
+
+Both examples apply the claim templates, then select a test case by editing `resourceClaimTemplateName:` in `mpi-job.yaml`:
+
+```bash
+kubectl apply -f resource-claim-template.yaml
+kubectl apply -f mpi-job.yaml
+kubectl exec nccl-test-dra-worker-0 -- ls /dev/infiniband/   # confirms per-pod NIC isolation
+```
+
+## NVIDIA GB300
+
+Each ND GB300 v6 node has 4 NVIDIA GB300 GPUs and 4 Mellanox ConnectX IB NICs across 2 NUMA nodes (2 GPU + 2 NIC each). The GPU DRA devices carry `pciBusID` and NUMA attributes; the NIC DRA devices carry `pciAddress`, `rdmaDevice`, and `numaNode`.
+
+Four `ResourceClaimTemplate`s are defined (`1nic-aligned`, `1nic-unaligned`, `2nic-aligned`, `ib-same-fabric`). The aligned variant co-locates the GPU and NIC on the same NUMA node:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: 1nic-aligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pciBusID == "0008:06:00.0"'
+      - name: nic
+        exactly:
+          deviceClassName: dranet.net
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["dra.net"]["rdmaDevice"] == "mlx5_0"'
+```
+
+The `2nic-aligned` template requests `count: 2` NICs constrained to the same NUMA node, and `ib-same-fabric` constrains the NICs to a specific Azure placement group. See [`gb300/`](https://github.com/kubernetes-sigs/dranet/tree/main/examples/azure_aks_examples/gb300) for all four templates and the `MPIJob`.
+
+### GB300 results
+
+2-node `all_reduce_perf`, 1 GPU per worker, GDR via nvidia-peermem. Full results in the [GB300 README](https://github.com/kubernetes-sigs/dranet/blob/main/examples/azure_aks_examples/gb300/README.md).
+
+| Template | NIC(s) | NUMA relation | GDR | Avg busbw |
+|---|---|---|---|---:|
+| `1nic-aligned` | mlx5_0 (NUMA 0) | NODE | yes | ~56 GB/s |
+| `2nic-aligned` | mlx5_0 + mlx5_1 (NUMA 0) | NODE | yes | ~112 GB/s |
+| `1nic-unaligned` | mlx5_2 (NUMA 1) | SYS | no | ~25 GB/s |
+
+NUMA alignment matters ~4.5x here: cross-NUMA (SYS) placement drops from ~56 to ~25 GB/s with the same NIC count, because GDR is disabled and every transfer crosses the inter-socket interconnect.
+
+## AMD MI300X
+
+Each ND MI300X v5 node has 8 AMD Instinct MI300X GPUs and 8 ConnectX-7 VFs across 2 NUMA nodes (4 GPU + 4 NIC each). GPUs are allocated via `gpu.amd.com` and the NICs via dranet (`dra.net`). Three `ResourceClaimTemplate`s select NICs by NUMA node: `4nic-same-numa` (NUMA 0), `4nic-cross-numa` (NUMA 1), and `8nic-all`. See [`mi300x/`](https://github.com/kubernetes-sigs/dranet/tree/main/examples/azure_aks_examples/mi300x) for the templates and `MPIJob`.
+
+### MI300X results
+
+2-node `all_reduce_perf` across MI300X nodes, NIC set controlled by the DRA template. Full results in the [MI300X README](https://github.com/kubernetes-sigs/dranet/blob/main/examples/azure_aks_examples/mi300x/README.md).
+
+| Template | GPUs x NICs | Avg busbw | Peak busbw |
+|---|---|---:|---:|
+| `4nic-cross-numa` | 4 x 4 | 6.10 GB/s | 6.19 GB/s |
+| `4nic-same-numa` | 4 x 4 | 42.53 GB/s | 49.28 GB/s |
+| `8nic-all` | 8 x 8 | 67.73 GB/s | 78.81 GB/s |
+
+Same-NUMA NIC selection is ~7x faster than cross-NUMA at 4 GPU x 4 NIC, and scaling to all 8 NICs reaches ~78 GB/s, with no change except the claim template.

--- a/site/content/docs/user/distributed-training.md
+++ b/site/content/docs/user/distributed-training.md
@@ -1,0 +1,117 @@
+---
+title: "Distributed Training with NUMA-aligned GPUs and NICs"
+date: 2026-06-25T00:00:00Z
+---
+
+This example runs a PyTorch DistributedDataParallel (DDP) benchmark over NCCL and reports Model FLOPs Utilization (MFU). It follows the DRA + MPIJob pattern and compares **NUMA-aligned vs NUMA-unaligned** NIC placement for a 4 GPU / 4 NIC run on H100 nodes.
+
+The full source, including the launcher scripts, the benchmark, and both MPIJob manifests, lives at [examples/distributed_training](https://github.com/kubernetes-sigs/dranet/tree/main/examples/distributed_training).
+
+## Why NUMA alignment matters
+
+On a multi-socket GPU node, both the GPUs and the RDMA NICs attach to specific NUMA nodes via the PCIe topology. When a GPU and the NIC it uses for inter-node communication sit on the *same* NUMA node, traffic stays local to that socket (`NODE` path in `nvidia-smi topo -m`). When they sit on *different* NUMA nodes, traffic crosses the inter-socket interconnect (`SYS` path), adding latency and reducing bandwidth.
+
+This example demonstrates the effect by allocating the **same four GPUs** in both runs and varying only **which four NICs** are bound to them. DRANET makes this controllable because it publishes per-device attributes (including `rdma` and `numaNode`) that you select against in a `ResourceClaimTemplate` using CEL.
+
+## DeviceClass
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: dranet.net
+spec:
+  selectors:
+  - cel:
+      expression: device.driver == "dra.net"
+```
+
+## ResourceClaimTemplates
+
+Both templates request the **same four GPUs** (selected by `pciBusID`) and four NICs requiring `rdma == true`, differing only in the NIC `numaNode`:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: h100-4gpu-4nic-numa-aligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 4
+          selectors:
+          - cel:
+              expression: >-
+                device.attributes["resource.kubernetes.io"]["pciBusID"] in
+                ["0001:00:00.0", "0002:00:00.0", "0003:00:00.0", "0008:00:00.0"]
+      - name: nic
+        exactly:
+          deviceClassName: dranet.net
+          count: 4
+          selectors:
+          - cel:
+              expression: >-
+                device.attributes["dra.net"]["rdma"] == true &&
+                device.attributes["dra.net"]["numaNode"] == 0
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: h100-4gpu-4nic-numa-unaligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 4
+          selectors:
+          - cel:
+              expression: >-
+                device.attributes["resource.kubernetes.io"]["pciBusID"] in
+                ["0001:00:00.0", "0002:00:00.0", "0003:00:00.0", "0008:00:00.0"]
+      - name: nic
+        exactly:
+          deviceClassName: dranet.net
+          count: 4
+          selectors:
+          - cel:
+              expression: >-
+                device.attributes["dra.net"]["rdma"] == true &&
+                device.attributes["dra.net"]["numaNode"] == 1
+```
+
+The two `MPIJob` manifests (`mpi-job-4gpu-4nic-numa-aligned.yaml` / `-unaligned.yaml`) and the launcher, worker, and benchmark scripts are in the [example directory](https://github.com/kubernetes-sigs/dranet/tree/main/examples/distributed_training). The aligned and unaligned manifests are otherwise identical; they differ only in which `ResourceClaimTemplate` they reference.
+
+## Running the example
+
+Install the MPI Operator if the cluster does not already have the `MPIJob` CRD:
+
+```bash
+kubectl apply --server-side -k "https://github.com/kubeflow/mpi-operator/manifests/overlays/standalone?ref=v0.7.0"
+```
+
+`kubectl apply -k .` builds the benchmark ConfigMap and applies the device class and templates. Then apply one of the MPIJobs:
+
+```bash
+kubectl apply -k .
+kubectl apply -f mpi-job-4gpu-4nic-numa-aligned.yaml
+```
+
+Repeat with `mpi-job-4gpu-4nic-numa-unaligned.yaml` for the unaligned run. Each launcher prints a final `MFU_RESULT` line.
+
+## Results
+
+Cluster: 2 x `Standard_ND96isr_H100_v5` workers, 4 H100 GPUs per worker, 4 RDMA NICs per worker, BF16 DDP over NCCL. Full methodology and per-step output are in the [example README](https://github.com/kubernetes-sigs/dranet/blob/main/examples/distributed_training/README.md).
+
+| Case | Avg step | TFLOP/s per GPU | MFU |
+|---|---:|---:|---:|
+| NUMA aligned | 55.496 ms | 356.62 | 36.06% |
+| NUMA unaligned | 60.951 ms | 324.70 | 32.83% |
+
+The aligned run was ~8.95% faster per step and ~9.84% higher MFU, with no change except the NIC NUMA placement chosen by the `ResourceClaimTemplate`. That gap is the cost of crossing the inter-socket interconnect that NUMA-aware device selection avoids.

--- a/site/content/docs/user/gke-multinetwork.md
+++ b/site/content/docs/user/gke-multinetwork.md
@@ -1,0 +1,164 @@
+---
+title: "GKE Multiple Networks"
+date: 2026-06-25T00:00:00Z
+---
+
+This guide shows how to use DRANET on GKE to give Pods access to additional GCE
+network interfaces through Dynamic Resource Allocation (DRA). The full manifests
+are in the [demo_gke_multinetwork example](https://github.com/kubernetes-sigs/dranet/tree/main/examples/demo_gke_multinetwork).
+
+## Create a cluster
+
+DRANET on GKE needs multi-networking and Dataplane V2 enabled:
+
+```sh
+PROJECT="test-project"
+CLUSTER="test-cluster"
+ZONE="us-central1-c"
+VERSION="1.34"
+
+gcloud container clusters create "${CLUSTER}" \
+    --cluster-version="${VERSION}" \
+    --enable-multi-networking \
+    --enable-dataplane-v2 \
+    --no-enable-autorepair \
+    --no-enable-autoupgrade \
+    --zone="${ZONE}" \
+    --project="${PROJECT}"
+```
+
+## Create a node pool with multiple networks
+
+`dranetctl` is an opinionated tool that sets up the network infrastructure and
+labels the nodes with `dra.net/acceleratorpod: "true"`:
+
+```sh
+dranetctl gke acceleratorpod create dranet1 \
+    --additional-network-interfaces 2 \
+    --machine-type e2-standard-16 \
+    --node-count 2 \
+    --cluster test-cluster \
+    --location us-central1-c -v 2
+```
+
+## Install DRANET
+
+Install DRANET on the nodes created above:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/dranet/main/examples/dranetctl-install.yaml
+kubectl get pods -l k8s-app=dranet -n kube-system
+```
+
+Once the pods are running, DRANET exposes the node interfaces as DRA devices.
+Inspect them with `kubectl get resourceslices -o yaml`.
+
+## Define a DeviceClass
+
+The DeviceClass selects devices managed by the `dra.net` driver:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: multinic
+spec:
+  selectors:
+    - cel:
+        expression: device.driver == "dra.net"
+```
+
+## Request interfaces
+
+There are two ways to attach an interface to a workload.
+
+### Per-Pod claims with a ResourceClaimTemplate
+
+A `ResourceClaimTemplate` gives each Pod its own claim. This example selects the
+interface named `eth1` and attaches it to every replica of a Deployment:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: phy-interfaces-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: phy-interfaces-template
+          exactly:
+            deviceClassName: multinic
+            selectors:
+              - cel:
+                  expression: device.attributes["dra.net"].name == "eth1"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server-deployment
+  labels:
+    app: MyApp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: MyApp
+  template:
+    metadata:
+      labels:
+        app: MyApp
+    spec:
+      resourceClaims:
+        - name: phy-interfaces
+          resourceClaimTemplateName: phy-interfaces-template
+      containers:
+        - name: agnhost
+          image: registry.k8s.io/e2e-test-images/agnhost:2.54
+          args:
+            - netexec
+            - --http-port=80
+          ports:
+            - containerPort: 80
+```
+
+### A shared claim with a ResourceClaim
+
+A single `ResourceClaim` can be referenced directly by a Pod. This example
+selects an interface on the `dranet-net` cloud network:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: dranet-network
+spec:
+  devices:
+    requests:
+      - name: req-phy-interface
+        exactly:
+          deviceClassName: multinic
+          selectors:
+            - cel:
+                expression: device.attributes["dra.net"].cloudNetwork.contains("dranet-net")
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  labels:
+    app: pod
+spec:
+  containers:
+    - name: ctr1
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
+  resourceClaims:
+    - name: dranet-network
+      resourceClaimName: dranet-network
+```
+
+## Clean up
+
+```sh
+dranetctl gke acceleratorpod delete dranet1
+```

--- a/site/content/docs/user/nixl-kv-transfer.md
+++ b/site/content/docs/user/nixl-kv-transfer.md
@@ -1,0 +1,118 @@
+---
+title: "NIXL KV Transfer"
+date: 2026-06-25T00:00:00Z
+---
+
+This example demonstrates topologically-aware GPU + RDMA NIC allocation using Kubernetes Dynamic Resource Allocation (DRA). The workload uses [NIXL](https://github.com/ai-dynamo/nixl) over UCX/RDMA to copy a GPU-resident buffer between two pods running on two GPU nodes. The buffer is sized like an inference KV-cache handoff, so the result isolates the RDMA transfer path used by disaggregated prefill/decode serving without requiring a full vLLM router/model stack.
+
+Both GPUs and NICs are allocated through DRA: GPUs via the `gpu.nvidia.com` DeviceClass and RDMA NICs via DRANET's `dranet.net` DeviceClass. By keeping the same 4-GPU set across runs and changing only the NIC NUMA placement, the example measures how same-NUMA versus cross-NUMA GPU/NIC alignment affects KV transfer bandwidth and latency.
+
+Full source: [examples/nixl-kv-transfer](https://github.com/kubernetes-sigs/dranet/tree/main/examples/nixl-kv-transfer).
+
+## Tested topology
+
+The included templates were tested on two GPU nodes with:
+
+| Resource | Count | Detail |
+|---|---:|---|
+| GPU | 8 x NVIDIA H100 | 80 GB HBM3 each |
+| NIC | 8 x Mellanox ConnectX VF | RDMA-capable |
+| NUMA nodes | 2 | 4 GPU + 4 NIC per NUMA node |
+
+The manifests are intentionally cloud-provider agnostic. The checked-in `ResourceClaimTemplate` values match the tested 8-GPU H100 topology; adapt the GPU `pciBusID` and NIC `numaNode` selectors to your hardware before running on another SKU. Some GPU DRA drivers publish GPU `pciBusID` but not GPU `numaNode`, so this example selects GPUs by `pciBusID`; DRANET publishes NIC `numaNode` directly.
+
+## ResourceClaimTemplates
+
+The core DRA manifests are two `ResourceClaimTemplate`s. Both keep compute fixed (the same 4 GPUs on NUMA 0) and keep the aggregate NIC count fixed (4 NICs). The only intended difference is whether each visible GPU reaches a same-NUMA or remote-NUMA NIC.
+
+| Template | GPU selection | NIC selection | Purpose |
+|---|---|---|---|
+| `h100-4gpu-4nic-numa-aligned` | 4 GPUs on NUMA 0 | 4 NICs on NUMA 0 | Same-NUMA GPU/NIC path |
+| `h100-4gpu-4nic-numa-unaligned` | Same 4 GPUs on NUMA 0 | 4 NICs on NUMA 1 | Cross-NUMA GPU/NIC path |
+
+`resource-claim-template-aligned.yaml` selects NUMA-aligned GPUs and NICs:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: h100-4gpu-4nic-numa-aligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 4
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"]["pciBusID"] in ["0001:00:00.0","0002:00:00.0","0003:00:00.0","0008:00:00.0"]'
+      - name: nic
+        exactly:
+          deviceClassName: dranet.net
+          count: 4
+          selectors:
+          - cel:
+              expression: 'device.attributes["dra.net"]["rdma"] == true && device.attributes["dra.net"]["numaNode"] == 0'
+```
+
+`resource-claim-template-unaligned.yaml` uses the same GPUs but cross-NUMA NICs (note `numaNode == 1`):
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: h100-4gpu-4nic-numa-unaligned
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 4
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"]["pciBusID"] in ["0001:00:00.0","0002:00:00.0","0003:00:00.0","0008:00:00.0"]'
+      - name: nic
+        exactly:
+          deviceClassName: dranet.net
+          count: 4
+          selectors:
+          - cel:
+              expression: 'device.attributes["dra.net"]["rdma"] == true && device.attributes["dra.net"]["numaNode"] == 1'
+```
+
+## Run
+
+Apply everything via kustomize. This creates both `ResourceClaimTemplate`s, the `nixl-benchmark` ConfigMap (generated from `nixl_benchmark.py` and `run_bench.sh`), the headless Service, and both pods:
+
+```bash
+kubectl apply -k .
+```
+
+The pods default to the `h100-4gpu-4nic-numa-aligned` template. The initiator and target manifests, the headless Service, the benchmark, and the run script are in the [example directory](https://github.com/kubernetes-sigs/dranet/tree/main/examples/nixl-kv-transfer). The initiator log contains one `RESULT` JSON object with `avg_GBps`, `avg_seconds`, and the `p50`/`p95`/`p99` latencies.
+
+## Verify allocation
+
+Confirm that only the allocated RDMA devices are visible inside each pod:
+
+```bash
+kubectl get resourceclaims -o yaml | grep -E 'name:|device:|driver:|request:'
+kubectl exec nixl-kv-initiator -- ls /dev/infiniband
+kubectl exec nixl-kv-target -- ls /dev/infiniband
+```
+
+In the aligned case the visible NICs are NODE-local to the selected GPUs; in the unaligned case they are SYS/cross-NUMA.
+
+## Benchmark results
+
+Observed on the tested 8 x H100 node topology with 1 GiB NIXL `WRITE` transfers, 20 warmup iterations, and 100 timed iterations per run (three-run mean). Full results are in the [example README](https://github.com/kubernetes-sigs/dranet/blob/main/examples/nixl-kv-transfer/README.md).
+
+| Template | NICs | Avg bandwidth | Avg latency |
+|---|---|---:|---:|
+| `h100-4gpu-4nic-numa-aligned` | `mlx5_0`..`mlx5_3` | 39.07 GB/s | 27.49 ms |
+| `h100-4gpu-4nic-numa-unaligned` | `mlx5_4`..`mlx5_7` | 27.54 GB/s | 38.99 ms |
+
+Same GPUs, same NIC count, same transfer size: same-NUMA GPU/NIC allocation delivers about 1.42x higher bandwidth and about 29.5% lower latency for this transfer. This is the inference KV-cache handoff path, so the bandwidth gap surfaces as decode tail latency under concurrency.


### PR DESCRIPTION
Adds website pages for the examples that were not yet on dranet.sigs.k8s.io,
following the existing `gke-rdma.md` / `nvidia-dranet.md` pattern:

- gke-multinetwork
- aws-eks-efa
- azure-aks (GB300 + MI300X)
- distributed-training
- nixl-kv-transfer

Each page adapts the example's README and embeds its core DeviceClass /
ResourceClaimTemplate manifests; benchmark figures are transcribed from each
example's README, with links back to the example directory for the full
manifests and results.

Fixes #204.

Note: while writing the GKE multi-network page I noticed
`examples/demo_gke_multinetwork/resourceclaim.yaml` still uses
`resource.k8s.io/v1beta1`, which was removed in 1.34. I used `v1` on the page to
match the other manifests; happy to send a follow-up that updates the example
itself.



```release-note
NONE
```
