### PR TITLE
feat: implement IPVLAN Subinterface configuration and provision

### DIFF
--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -166,9 +166,13 @@ func main() {
 
 	opts := []driver.Option{}
 
-	if dbPath != "" {
-		opts = append(opts, driver.WithDBPath(dbPath))
+	// Build the pod config store. If dbPath is empty the store is in-memory only;
+	// otherwise it is backed by a bbolt checkpoint at that path.
+	store, err := driver.NewPodConfigStore(dbPath)
+	if err != nil {
+		klog.Fatalf("failed to initialize pod config store: %v", err)
 	}
+	defer store.Close()
 
 	opts = append(opts, driver.WithKubeletRootDir(kubeletRootDir))
 
@@ -224,7 +228,7 @@ func main() {
 
 	db := inventory.New(optsDb...)
 	opts = append(opts, driver.WithInventory(db))
-	dranet, err := driver.Start(ctx, driverName, clientset, nodeName, opts...)
+	dranet, err := driver.Start(ctx, driverName, clientset, nodeName, store, opts...)
 	if err != nil {
 		klog.Fatalf("driver failed to start: %v", err)
 	}

--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -201,8 +201,9 @@ func main() {
 		profileProvider:   profileProvider,
 		webhookURL:        webhookURL,
 		dependencies: discovery.Dependencies{
-			NodeClient: clientset.CoreV1().Nodes(),
-			NodeName:   nodeName,
+			NodeClient:        clientset.CoreV1().Nodes(),
+			NodeName:          nodeName,
+			ReservedAddresses: store.GetInUseSubinterfaceIPs(),
 		},
 	}
 	cloudInst, profProv, err := setupProviders(ctx, providerOpts)

--- a/pkg/apis/config_merge.go
+++ b/pkg/apis/config_merge.go
@@ -24,7 +24,8 @@ import (
 // It returns a new *NetworkConfig with the merged result.
 // It follows a strict "User wins" strategy: any scalar setting defined in the user config
 // overrides the cloud provider config. For slices, the two configurations are combined,
-// but duplicates are resolved in favor of the user config.
+// but duplicates are resolved in favor of the user config. For subinterface IPRanges,
+// user-provided ranges are ordered before cloud-provided ranges before deduplication.
 // The user parameter is assumed to be non-nil. The cloud parameter can be nil, resulting in
 // a copy of the user parameter.
 func MergeNetworkConfig(user, cloud *NetworkConfig) *NetworkConfig {
@@ -48,6 +49,26 @@ func MergeNetworkConfig(user, cloud *NetworkConfig) *NetworkConfig {
 	// Deduplicate slices where order or uniqueness matters.
 	// For addresses, we just unique them.
 	merged.Interface.Addresses = deduplicateStrings(merged.Interface.Addresses)
+	if merged.SubInterface != nil {
+		merged.SubInterface.Addresses = deduplicateStrings(merged.SubInterface.Addresses)
+
+		// For IPRanges, place user-provided ranges first and cloud-provided
+		// ranges after, then remove exact duplicates.
+		var userRanges, cloudRanges []IPRangeConfig
+		if user.SubInterface != nil {
+			userRanges = user.SubInterface.IPRanges
+		}
+		if cloud.SubInterface != nil {
+			cloudRanges = cloud.SubInterface.IPRanges
+		}
+		combined := append(append([]IPRangeConfig{}, userRanges...), cloudRanges...)
+		merged.SubInterface.IPRanges = deduplicateIPRanges(combined)
+	}
+
+	// Subinterface creation is activated only when Type is set; otherwise, discard the subinterface config.
+	if merged.SubInterface != nil && merged.SubInterface.Type == "" {
+		merged.SubInterface = nil
+	}
 
 	// For Routes, deduplicate by destination and table (user wins, which were appended last, so we
 	// iterate backwards). Routes to the same destination in different tables are distinct entries
@@ -66,6 +87,20 @@ func deduplicateStrings(s []string) []string {
 		if !seen[s[i]] {
 			seen[s[i]] = true
 			res = append([]string{s[i]}, res...)
+		}
+	}
+	return res
+}
+
+// deduplicateIPRanges removes exact-duplicate ranges, preserving the order of the
+// first occurrence.
+func deduplicateIPRanges(ranges []IPRangeConfig) []IPRangeConfig {
+	seen := make(map[IPRangeConfig]bool)
+	var res []IPRangeConfig
+	for _, r := range ranges {
+		if !seen[r] {
+			seen[r] = true
+			res = append(res, r)
 		}
 	}
 	return res

--- a/pkg/apis/config_merge.go
+++ b/pkg/apis/config_merge.go
@@ -53,7 +53,13 @@ func MergeNetworkConfig(user, cloud *NetworkConfig) *NetworkConfig {
 	// iterate backwards). Routes to the same destination in different tables are distinct entries
 	// (policy routing) and are all kept.
 	merged.Routes = deduplicateRoutes(merged.Routes)
+	merged.Rules = deduplicateRules(merged.Rules)
 	merged.Neighbors = deduplicateNeighbors(merged.Neighbors)
+
+	// Drop the meaningless IPVLAN config if the resolved type is not ipvlan.
+	if merged.Interface.Type != InterfaceTypeIPVLAN {
+		merged.Interface.IPVlan = nil
+	}
 
 	return merged
 }
@@ -85,6 +91,18 @@ func deduplicateRoutes(routes []RouteConfig) []RouteConfig {
 		if !seen[key] {
 			seen[key] = true
 			res = append([]RouteConfig{routes[i]}, res...)
+		}
+	}
+	return res
+}
+
+func deduplicateRules(rules []RuleConfig) []RuleConfig {
+	seen := make(map[RuleConfig]bool)
+	var res []RuleConfig
+	for i := len(rules) - 1; i >= 0; i-- {
+		if !seen[rules[i]] {
+			seen[rules[i]] = true
+			res = append([]RuleConfig{rules[i]}, res...)
 		}
 	}
 	return res

--- a/pkg/apis/config_merge_test.go
+++ b/pkg/apis/config_merge_test.go
@@ -173,6 +173,76 @@ func TestMergeNetworkConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "subinterface: user requests IPVlan type subinterface, keep the configuration",
+			user: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					Type: "ipvlan",
+				},
+			},
+			cloud: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					IPRanges: []IPRangeConfig{{CIDR: "10.24.3.0/24"}},
+				},
+			},
+			want: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					Type:     "ipvlan",
+					IPRanges: []IPRangeConfig{{CIDR: "10.24.3.0/24"}},
+				},
+			},
+		},
+		{
+			name: "subinterface: cloud provider requests IPVlan type subinterface, keep the configuration",
+			user: &NetworkConfig{},
+			cloud: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					Type:     "ipvlan",
+					IPRanges: []IPRangeConfig{{CIDR: "10.24.3.0/24"}},
+				},
+			},
+			want: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					Type:     "ipvlan",
+					IPRanges: []IPRangeConfig{{CIDR: "10.24.3.0/24"}},
+				},
+			},
+		},
+		{
+			name: "subinterface: IPRanges from user and cloud are combined user-first and deduplicated",
+			user: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					Type:     "ipvlan",
+					IPRanges: []IPRangeConfig{{CIDR: "10.1.0.0/24"}, {CIDR: "10.24.3.0/24"}},
+				},
+			},
+			cloud: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					Type:     "ipvlan",
+					IPRanges: []IPRangeConfig{{CIDR: "10.24.3.0/24"}, {CIDR: "10.2.0.0/24"}},
+				},
+			},
+			want: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					Type:     "ipvlan",
+					IPRanges: []IPRangeConfig{{CIDR: "10.1.0.0/24"}, {CIDR: "10.24.3.0/24"}, {CIDR: "10.2.0.0/24"}},
+				},
+			},
+		},
+		{
+			name: "subinterface: Type is not specified, discard the configuration",
+			user: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					Name: "eth0",
+				},
+			},
+			cloud: &NetworkConfig{
+				SubInterface: &SubInterfaceConfig{
+					IPRanges: []IPRangeConfig{{CIDR: "10.24.3.0/24"}},
+				},
+			},
+			want: &NetworkConfig{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/apis/config_merge_test.go
+++ b/pkg/apis/config_merge_test.go
@@ -173,6 +173,62 @@ func TestMergeNetworkConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "user requests ipvlan interface type, cloud provider configs merge in",
+			user: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Name: "eth0",
+					Type: InterfaceTypeIPVLAN,
+				},
+			},
+			cloud: &NetworkConfig{
+				Interface: InterfaceConfig{
+					MTU: ptr.To[int32](1500),
+				},
+			},
+			want: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Name: "eth0",
+					Type: InterfaceTypeIPVLAN,
+					MTU:  ptr.To[int32](1500),
+				},
+			},
+		},
+		{
+			name: "no user request, cloud provider configures ipvlan type, cloud provider override",
+			user: &NetworkConfig{},
+			cloud: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type:   InterfaceTypeIPVLAN,
+					IPVlan: &IPVlanConfig{Mode: "L2", Flag: "Bridge"},
+				},
+			},
+			want: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type:   InterfaceTypeIPVLAN,
+					IPVlan: &IPVlanConfig{Mode: "L2", Flag: "Bridge"},
+				},
+			},
+		},
+		{
+			name: "user requests passthrough type, cloud provider configures ipvlan type, user wins",
+			user: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type: "Passthrough",
+				},
+			},
+			cloud: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type:   InterfaceTypeIPVLAN,
+					IPVlan: &IPVlanConfig{Mode: "L2", Flag: "Bridge"},
+				},
+			},
+			want: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type: "Passthrough",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/apis/constants.go
+++ b/pkg/apis/constants.go
@@ -30,7 +30,14 @@ const (
 	RdmaNetnsModeShared    = "shared"
 	RdmaNetnsModeExclusive = "exclusive"
 
-	// VRFTableOffset is the offset used for VRF routing tables to avoid ID collisions
-	// with reserved tables (0, 253, 254, 255) and to identify DRANET managed tables.
-	VRFTableOffset = 1000
+	// RouteTableOffset is the offset used for DRANET-managed routing tables
+	// (VRF and source-based routing) to avoid ID collisions with reserved
+	// tables (0, 253, 254, 255) and to identify DRANET managed tables.
+	RouteTableOffset = 1000
+
+	// SourceRoutingRulePriority is the priority for provider-generated source
+	// based routing rules. It must be lower than the kernel's implicit "main"
+	// table rule (32766) so matching traffic is routed via the interface's
+	// table instead of falling through to the default route.
+	SourceRoutingRulePriority = 32000
 )

--- a/pkg/apis/defaults.go
+++ b/pkg/apis/defaults.go
@@ -9,6 +9,9 @@ func (c *NetworkConfig) Default() {
 	if c.Interface.VRF != nil {
 		c.Interface.VRF.Default()
 	}
+	if c.SubInterface != nil {
+		c.SubInterface.Default()
+	}
 }
 
 // Default applies default values to the VRFConfig.
@@ -21,5 +24,20 @@ func (c *VRFConfig) Default() {
 		// Use the constant from this package
 		tableID := int((h.Sum32() % 1000) + VRFTableOffset)
 		c.Table = &tableID
+	}
+}
+
+// Default applies default values to the SubInterfaceConfig.
+func (c *SubInterfaceConfig) Default() {
+	if c.Type == SubInterfaceTypeIPVlan {
+		if c.IPVlan == nil {
+			c.IPVlan = &IPVlanConfig{}
+		}
+		if c.IPVlan.Mode == "" {
+			c.IPVlan.Mode = "l2"
+		}
+		if c.IPVlan.Flag == "" {
+			c.IPVlan.Flag = "bridge"
+		}
 	}
 }

--- a/pkg/apis/defaults.go
+++ b/pkg/apis/defaults.go
@@ -6,8 +6,23 @@ import (
 
 // Default applies default values to the NetworkConfig.
 func (c *NetworkConfig) Default() {
+	c.Interface.Default()
+	if c.Interface.Type == InterfaceTypeIPVLAN {
+		if c.Interface.IPVlan == nil {
+			c.Interface.IPVlan = &IPVlanConfig{}
+		}
+		c.Interface.IPVlan.Default()
+	}
 	if c.Interface.VRF != nil {
 		c.Interface.VRF.Default()
+	}
+}
+
+// Default applies default values to the InterfaceConfig.
+func (c *InterfaceConfig) Default() {
+	// Fold the deprecated DHCP field into Addressing when Addressing is unset.
+	if c.Addressing == "" && c.DHCP != nil && *c.DHCP {
+		c.Addressing = AddressingModeDHCP
 	}
 }
 
@@ -16,10 +31,26 @@ func (c *VRFConfig) Default() {
 	if c.Table == nil && c.Name != "" {
 		// Derive a deterministic table ID from the VRF name to ensure interfaces
 		// joining the same VRF automatically share the same table ID.
-		h := fnv.New32a()
-		h.Write([]byte(c.Name))
-		// Use the constant from this package
-		tableID := int((h.Sum32() % 1000) + VRFTableOffset)
+		tableID := TableIDForName(c.Name)
 		c.Table = &tableID
+	}
+}
+
+// TableIDForName derives a deterministic DRANET-managed routing table ID from a
+// name (e.g. a VRF name or a device identifier). VRF and policy based routing
+// share this scheme so their tables come from the same reserved range.
+func TableIDForName(name string) int {
+	h := fnv.New32a()
+	h.Write([]byte(name))
+	return int((h.Sum32() % 1000) + RouteTableOffset)
+}
+
+// Default applies default values to the IPVlanConfig.
+func (c *IPVlanConfig) Default() {
+	if c.Mode == "" {
+		c.Mode = IPVlanModeL2
+	}
+	if c.Flag == "" {
+		c.Flag = IPVlanFlagBridge
 	}
 }

--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -23,6 +23,7 @@ type NetworkConfig struct {
 	// parameters resolved by the provider plugin (e.g., dynamic IPAM).
 	// This separates user intent from infrastructure implementation.
 	Profile string `json:"profile,omitempty"`
+
 	// Interface defines core properties of the network interface.
 	// Settings here are typically managed by `ip link` commands.
 	Interface InterfaceConfig `json:"interface"`
@@ -48,12 +49,31 @@ type InterfaceConfig struct {
 	// If not specified, DraNet may use or derive a name from the original interface.
 	Name string `json:"name,omitempty"`
 
+	// Type selects how the allocated device is presented to the Pod:
+	//   - "Passthrough" (default): the network device itself is moved into the
+	//     Pod's network namespace.
+	//   - "IPVLAN": the device stays in the host namespace and an IPVLAN
+	//     subinterface is created on top of it inside the Pod.
+	// It may be set by the cloud provider or in the user's ResourceClaim.
+	// If empty, it is treated as "Passthrough".
+	Type InterfaceType `json:"type,omitempty"`
+
+	// Addressing selects the IP address configuration strategy:
+	// "Static" (default), "DHCP", or "Unnumbered".
+	// An empty value is treated as "Static".
+	Addressing AddressingMode `json:"addressing,omitempty"`
+
 	// Addresses is a list of IP addresses in CIDR format (e.g., "192.168.1.10/24")
 	// to be assigned to the interface.
 	Addresses []string `json:"addresses,omitempty"`
 
 	// DHCP, if true, indicates that the interface should be configured via DHCP.
 	// This is mutually exclusive with the 'addresses' field.
+	//
+	// Deprecated: use Addressing: "DHCP" instead. Retained for backward
+	// compatibility: when Addressing is unset, DHCP=true is normalized to
+	// Addressing: "DHCP". Setting DHCP together with an explicit Addressing is
+	// rejected by validation.
 	DHCP *bool `json:"dhcp,omitempty"`
 
 	// MTU is the Maximum Transmission Unit for the interface.
@@ -104,6 +124,9 @@ type InterfaceConfig struct {
 	// If provided, the interface will be enslaved to a VRF device with this name.
 	// This enables grouping multiple network interfaces into the same VRF.
 	VRF *VRFConfig `json:"vrf,omitempty"`
+
+	// IPVlan holds IPVLAN-specific settings (mode and flag). Applies only when Type is "IPVLAN".
+	IPVlan *IPVlanConfig `json:"ipvlan,omitempty"`
 }
 
 // VRFConfig represents the configuration for a Virtual Routing and Forwarding domain.
@@ -117,6 +140,61 @@ type VRFConfig struct {
 	// Common reserved tables: 255 (local), 254 (main), 253 (default).
 	Table *int `json:"table,omitempty"`
 }
+
+// InterfaceType specifies how an allocated network device is presented to the Pod.
+type InterfaceType string
+
+const (
+	// InterfaceTypePassthrough moves the network device into the Pod's namespace. This is the default.
+	InterfaceTypePassthrough InterfaceType = "Passthrough"
+	// InterfaceTypeIPVLAN creates an IPVLAN subinterface in the Pod on top of the host device.
+	InterfaceTypeIPVLAN InterfaceType = "IPVLAN"
+)
+
+// AddressingMode selects how a Pod interface obtains its IP configuration.
+type AddressingMode string
+
+const (
+	// AddressingModeStatic configures IP addresses from InterfaceConfig.Addresses
+	// or from a cloud provider profile. This is the default.
+	AddressingModeStatic AddressingMode = "Static"
+	// AddressingModeDHCP obtains network configuration via DHCP.
+	AddressingModeDHCP AddressingMode = "DHCP"
+	// AddressingModeUnnumbered brings the interface up without driver configuring
+	// IP addresses or routes. Valid only for subinterfaces.
+	AddressingModeUnnumbered AddressingMode = "Unnumbered"
+)
+
+// IsSubinterface reports whether this interface must be realized as a
+// subinterface created on top of the parent device (e.g. IPVLAN), rather than
+// moving the device itself into the Pod's network namespace (passthrough).
+func (c InterfaceConfig) IsSubinterface() bool {
+	return c.Type == InterfaceTypeIPVLAN
+}
+
+// IPVlanConfig holds the mode and flag of an IPVLAN subinterface.
+type IPVlanConfig struct {
+	// Mode selects the IPVLAN operating mode. Defaults to IPVlanModeL2.
+	Mode IPVlanMode `json:"mode,omitempty"`
+	// Flag selects the IPVLAN link behavior. Defaults to IPVlanFlagBridge.
+	Flag IPVlanFlag `json:"flag,omitempty"`
+}
+
+// IPVlanMode defines how traffic is routed to the IPVLAN child interfaces.
+type IPVlanMode string
+
+const (
+	// IPVlanModeL2 has child interfaces handle their own L2 protocols like ARP.
+	IPVlanModeL2 IPVlanMode = "L2"
+)
+
+// IPVlanFlag defines the link behavior of the IPVLAN child interfaces.
+type IPVlanFlag string
+
+const (
+	// IPVlanFlagBridge lets child interfaces talk directly to each other internally.
+	IPVlanFlagBridge IPVlanFlag = "Bridge"
+)
 
 // RouteConfig represents a network route configuration.
 type RouteConfig struct {

--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -23,9 +23,15 @@ type NetworkConfig struct {
 	// parameters resolved by the provider plugin (e.g., dynamic IPAM).
 	// This separates user intent from infrastructure implementation.
 	Profile string `json:"profile,omitempty"`
+
 	// Interface defines core properties of the network interface.
 	// Settings here are typically managed by `ip link` commands.
 	Interface InterfaceConfig `json:"interface"`
+
+	// SubInterface defines the properties of the subinterfaces created on the network interface.
+	// When specified, new subinterfaces will be created in the pod namespace based
+	// on this config, while the original interface stays in the host namespace.
+	SubInterface *SubInterfaceConfig `json:"subInterface,omitempty"`
 
 	// Routes defines static routes to be configured for this interface.
 	Routes []RouteConfig `json:"routes,omitempty"`
@@ -102,6 +108,85 @@ type VRFConfig struct {
 	// If not specified, a unique table ID will be automatically assigned (typically interface index + 100).
 	// Common reserved tables: 255 (local), 254 (main), 253 (default).
 	Table *int `json:"table,omitempty"`
+}
+
+// SubInterfaceConfig describes a virtual subinterface (e.g. IPVLAN) to create
+// in the Pod on top of a shared host network interface. A valid Type field
+// activates it and triggers creation of the subinterface.
+type SubInterfaceConfig struct {
+	// Type indicates the network type of the subinterface.
+	// A valid Type activates the configuration and creation of
+	// the subinterface. It can either be populated by the cloud
+	// provider or explicitly requested in the user's ResourceClaim.
+	// For now, we only support type "ipvlan".
+	Type SubInterfaceType `json:"type,omitempty"`
+
+	// Name is the desired logical name of the subinterface inside the Pod.
+	// If not specified, it will be derived by adding a type prefix to the parent interface name.
+	// e.g. for ipvlan type, Name will be "ipvlan-<parent_interface_name>"
+	Name string `json:"name,omitempty"`
+
+	// Addresses is a list of IP addresses in CIDR format assigned to the subinterface.
+	// It is normally populated dynamically by node-local IPAM from IPRanges; if set
+	// explicitly, those addresses are used as-is and IPAM allocation is skipped.
+	// If no custom routes or rules are specified, automatic source-based routing is
+	// configured for these addresses on the subinterface.
+	Addresses []string `json:"addresses,omitempty"`
+
+	// IPRanges is a list of IP address ranges from which the node-local IPAM
+	// generates IP addresses for the subinterface. It may be provided by the cloud
+	// provider in GetDeviceConfig and/or by the user. Exactly one IP address is
+	// generated per IP family present in the list.
+	IPRanges []IPRangeConfig `json:"ipRanges,omitempty"`
+
+	// IPVlan holds IPVLAN-specific settings (mode and flag); it applies only
+	// when Type is "ipvlan".
+	IPVlan *IPVlanConfig `json:"ipvlan,omitempty"`
+}
+
+// IPRangeConfig describes an allocatable IP address range for node-local IPAM.
+//
+// A range can be specified in one of two ways:
+//  1. Explicit boundaries: both StartIP and EndIP are set (CIDR may be omitted).
+//     The driver validates that both are valid IP addresses of the same family
+//     and that StartIP <= EndIP.
+//  2. CIDR: only CIDR is set (StartIP and EndIP omitted). The driver validates
+//     the CIDR and derives the allocatable boundaries from it, spanning every
+//     address except the network (base) address and the broadcast (last) address.
+//
+// If all three fields are set, StartIP/EndIP take priority (when valid) and CIDR
+// is used only to sanity-check that the boundaries fall within it.
+type IPRangeConfig struct {
+	// CIDR is the network range in CIDR notation.
+	// It is optional when both StartIP and EndIP are provided.
+	CIDR string `json:"cidr,omitempty"`
+	// StartIP is the first IP address that can be allocated from the range.
+	// If empty, the driver derives it from CIDR as the first address after the network address.
+	StartIP string `json:"startIP,omitempty"`
+	// EndIP is the last IP address that can be allocated from the range.
+	// If empty, the driver derives it from CIDR as the last address before the broadcast address.
+	EndIP string `json:"endIP,omitempty"`
+}
+
+// SubInterfaceType specifies the available subinterface network types.
+// Currently the supported type is "ipvlan".
+type SubInterfaceType string
+
+const (
+	SubInterfaceTypeIPVlan SubInterfaceType = "ipvlan"
+)
+
+// IPVlanConfig holds the mode and flag of an IPVLAN subinterface.
+// Currently only "l2" mode with the "bridge" flag is supported.
+type IPVlanConfig struct {
+	// Mode defines how traffic is routed to the IPVlan child interfaces.
+	// Currently the supported mode is:
+	// - "l2": child interfaces handle their own L2 protocols like ARP.
+	Mode string `json:"mode,omitempty"`
+	// Flag defines the link behavior of the IPVlan child interfaces.
+	// Currently the supported flag is:
+	// - "bridge": child interfaces can talk directly to each other internally.
+	Flag string `json:"flag,omitempty"`
 }
 
 // RouteConfig represents a network route configuration.

--- a/pkg/apis/validation.go
+++ b/pkg/apis/validation.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -137,6 +138,33 @@ func validateInterfaceConfig(cfg *InterfaceConfig, fieldPath string) (allErrors 
 		return
 	}
 
+	if !slices.Contains([]InterfaceType{"", InterfaceTypePassthrough, InterfaceTypeIPVLAN}, cfg.Type) {
+		allErrors = append(allErrors, fmt.Errorf("%s.type: '%s' is not supported", fieldPath, cfg.Type))
+	}
+
+	if cfg.IsSubinterface() {
+		allErrors = append(allErrors, validateSubinterfaceOnlyConfig(cfg, fieldPath)...)
+	}
+
+	if !slices.Contains([]AddressingMode{"", AddressingModeStatic, AddressingModeDHCP, AddressingModeUnnumbered}, cfg.Addressing) {
+		allErrors = append(allErrors, fmt.Errorf("%s.addressing: '%s' is not supported", fieldPath, cfg.Addressing))
+	}
+
+	// The deprecated dhcp field may only coexist with "DHCP" addressing.
+	if cfg.DHCP != nil && *cfg.DHCP && cfg.Addressing != "" && cfg.Addressing != AddressingModeDHCP {
+		allErrors = append(allErrors, fmt.Errorf("%s: dhcp is deprecated and conflicts with addressing '%s'", fieldPath, cfg.Addressing))
+	}
+
+	// Unnumbered is only valid for subinterfaces and cannot carry addresses.
+	if cfg.Addressing == AddressingModeUnnumbered {
+		if !cfg.IsSubinterface() {
+			allErrors = append(allErrors, fmt.Errorf("%s.addressing: '%s' is only valid for subinterface types", fieldPath, AddressingModeUnnumbered))
+		}
+		if len(cfg.Addresses) > 0 {
+			allErrors = append(allErrors, fmt.Errorf("%s.addressing: '%s' cannot be set together with addresses", fieldPath, AddressingModeUnnumbered))
+		}
+	}
+
 	allErrors = append(allErrors, isValidLinuxInterfaceName(cfg.Name, fieldPath+".name")...)
 
 	for i, addr := range cfg.Addresses {
@@ -145,7 +173,7 @@ func validateInterfaceConfig(cfg *InterfaceConfig, fieldPath string) (allErrors 
 		}
 	}
 
-	if cfg.DHCP != nil && *cfg.DHCP && len(cfg.Addresses) > 0 {
+	if (cfg.Addressing == AddressingModeDHCP || (cfg.DHCP != nil && *cfg.DHCP)) && len(cfg.Addresses) > 0 {
 		allErrors = append(allErrors, fmt.Errorf("%s: dhcp and addresses are mutually exclusive", fieldPath))
 	}
 
@@ -189,6 +217,15 @@ func validateInterfaceConfig(cfg *InterfaceConfig, fieldPath string) (allErrors 
 		allErrors = append(allErrors, validateVRFConfig(cfg.VRF, fieldPath+".vrf")...)
 	}
 
+	if cfg.IPVlan != nil {
+		// Surface an error for the misconfiguration instead of silently dropping it.
+		if cfg.Type != InterfaceTypeIPVLAN {
+			allErrors = append(allErrors, fmt.Errorf("%s.ipvlan: configuration invalid for non-ipvlan interface type", fieldPath))
+		} else {
+			allErrors = append(allErrors, validateIPVlanConfig(cfg.IPVlan, fieldPath+".ipvlan")...)
+		}
+	}
+
 	return allErrors
 }
 
@@ -205,6 +242,17 @@ func validateVRFConfig(cfg *VRFConfig, fieldPath string) (allErrors []error) {
 		if *cfg.Table == 253 || *cfg.Table == 254 || *cfg.Table == 255 {
 			allErrors = append(allErrors, fmt.Errorf("%s.table: cannot use reserved table ID %d", fieldPath, *cfg.Table))
 		}
+	}
+
+	return allErrors
+}
+
+func validateIPVlanConfig(cfg *IPVlanConfig, fieldPath string) (allErrors []error) {
+	if cfg.Mode != IPVlanModeL2 {
+		allErrors = append(allErrors, fmt.Errorf("%s.mode: '%s' is not supported", fieldPath, cfg.Mode))
+	}
+	if cfg.Flag != IPVlanFlagBridge {
+		allErrors = append(allErrors, fmt.Errorf("%s.flag: '%s' is not supported", fieldPath, cfg.Flag))
 	}
 
 	return allErrors
@@ -333,12 +381,14 @@ func ValidateRDMAOnlyConfig(raw *runtime.RawExtension) []error {
 	for _, e := range strictErrs {
 		allErrors = append(allErrors, fmt.Errorf("failed to unmarshal strict JSON data: %w", e))
 	}
-	if config.Interface.Name != "" || len(config.Interface.Addresses) > 0 ||
+	if config.Interface.Name != "" || config.Interface.Type != "" ||
+		config.Interface.Addressing != "" || len(config.Interface.Addresses) > 0 ||
 		config.Interface.MTU != nil || config.Interface.HardwareAddr != nil ||
 		config.Interface.DHCP != nil || config.Interface.GSOMaxSize != nil ||
 		config.Interface.GROMaxSize != nil || config.Interface.GSOIPv4MaxSize != nil ||
 		config.Interface.GROIPv4MaxSize != nil || config.Interface.DisableEBPFPrograms != nil ||
-		config.Interface.ARPIgnore != nil || config.Interface.ARPAnnounce != nil {
+		config.Interface.ARPIgnore != nil || config.Interface.ARPAnnounce != nil ||
+		config.Interface.IPVlan != nil {
 		allErrors = append(allErrors, fmt.Errorf("interface configuration is not supported for RDMA-only devices (no network interface present)"))
 	}
 	if len(config.Routes) > 0 {
@@ -352,6 +402,19 @@ func ValidateRDMAOnlyConfig(raw *runtime.RawExtension) []error {
 	}
 	if len(config.Neighbors) > 0 {
 		allErrors = append(allErrors, fmt.Errorf("neighbors are not supported for RDMA-only devices (no network interface present)"))
+	}
+	return allErrors
+}
+
+// validateSubinterfaceOnlyConfig checks that a NetworkConfig does not contain
+// network-specific fields that are meaningless for a subinterface (e.g. IPVLAN).
+func validateSubinterfaceOnlyConfig(cfg *InterfaceConfig, fieldPath string) (allErrors []error) {
+	if cfg.MTU != nil || cfg.HardwareAddr != nil ||
+		cfg.GSOMaxSize != nil || cfg.GROMaxSize != nil ||
+		cfg.GSOIPv4MaxSize != nil || cfg.GROIPv4MaxSize != nil ||
+		cfg.ARPIgnore != nil || cfg.ARPAnnounce != nil ||
+		cfg.Addressing == AddressingModeDHCP || (cfg.DHCP != nil && *cfg.DHCP) {
+		allErrors = append(allErrors, fmt.Errorf("%s: mtu, hardwareAddr, gso/gro sizes, arpIgnore, arpAnnounce and dhcp are not yet supported for subinterface types (type: %s)", fieldPath, cfg.Type))
 	}
 	return allErrors
 }

--- a/pkg/apis/validation.go
+++ b/pkg/apis/validation.go
@@ -65,6 +65,9 @@ func ValidateConfig(raw *runtime.RawExtension) (*NetworkConfig, []error) {
 	// Validate InterfaceConfig
 	allErrors = append(allErrors, validateInterfaceConfig(&config.Interface, "interface")...)
 
+	// Validate SubInterfaceConfig
+	allErrors = append(allErrors, validateSubInterfaceConfig(config.SubInterface, "subInterface")...)
+
 	// Validate Routes
 	if len(config.Routes) > 0 {
 		allErrors = append(allErrors, validateRoutes(config.Routes, "routes")...)
@@ -179,6 +182,96 @@ func validateInterfaceConfig(cfg *InterfaceConfig, fieldPath string) (allErrors 
 
 	if cfg.VRF != nil {
 		allErrors = append(allErrors, validateVRFConfig(cfg.VRF, fieldPath+".vrf")...)
+	}
+
+	return allErrors
+}
+
+// Validate reports whether the IPRangeConfig is well-formed. It is exported as a
+// method so the same range check is reused both when validating user-provided
+// config and when the node-local IPAM validates the merged ranges before allocation.
+//
+// A range may be specified in one of two ways:
+//
+//  1. Explicit startIP and endIP (both required). They must be valid IP addresses
+//     of the same family with startIP <= endIP. If cidr is also set, both must
+//     fall within it.
+//  2. Only cidr range. It must be a valid CIDR.
+func (r IPRangeConfig) Validate() error {
+	if r.StartIP != "" || r.EndIP != "" {
+		if r.StartIP == "" || r.EndIP == "" {
+			return fmt.Errorf("startIP and endIP must be provided together")
+		}
+		start, err := netip.ParseAddr(r.StartIP)
+		if err != nil {
+			return fmt.Errorf("invalid startIP %q: %w", r.StartIP, err)
+		}
+		end, err := netip.ParseAddr(r.EndIP)
+		if err != nil {
+			return fmt.Errorf("invalid endIP %q: %w", r.EndIP, err)
+		}
+		if start.BitLen() != end.BitLen() {
+			return fmt.Errorf("startIP %s and endIP %s belong to different IP families", r.StartIP, r.EndIP)
+		}
+		if start.Compare(end) > 0 {
+			return fmt.Errorf("startIP %s is after endIP %s", r.StartIP, r.EndIP)
+		}
+		if r.CIDR != "" {
+			cidr, err := netip.ParsePrefix(r.CIDR)
+			if err != nil {
+				return fmt.Errorf("invalid cidr %q: %w", r.CIDR, err)
+			}
+			if !cidr.Contains(start) || !cidr.Contains(end) {
+				return fmt.Errorf("range [%s, %s] is not within cidr %s", r.StartIP, r.EndIP, r.CIDR)
+			}
+		}
+		return nil
+	}
+
+	if r.CIDR != "" {
+		if _, err := netip.ParsePrefix(r.CIDR); err != nil {
+			return fmt.Errorf("invalid cidr %q: %w", r.CIDR, err)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("must specify either cidr or both startIP and endIP")
+}
+
+func validateSubInterfaceConfig(cfg *SubInterfaceConfig, fieldPath string) (allErrors []error) {
+	if cfg == nil {
+		return
+	}
+
+	for i, addr := range cfg.Addresses {
+		if _, err := netip.ParsePrefix(addr); err != nil {
+			allErrors = append(allErrors, fmt.Errorf("%s.addresses[%d]: invalid IP CIDR format '%s': %w", fieldPath, i, addr, err))
+		}
+	}
+
+	for i, r := range cfg.IPRanges {
+		if err := r.Validate(); err != nil {
+			allErrors = append(allErrors, fmt.Errorf("%s.ipRanges[%d]: %w", fieldPath, i, err))
+		}
+	}
+
+	if cfg.Type == SubInterfaceTypeIPVlan {
+		if cfg.IPVlan != nil {
+			allErrors = append(allErrors, validateIPVlanConfig(cfg.IPVlan, fieldPath+".ipvlan")...)
+		}
+	} else {
+		allErrors = append(allErrors, fmt.Errorf("%s.type: '%s' is not supported", fieldPath, cfg.Type))
+	}
+
+	return allErrors
+}
+
+func validateIPVlanConfig(cfg *IPVlanConfig, fieldPath string) (allErrors []error) {
+	if cfg.Mode != "l2" {
+		allErrors = append(allErrors, fmt.Errorf("%s.mode: '%s' is not supported", fieldPath, cfg.Mode))
+	}
+	if cfg.Flag != "bridge" {
+		allErrors = append(allErrors, fmt.Errorf("%s.flag: '%s' is not supported", fieldPath, cfg.Flag))
 	}
 
 	return allErrors

--- a/pkg/apis/validation_test.go
+++ b/pkg/apis/validation_test.go
@@ -381,15 +381,196 @@ func TestValidateInterfaceConfig(t *testing.T) {
 			fieldPath: "iface",
 			expectErr: false, // Function should handle nil gracefully
 		},
+		{
+			name:      "explicit passthrough type",
+			cfg:       &InterfaceConfig{Type: "Passthrough"},
+			fieldPath: "iface",
+			expectErr: false,
+		},
+		{
+			name:      "ipvlan type without ipvlan config",
+			cfg:       &InterfaceConfig{Type: "IPVLAN"},
+			fieldPath: "iface",
+			expectErr: false,
+		},
+		{
+			name:      "ipvlan type with unsupported mode and flag",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", IPVlan: &IPVlanConfig{Mode: "L3", Flag: "Private"}},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  2,
+		},
+		{
+			name:      "passthrough type with ipvlan config",
+			cfg:       &InterfaceConfig{Type: "Passthrough", IPVlan: &IPVlanConfig{Mode: "L2", Flag: "Bridge"}},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "unsupported type",
+			cfg:       &InterfaceConfig{Type: "MACVLAN"},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "invalid addressing mode",
+			cfg:       &InterfaceConfig{Addressing: "bogus"},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "addressing dhcp",
+			cfg:       &InterfaceConfig{Addressing: AddressingModeDHCP},
+			fieldPath: "iface",
+			expectErr: false,
+		},
+		{
+			name:      "addressing dhcp with addresses",
+			cfg:       &InterfaceConfig{Addressing: AddressingModeDHCP, Addresses: []string{"10.0.0.1/24"}},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "dhcp conflicts with explicit static addressing",
+			cfg:       &InterfaceConfig{DHCP: ptr.To(true), Addressing: AddressingModeStatic},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "dhcp with matching addressing dhcp is allowed",
+			cfg:       &InterfaceConfig{DHCP: ptr.To(true), Addressing: AddressingModeDHCP},
+			fieldPath: "iface",
+			expectErr: false,
+		},
+		{
+			name:      "unnumbered on ipvlan subinterface without addresses or dhcp",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", Addressing: AddressingModeUnnumbered},
+			fieldPath: "iface",
+			expectErr: false,
+		},
+		{
+			name:      "unnumbered on non-subinterface type",
+			cfg:       &InterfaceConfig{Type: "Passthrough", Addressing: AddressingModeUnnumbered},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "unnumbered with addresses",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", Addressing: AddressingModeUnnumbered, Addresses: []string{"10.0.0.1/24"}},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "unnumbered with dhcp on ipvlan type",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", Addressing: AddressingModeUnnumbered, DHCP: ptr.To(true)},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  2,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.cfg != nil {
+				nc := &NetworkConfig{Interface: *tt.cfg}
+				nc.Default()
+				tt.cfg = &nc.Interface
+			}
 			errs := validateInterfaceConfig(tt.cfg, tt.fieldPath)
 			if (len(errs) > 0) != tt.expectErr {
 				t.Errorf("validateInterfaceConfig() expectErr %v, got errors: %v", tt.expectErr, errs)
 			}
 			if tt.expectErr && len(errs) != tt.errCount {
 				t.Errorf("validateInterfaceConfig() expected %d errors, got %d: %v", tt.errCount, len(errs), errs)
+			}
+		})
+	}
+}
+
+func TestValidateSubinterfaceOnlyConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *InterfaceConfig
+		fieldPath string
+		expectErr bool
+		errCount  int
+	}{
+		{
+			name:      "addresses only is valid",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", Addresses: []string{"10.0.0.1/24"}},
+			fieldPath: "iface",
+			expectErr: false,
+		},
+		{
+			name:      "addressing unnumbered is valid",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", Addressing: AddressingModeUnnumbered},
+			fieldPath: "iface",
+			expectErr: false,
+		},
+		{
+			name:      "mtu is rejected",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", MTU: ptr.To[int32](1500)},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "hardwareAddr is rejected",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", HardwareAddr: ptr.To("00:1A:2B:3C:4D:5E")},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "gso size is rejected",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", GSOMaxSize: ptr.To[int32](65536)},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "arp settings are rejected",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", ARPIgnore: ptr.To[int32](1)},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "addressing dhcp is rejected",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", Addressing: AddressingModeDHCP},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "deprecated dhcp is rejected",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", DHCP: ptr.To(true)},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "multiple unsupported fields is one error",
+			cfg:       &InterfaceConfig{Type: "IPVLAN", MTU: ptr.To[int32](1500), ARPIgnore: ptr.To[int32](1)},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateSubinterfaceOnlyConfig(tt.cfg, tt.fieldPath)
+			if (len(errs) > 0) != tt.expectErr {
+				t.Errorf("validateSubinterfaceOnlyConfig() expectErr %v, got errors: %v", tt.expectErr, errs)
+			}
+			if tt.expectErr && len(errs) != tt.errCount {
+				t.Errorf("validateSubinterfaceOnlyConfig() expected %d errors, got %d: %v", tt.errCount, len(errs), errs)
 			}
 		})
 	}
@@ -409,6 +590,16 @@ func TestValidateRDMAOnlyConfigRejectsARPSettings(t *testing.T) {
 		{
 			name:      "arpAnnounce is rejected",
 			raw:       `{"interface":{"arpAnnounce":2}}`,
+			expectErr: true,
+		},
+		{
+			name:      "type is rejected",
+			raw:       `{"interface":{"type":"IPVLAN"}}`,
+			expectErr: true,
+		},
+		{
+			name:      "addressing is rejected",
+			raw:       `{"interface":{"addressing":"DHCP"}}`,
 			expectErr: true,
 		},
 		{

--- a/pkg/apis/validation_test.go
+++ b/pkg/apis/validation_test.go
@@ -327,6 +327,91 @@ func TestValidateInterfaceConfig(t *testing.T) {
 	}
 }
 
+func TestValidateSubInterfaceConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *SubInterfaceConfig
+		fieldPath string
+		expectErr bool
+		errCount  int
+	}{
+		{
+			name:      "valid subinterface config",
+			cfg:       &SubInterfaceConfig{Type: "ipvlan", IPRanges: []IPRangeConfig{{CIDR: "10.24.3.0/24"}, {StartIP: "10.24.4.10", EndIP: "10.24.4.20"}}, IPVlan: &IPVlanConfig{Mode: "l2", Flag: "bridge"}},
+			fieldPath: "subInterface",
+			expectErr: false,
+		},
+		{
+			name:      "nil config",
+			cfg:       nil,
+			fieldPath: "subInterface",
+			expectErr: false,
+		},
+		{
+			name:      "unsupported subinterface type",
+			cfg:       &SubInterfaceConfig{Type: "macvlan"},
+			fieldPath: "subInterface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "invalid subinterface addresses",
+			cfg:       &SubInterfaceConfig{Type: "ipvlan", Addresses: []string{"invalid-address"}},
+			fieldPath: "subInterface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "unsupported subinterface mode and flag",
+			cfg:       &SubInterfaceConfig{Type: "ipvlan", IPVlan: &IPVlanConfig{Mode: "l3", Flag: "private"}},
+			fieldPath: "subInterface",
+			expectErr: true,
+			errCount:  2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateSubInterfaceConfig(tt.cfg, tt.fieldPath)
+			if (len(errs) > 0) != tt.expectErr {
+				t.Errorf("validateSubInterfaceConfig() expectErr %v, got errors: %v", tt.expectErr, errs)
+			}
+			if tt.expectErr && len(errs) != tt.errCount {
+				t.Errorf("validateSubInterfaceConfig() expected %d errors, got %d. Errors: %v", tt.errCount, len(errs), errs)
+			}
+		})
+	}
+}
+
+func TestIPRangeConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     IPRangeConfig
+		wantErr bool
+	}{
+		{name: "CIDR only", cfg: IPRangeConfig{CIDR: "192.168.1.0/24"}},
+		{name: "IPv6 CIDR only", cfg: IPRangeConfig{CIDR: "2001:db8::/64"}},
+		{name: "start and end only", cfg: IPRangeConfig{StartIP: "10.0.0.5", EndIP: "10.0.0.10"}},
+		{name: "start == end", cfg: IPRangeConfig{StartIP: "10.0.0.5", EndIP: "10.0.0.5"}},
+		{name: "all three, within cidr", cfg: IPRangeConfig{CIDR: "10.0.0.0/24", StartIP: "10.0.0.5", EndIP: "10.0.0.10"}},
+		{name: "invalid cidr", cfg: IPRangeConfig{CIDR: "not-a-cidr"}, wantErr: true},
+		{name: "invalid startIP", cfg: IPRangeConfig{StartIP: "bad", EndIP: "10.0.0.10"}, wantErr: true},
+		{name: "startIP without endIP", cfg: IPRangeConfig{StartIP: "10.0.0.5"}, wantErr: true},
+		{name: "endIP without startIP", cfg: IPRangeConfig{EndIP: "10.0.0.5"}, wantErr: true},
+		{name: "family mismatch", cfg: IPRangeConfig{StartIP: "10.0.0.5", EndIP: "2001:db8::5"}, wantErr: true},
+		{name: "start after end", cfg: IPRangeConfig{StartIP: "10.0.0.10", EndIP: "10.0.0.5"}, wantErr: true},
+		{name: "range outside cidr", cfg: IPRangeConfig{CIDR: "10.0.0.0/24", StartIP: "10.1.0.5", EndIP: "10.1.0.10"}, wantErr: true},
+		{name: "nothing set", cfg: IPRangeConfig{}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IPRangeConfig.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateRoutes(t *testing.T) {
 	scopeLink := uint8(unix.RT_SCOPE_LINK)
 	scopeUniverse := uint8(unix.RT_SCOPE_UNIVERSE)

--- a/pkg/cloudprovider/cloudutil.go
+++ b/pkg/cloudprovider/cloudutil.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file holds generic helpers shared by the individual cloud provider
+// implementations (gce, aws, azure, ...). Keep provider-specific logic in the
+// respective provider package; only put broadly reusable utilities here.
+
+package cloudprovider
+
+import (
+	"fmt"
+	"math/big"
+	"net/netip"
+)
+
+// IPRangeFromCIDR derives explicit [startIP, endIP] allocation boundaries from a
+// CIDR block.
+//
+// The network (base) address and the broadcast (last) address are always
+// excluded automatically. startReserved and endReserved specify how many
+// additional addresses to reserve.
+//
+// It returns an error if the reserved counts are negative, the CIDR is invalid,
+// or the block is too small to yield at least one allocatable address.
+func IPRangeFromCIDR(cidr string, startReserved, endReserved int) (startIP, endIP string, err error) {
+	if startReserved < 0 || endReserved < 0 {
+		return "", "", fmt.Errorf("reserved counts must be non-negative (start=%d, end=%d)", startReserved, endReserved)
+	}
+
+	prefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid cidr %q: %w", cidr, err)
+	}
+	prefix = prefix.Masked()
+	base := prefix.Addr()
+
+	// size = number of addresses in the block = 2^hostBits.
+	hostBits := base.BitLen() - prefix.Bits()
+	size := new(big.Int).Lsh(big.NewInt(1), uint(hostBits))
+
+	// Offset 0 is the network address and offset size-1 is the broadcast address;
+	// both are always excluded. startReserved/endReserved reserve additional
+	// addresses inward from each end.
+	startOff := big.NewInt(int64(startReserved) + 1)
+	endOff := new(big.Int).Sub(size, big.NewInt(int64(endReserved)+2))
+
+	if startOff.Cmp(endOff) > 0 {
+		return "", "", fmt.Errorf("cidr %q is too small to reserve %d start and %d end addresses (network and broadcast are also excluded)", cidr, startReserved, endReserved)
+	}
+
+	start, err := addOffset(base, startOff)
+	if err != nil {
+		return "", "", err
+	}
+	end, err := addOffset(base, endOff)
+	if err != nil {
+		return "", "", err
+	}
+	return start.String(), end.String(), nil
+}
+
+// addOffset returns addr + offset, staying within the address family of addr. It
+// returns an error if the result overflows the address width.
+func addOffset(addr netip.Addr, offset *big.Int) (netip.Addr, error) {
+	sum := new(big.Int).Add(new(big.Int).SetBytes(addr.AsSlice()), offset)
+
+	width := addr.BitLen() / 8 // 4 for IPv4, 16 for IPv6
+	b := sum.Bytes()
+	if len(b) > width {
+		return netip.Addr{}, fmt.Errorf("address offset %s overflows the %d-bit space starting at %s", offset, addr.BitLen(), addr)
+	}
+
+	buf := make([]byte, width)
+	copy(buf[width-len(b):], b)
+	res, ok := netip.AddrFromSlice(buf)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("failed to construct address from bytes %v", buf)
+	}
+	return res, nil
+}

--- a/pkg/cloudprovider/cloudutil.go
+++ b/pkg/cloudprovider/cloudutil.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file holds generic helpers shared by the individual cloud provider
+// implementations (gce, aws, azure, ...). Keep provider-specific logic in the
+// respective provider package; only put broadly reusable utilities here.
+
+package cloudprovider
+
+import (
+	"fmt"
+	"math/big"
+	"net/netip"
+)
+
+// IPRangeFromCIDR derives explicit [startIP, endIP] allocation boundaries from a
+// CIDR block.
+//
+// The network (base) address and the broadcast (last) address are always
+// excluded no matter what IP family it is. startReserved and endReserved
+// specify how many additional addresses to reserve.
+//
+// It returns an error if the reserved counts are negative, the CIDR is invalid,
+// or the block is too small to yield at least one allocatable address.
+func IPRangeFromCIDR(cidr string, startReserved, endReserved int) (startIP, endIP netip.Addr, err error) {
+	if startReserved < 0 || endReserved < 0 {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("reserved counts must be non-negative (start=%d, end=%d)", startReserved, endReserved)
+	}
+
+	prefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("invalid cidr %q: %w", cidr, err)
+	}
+	prefix = prefix.Masked()
+	base := prefix.Addr()
+
+	// size = number of addresses in the block = 2^hostBits.
+	hostBits := base.BitLen() - prefix.Bits()
+	size := new(big.Int).Lsh(big.NewInt(1), uint(hostBits))
+
+	// Offset 0 is the network address and offset size-1 is the broadcast address;
+	// both are always excluded. startReserved/endReserved reserve additional
+	// addresses inward from each end.
+	startOff := big.NewInt(int64(startReserved) + 1)
+	endOff := new(big.Int).Sub(size, big.NewInt(int64(endReserved)+2))
+
+	if startOff.Cmp(endOff) > 0 {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("cidr %q is too small to reserve %d start and %d end addresses (network and broadcast are also excluded)", cidr, startReserved, endReserved)
+	}
+
+	start, err := addOffset(base, startOff)
+	if err != nil {
+		return netip.Addr{}, netip.Addr{}, err
+	}
+	end, err := addOffset(base, endOff)
+	if err != nil {
+		return netip.Addr{}, netip.Addr{}, err
+	}
+	return start, end, nil
+}
+
+// addOffset returns addr + offset, staying within the address family of addr. It
+// returns an error if the result overflows the address width.
+func addOffset(addr netip.Addr, offset *big.Int) (netip.Addr, error) {
+	sum := new(big.Int).Add(new(big.Int).SetBytes(addr.AsSlice()), offset)
+
+	width := addr.BitLen() / 8 // 4 for IPv4, 16 for IPv6
+	b := sum.Bytes()
+	if len(b) > width {
+		return netip.Addr{}, fmt.Errorf("address offset %s overflows the %d-bit space starting at %s", offset, addr.BitLen(), addr)
+	}
+
+	buf := make([]byte, width)
+	copy(buf[width-len(b):], b)
+	res, ok := netip.AddrFromSlice(buf)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("failed to construct address from bytes %v", buf)
+	}
+	return res, nil
+}

--- a/pkg/cloudprovider/cloudutil_test.go
+++ b/pkg/cloudprovider/cloudutil_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudprovider
+
+import "testing"
+
+func TestIPRangeFromCIDR(t *testing.T) {
+	tests := []struct {
+		name          string
+		cidr          string
+		startReserved int
+		endReserved   int
+		wantStart     string
+		wantEnd       string
+		wantErr       bool
+	}{
+		{
+			name:      "IPv4 /24 no extra reserve excludes network and broadcast",
+			cidr:      "10.0.0.0/24",
+			wantStart: "10.0.0.1",
+			wantEnd:   "10.0.0.254",
+		},
+		{
+			name:          "IPv4 asymmetric reserve",
+			cidr:          "192.168.1.0/28",
+			startReserved: 2,
+			endReserved:   1,
+			wantStart:     "192.168.1.3",
+			wantEnd:       "192.168.1.13",
+		},
+		{
+			name:      "input CIDR is not masked",
+			cidr:      "10.0.0.7/24",
+			wantStart: "10.0.0.1",
+			wantEnd:   "10.0.0.254",
+		},
+		{
+			name:      "IPv6 /64 no extra reserve",
+			cidr:      "2001:db8::/64",
+			wantStart: "2001:db8::1",
+			wantEnd:   "2001:db8::ffff:ffff:ffff:fffe",
+		},
+		{
+			name:    "tiny prefix /31 has no allocatable addresses",
+			cidr:    "10.0.0.0/31",
+			wantErr: true,
+		},
+		{
+			name:          "negative start reserve is rejected",
+			cidr:          "10.0.0.0/24",
+			startReserved: -1,
+			wantErr:       true,
+		},
+		{
+			name:    "invalid CIDR is rejected",
+			cidr:    "not-a-cidr",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, err := IPRangeFromCIDR(tt.cidr, tt.startReserved, tt.endReserved)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("IPRangeFromCIDR(%q, %d, %d) error = %v, wantErr %v", tt.cidr, tt.startReserved, tt.endReserved, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if start != tt.wantStart || end != tt.wantEnd {
+				t.Errorf("IPRangeFromCIDR(%q, %d, %d) = (%q, %q), want (%q, %q)", tt.cidr, tt.startReserved, tt.endReserved, start, end, tt.wantStart, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/cloudutil_test.go
+++ b/pkg/cloudprovider/cloudutil_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudprovider
+
+import "testing"
+
+func TestIPRangeFromCIDR(t *testing.T) {
+	tests := []struct {
+		name          string
+		cidr          string
+		startReserved int
+		endReserved   int
+		wantStart     string
+		wantEnd       string
+		wantErr       bool
+	}{
+		{
+			name:      "IPv4 /24 no extra reserve excludes network and broadcast",
+			cidr:      "10.0.0.0/24",
+			wantStart: "10.0.0.1",
+			wantEnd:   "10.0.0.254",
+		},
+		{
+			name:          "IPv4 asymmetric reserve",
+			cidr:          "192.168.1.0/28",
+			startReserved: 2,
+			endReserved:   1,
+			wantStart:     "192.168.1.3",
+			wantEnd:       "192.168.1.13",
+		},
+		{
+			name:      "input CIDR is not masked",
+			cidr:      "10.0.0.7/24",
+			wantStart: "10.0.0.1",
+			wantEnd:   "10.0.0.254",
+		},
+		{
+			name:      "IPv6 /64 no extra reserve",
+			cidr:      "2001:db8::/64",
+			wantStart: "2001:db8::1",
+			wantEnd:   "2001:db8::ffff:ffff:ffff:fffe",
+		},
+		{
+			name:    "tiny prefix /31 has no allocatable addresses",
+			cidr:    "10.0.0.0/31",
+			wantErr: true,
+		},
+		{
+			name:          "negative start reserve is rejected",
+			cidr:          "10.0.0.0/24",
+			startReserved: -1,
+			wantErr:       true,
+		},
+		{
+			name:    "invalid CIDR is rejected",
+			cidr:    "not-a-cidr",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, err := IPRangeFromCIDR(tt.cidr, tt.startReserved, tt.endReserved)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("IPRangeFromCIDR(%q, %d, %d) error = %v, wantErr %v", tt.cidr, tt.startReserved, tt.endReserved, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if start.String() != tt.wantStart || end.String() != tt.wantEnd {
+				t.Errorf("IPRangeFromCIDR(%q, %d, %d) = (%q, %q), want (%q, %q)", tt.cidr, tt.startReserved, tt.endReserved, start.String(), end.String(), tt.wantStart, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/discovery/discovery.go
+++ b/pkg/cloudprovider/discovery/discovery.go
@@ -45,11 +45,13 @@ const (
 	CloudProviderHintNone    CloudProviderHint = "NONE"
 )
 
-// Dependencies contains Kubernetes-local inputs used by providers that do not
-// expose a conventional instance metadata service.
+// Dependencies carries host- and runtime-provided inputs that providers require
+// but cannot obtain from conventional instance metadata service.
 type Dependencies struct {
 	NodeClient corev1client.NodeInterface
 	NodeName   string
+	// ReservedAddresses seeds a provider with addresses already in use on the node.
+	ReservedAddresses []string
 }
 
 type cloudProviderProbe struct {
@@ -93,7 +95,7 @@ func detectCloudProvider(probes []cloudProviderProbe) CloudProviderHint {
 func GetInstanceProperties(ctx context.Context, hint CloudProviderHint, webhookURL string, dependencies Dependencies) (cloudprovider.CloudInstance, error) {
 	switch hint {
 	case CloudProviderHintGCE:
-		return gce.GetInstance(ctx)
+		return gce.GetInstance(ctx, gce.WithReservedAddresses(dependencies.ReservedAddresses))
 	case CloudProviderHintAWS:
 		return aws.GetInstance(ctx)
 	case CloudProviderHintAzure:

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -82,6 +84,7 @@ type gceNetworkInterface struct {
 	MTU       int      `json:"mtu,omitempty"`
 	Network   string   `json:"network,omitempty"`
 	IPAliases []string `json:"ipAliases,omitempty"`
+	Gateway   string   `json:"gateway,omitempty"`
 }
 
 var _ cloudprovider.CloudInstance = (*GCEInstance)(nil)
@@ -154,7 +157,59 @@ func (g *GCEInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) ma
 // GetDeviceConfig fetches any infrastructure-specific network configuration
 // required by the device. Returning nil means no specific config is needed.
 func (g *GCEInstance) GetDeviceConfig(id cloudprovider.DeviceIdentifiers) *apis.NetworkConfig {
-	return nil
+	if id.MAC == "" {
+		return nil
+	}
+
+	interfaceForMacFound := false
+	var interfaceForMac gceNetworkInterface
+	for _, cloudInterface := range g.Interfaces {
+		if cloudInterface.Mac == id.MAC {
+			interfaceForMacFound = true
+			interfaceForMac = cloudInterface
+			break
+		}
+	}
+	if !interfaceForMacFound {
+		klog.V(4).Infof("No cloud metadata found for device with mac %q; it is possible this device has no associated cloud provider metadata", id.MAC)
+		return nil
+	}
+
+	deviceConfig := &apis.NetworkConfig{}
+
+	// Calculate the IP range as metadata for subinterface.
+	// The config_merge layer will decide whether to keep or discard
+	// the configuration based on the user's request for subinterface.
+	var ipRanges []apis.IPRangeConfig
+
+	// For IPv6, compute the sub-interface range from the base IP.
+	if len(interfaceForMac.IPv6) > 0 {
+		if ipRange, err := getIPv6Range(interfaceForMac.IPv6[0]); err == nil {
+			if startIP, endIP, err := cloudprovider.IPRangeFromCIDR(ipRange, 0, 0); err == nil {
+				ipRanges = append(ipRanges, apis.IPRangeConfig{StartIP: startIP, EndIP: endIP})
+			} else {
+				klog.Warningf("Failed to derive IPv6 allocation range from %q: %v", ipRange, err)
+			}
+		} else {
+			klog.Warningf("Failed to calculate IPv6 range for base IP %q: %v", interfaceForMac.IPv6[0], err)
+		}
+	}
+	// For IPv4, retrieve the range from the first Alias IP Range if available.
+	if len(interfaceForMac.IPAliases) > 0 {
+		alias := interfaceForMac.IPAliases[0]
+		if startIP, endIP, err := cloudprovider.IPRangeFromCIDR(alias, 0, 0); err == nil {
+			ipRanges = append(ipRanges, apis.IPRangeConfig{StartIP: startIP, EndIP: endIP})
+		} else {
+			klog.Warningf("Failed to derive IPv4 allocation range from alias %q: %v", alias, err)
+		}
+	}
+	if len(ipRanges) > 0 {
+		deviceConfig.SubInterface = &apis.SubInterfaceConfig{
+			IPRanges: ipRanges,
+		}
+	}
+
+	return deviceConfig
 }
 
 // GetInstance retrieves GCE instance properties by querying the metadata server.
@@ -211,4 +266,38 @@ func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
 		return nil, err
 	}
 	return instance, nil
+}
+
+// getIPv6Range calculates the subinterface IPv6 range by appending 0xC0DE marker to the base range.
+func getIPv6Range(baseIPStr string) (string, error) {
+	const workerMarker = 0xC0DE
+
+	_, ipnet, err := net.ParseCIDR(baseIPStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse CIDR %q: %v", baseIPStr, err)
+	}
+	prefixLen, _ := ipnet.Mask.Size()
+	baseIP := ipnet.IP
+
+	if baseIP.To4() != nil {
+		return "", fmt.Errorf("IP %q is an IPv4 address, expected IPv6", baseIPStr)
+	}
+	ip16 := baseIP.To16()
+	if ip16 == nil {
+		return "", fmt.Errorf("IP %q is not a valid IPv6 address", baseIPStr)
+	}
+
+	workerIP := make(net.IP, 16)
+	numBaseBytes := prefixLen / 8
+
+	if numBaseBytes >= 14 {
+		return "", fmt.Errorf("prefix length %d is too large to append %x", prefixLen, workerMarker)
+	}
+
+	copy(workerIP[0:numBaseBytes], ip16[0:numBaseBytes])
+	workerIP[numBaseBytes] = byte(workerMarker >> 8)
+	workerIP[numBaseBytes+1] = byte(workerMarker & 0xFF)
+	newPrefixLen := (numBaseBytes + 2) * 8
+
+	return workerIP.String() + "/" + strconv.Itoa(newPrefixLen), nil
 }

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -20,18 +20,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/netip"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
+	"golang.org/x/sys/unix"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
+	"sigs.k8s.io/dranet/pkg/ipam"
 )
 
 // GPUDirectSupport represents the type of GPUDirect support for a given machine type.
@@ -76,15 +82,18 @@ var (
 
 // gceNetworkInterface matches the structure expected from GCE metadata.
 type gceNetworkInterface struct {
-	IPv4      string   `json:"ip,omitempty"`
-	IPv6      []string `json:"ipv6,omitempty"`
-	Mac       string   `json:"mac,omitempty"`
-	MTU       int      `json:"mtu,omitempty"`
-	Network   string   `json:"network,omitempty"`
-	IPAliases []string `json:"ipAliases,omitempty"`
+	IPv4        string   `json:"ip,omitempty"`
+	IPv6        []string `json:"ipv6,omitempty"`
+	Mac         string   `json:"mac,omitempty"`
+	MTU         int      `json:"mtu,omitempty"`
+	Network     string   `json:"network,omitempty"`
+	IPAliases   []string `json:"ipAliases,omitempty"`
+	Gateway     string   `json:"gateway,omitempty"`
+	GatewayIPv6 string   `json:"gatewayIpv6,omitempty"`
 }
 
 var _ cloudprovider.CloudInstance = (*GCEInstance)(nil)
+var _ cloudprovider.ProfileProvider = (*GCEInstance)(nil)
 
 // GCEInstance holds the GCE specific instance data.
 type GCEInstance struct {
@@ -93,6 +102,8 @@ type GCEInstance struct {
 	AcceleratorProtocol string
 	Interfaces          []gceNetworkInterface
 	Topology            string
+	// localIPAM is the node-local IP allocator used to assign addresses to subinterfaces.
+	localIPAM *ipam.LocalIPAM
 }
 
 // GetDeviceAttributes fetches all attributes related to the provided device,
@@ -151,14 +162,146 @@ func (g *GCEInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) ma
 	return attributes
 }
 
+// ManagedProfile is the profile GCE advertises on every device it recognizes,
+// so claim-scoped resolution (GetProfileConfig) always runs on GCE without the
+// user having to set interface.profile. Resolution is a no-op unless the claim
+// requests something GCE manages dynamically (e.g. an IPVLAN subinterface,
+// which gets IPAM addresses plus its policy based routing).
+const ManagedProfile = "gce-managed"
+
 // GetDeviceConfig fetches any infrastructure-specific network configuration
 // required by the device. Returning nil means no specific config is needed.
 func (g *GCEInstance) GetDeviceConfig(id cloudprovider.DeviceIdentifiers) *apis.NetworkConfig {
+	return &apis.NetworkConfig{Profile: ManagedProfile}
+}
+
+func (g *GCEInstance) GetProfileConfig(id cloudprovider.DeviceIdentifiers, claim *resourceapi.ResourceClaim, config *apis.NetworkConfig) (*apis.NetworkConfig, error) {
+	if id.MAC == "" {
+		return nil, nil
+	}
+
+	interfaceForMacFound := false
+	var interfaceForMac gceNetworkInterface
+	for _, cloudInterface := range g.Interfaces {
+		if cloudInterface.Mac == id.MAC {
+			interfaceForMacFound = true
+			interfaceForMac = cloudInterface
+			break
+		}
+	}
+	if !interfaceForMacFound {
+		klog.V(4).Infof("No cloud metadata found for device with mac %q; it is possible this device has no associated cloud provider metadata", id.MAC)
+		return nil, nil
+	}
+
+	if config == nil || !config.Interface.IsSubinterface() {
+		return nil, nil
+	}
+	if g.localIPAM == nil {
+		return nil, fmt.Errorf("GCE profile IPAM is not initialized for subinterface device %q", id.MAC)
+	}
+
+	// Record static sub-interface IP addresses in IPAM as in-use.
+	if len(config.Interface.Addresses) > 0 {
+		if err := g.localIPAM.Reserve(config.Interface.Addresses); err != nil {
+			return nil, fmt.Errorf("reserving static subinterface addresses for device %q: %w", id.MAC, err)
+		}
+		return sourceRoutingConfig(interfaceForMac, config, nil), nil
+	}
+
+	// Otherwise allocate node-local IPs from the interface's cloud ranges.
+	ranges, err := g.subinterfaceRanges(interfaceForMac)
+	if err != nil {
+		return nil, err
+	}
+	if len(ranges) == 0 {
+		return nil, fmt.Errorf("no subinterface IP ranges found in cloud metadata for device %q", id.MAC)
+	}
+	addrs, err := g.localIPAM.Allocate(ranges)
+	if err != nil {
+		return nil, fmt.Errorf("allocating subinterface addresses for device %q: %w", id.MAC, err)
+	}
+	return sourceRoutingConfig(interfaceForMac, config, addrs), nil
+}
+
+// sourceRoutingConfig builds the profile config for a subinterface: the newly
+// allocated addresses (if any) plus the policy based routing (PBR) needed for
+// them to egress via the parent NIC's gateway: a per-device routing table
+// holding an on-link gateway route and a default route, and one source rule per
+// address. When the merged config already carries routes, rules or a VRF, the
+// user/provider owns routing and nothing is synthesized.
+func sourceRoutingConfig(iface gceNetworkInterface, config *apis.NetworkConfig, allocated []string) *apis.NetworkConfig {
+	profile := &apis.NetworkConfig{Interface: apis.InterfaceConfig{Addresses: allocated}}
+
+	addrs := allocated
+	if len(addrs) == 0 {
+		addrs = config.Interface.Addresses
+	}
+	if len(config.Routes) > 0 || len(config.Rules) > 0 || config.Interface.VRF != nil {
+		if len(allocated) == 0 {
+			return nil
+		}
+		return profile
+	}
+
+	// Gateways from the VM metadata, keyed by netip.Addr.Is6().
+	gateways := map[bool]netip.Addr{}
+	if gw, err := netip.ParseAddr(iface.Gateway); err == nil && gw.Is4() {
+		gateways[false] = gw
+	}
+	if gw, err := netip.ParseAddr(iface.GatewayIPv6); err == nil && gw.Is6() {
+		gateways[true] = gw
+	}
+
+	tableID := apis.TableIDForName(iface.Mac)
+	routesAdded := map[bool]bool{}
+	for _, addrStr := range addrs {
+		prefix, err := netip.ParsePrefix(addrStr)
+		if err != nil {
+			continue
+		}
+		is6 := prefix.Addr().Is6()
+		gw, ok := gateways[is6]
+		if !ok {
+			continue
+		}
+		if !routesAdded[is6] {
+			defaultDst := "0.0.0.0/0"
+			if is6 {
+				defaultDst = "::/0"
+			}
+			profile.Routes = append(profile.Routes,
+				// On-link route so the gateway is reachable from a host-prefix address.
+				apis.RouteConfig{Destination: netip.PrefixFrom(gw, gw.BitLen()).String(), Scope: unix.RT_SCOPE_LINK, Table: tableID},
+				apis.RouteConfig{Destination: defaultDst, Gateway: gw.String(), Table: tableID})
+			routesAdded[is6] = true
+		}
+		// Host prefix (/32 or /128) so rules for sibling subinterfaces never overlap.
+		profile.Rules = append(profile.Rules, apis.RuleConfig{
+			Source:   netip.PrefixFrom(prefix.Addr(), prefix.Addr().BitLen()).String(),
+			Table:    tableID,
+			Priority: apis.SourceRoutingRulePriority,
+		})
+	}
+	if len(allocated) == 0 && len(profile.Routes) == 0 && len(profile.Rules) == 0 {
+		return nil
+	}
+	return profile
+}
+
+func (g *GCEInstance) ReleaseProfileConfig(id cloudprovider.DeviceIdentifiers, claimUID types.UID, config *apis.NetworkConfig) error {
+	if config == nil || !config.Interface.IsSubinterface() || g.localIPAM == nil {
+		return nil
+	}
+	// Release the node-local IP leases that GetProfileConfig allocated.
+	for _, addr := range config.Interface.Addresses {
+		g.localIPAM.Release(addr)
+	}
 	return nil
 }
 
 // GetInstance retrieves GCE instance properties by querying the metadata server.
-func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
+func GetInstance(ctx context.Context, opts ...Option) (cloudprovider.CloudInstance, error) {
 	var instance *GCEInstance
 	// metadata server can not be available during startup
 	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (done bool, err error) {
@@ -190,6 +333,10 @@ func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
 			Name:                instanceName,
 			Type:                instanceType,
 			AcceleratorProtocol: string(protocol),
+			localIPAM:           ipam.NewLocalIPAM(nil),
+		}
+		for _, opt := range opts {
+			opt(instance)
 		}
 		if err = json.Unmarshal([]byte(gceInterfacesRaw), &instance.Interfaces); err != nil {
 			klog.Infof("could not get network interfaces on GCE ... retrying: %v", err)
@@ -211,4 +358,76 @@ func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
 		return nil, err
 	}
 	return instance, nil
+}
+
+// Option configures a GCEInstance at construction time; see GetInstance.
+type Option func(*GCEInstance)
+
+// WithReservedAddresses seeds the instance's node-local IPAM with addresses
+// already in use on the node, so it doesn't hand out ones that are taken.
+func WithReservedAddresses(addrs []string) Option {
+	return func(g *GCEInstance) {
+		g.localIPAM = ipam.NewLocalIPAM(addrs)
+	}
+}
+
+// subinterfaceRanges derives the node-local IP allocation ranges for the given GCE network interface.
+func (g *GCEInstance) subinterfaceRanges(iface gceNetworkInterface) ([]ipam.IPRange, error) {
+	var ranges []ipam.IPRange
+	// IPv6: derive the subinterface range from the base IPv6 address.
+	if len(iface.IPv6) > 0 {
+		cidr, err := getIPv6Range(iface.IPv6[0])
+		if err != nil {
+			return nil, fmt.Errorf("calculating IPv6 range for base IP %q: %w", iface.IPv6[0], err)
+		}
+		start, end, err := cloudprovider.IPRangeFromCIDR(cidr, 0, 0)
+		if err != nil {
+			return nil, fmt.Errorf("deriving IPv6 allocation range from %q: %w", cidr, err)
+		}
+		ranges = append(ranges, ipam.IPRange{Start: start, End: end})
+	}
+	// IPv4: from the first alias range.
+	if len(iface.IPAliases) > 0 {
+		alias := iface.IPAliases[0]
+		start, end, err := cloudprovider.IPRangeFromCIDR(alias, 0, 0)
+		if err != nil {
+			return nil, fmt.Errorf("deriving IPv4 allocation range from alias %q: %w", alias, err)
+		}
+		ranges = append(ranges, ipam.IPRange{Start: start, End: end})
+	}
+	return ranges, nil
+}
+
+// getIPv6Range calculates the subinterface IPv6 range by appending 0xC0DE marker to the base range.
+func getIPv6Range(baseIPStr string) (string, error) {
+	const workerMarker = 0xC0DE
+
+	_, ipnet, err := net.ParseCIDR(baseIPStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse CIDR %q: %v", baseIPStr, err)
+	}
+	prefixLen, _ := ipnet.Mask.Size()
+	baseIP := ipnet.IP
+
+	if baseIP.To4() != nil {
+		return "", fmt.Errorf("IP %q is an IPv4 address, expected IPv6", baseIPStr)
+	}
+	ip16 := baseIP.To16()
+	if ip16 == nil {
+		return "", fmt.Errorf("IP %q is not a valid IPv6 address", baseIPStr)
+	}
+
+	workerIP := make(net.IP, 16)
+	numBaseBytes := prefixLen / 8
+
+	if numBaseBytes >= 14 {
+		return "", fmt.Errorf("prefix length %d is too large to append %x", prefixLen, workerMarker)
+	}
+
+	copy(workerIP[0:numBaseBytes], ip16[0:numBaseBytes])
+	workerIP[numBaseBytes] = byte(workerMarker >> 8)
+	workerIP[numBaseBytes+1] = byte(workerMarker & 0xFF)
+	newPrefixLen := (numBaseBytes + 2) * 8
+
+	return workerIP.String() + "/" + strconv.Itoa(newPrefixLen), nil
 }

--- a/pkg/cloudprovider/gce/gce_test.go
+++ b/pkg/cloudprovider/gce/gce_test.go
@@ -19,6 +19,7 @@ package gce
 import (
 	"testing"
 
+	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
 
 	"github.com/google/go-cmp/cmp"
@@ -150,6 +151,141 @@ func TestGetDeviceAttributes(t *testing.T) {
 			got := tt.instance.GetDeviceAttributes(cloudprovider.DeviceIdentifiers{MAC: tt.mac})
 			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("GetDeviceAttributes() returned unexpected diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetDeviceConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		mac      string
+		instance *GCEInstance
+		want     *apis.NetworkConfig
+	}{
+		{
+			name: "MAC not found in instance interfaces",
+			mac:  "00:11:22:33:44:FF",
+			instance: &GCEInstance{
+				Interfaces: []gceNetworkInterface{
+					{
+						Mac: "00:11:22:33:44:55",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "instance type with IPv4 alias range",
+			mac:  "00:11:22:33:44:55",
+			instance: &GCEInstance{
+				Type: "machine-type-a",
+				Interfaces: []gceNetworkInterface{
+					{
+						Mac:       "00:11:22:33:44:55",
+						IPAliases: []string{"10.24.3.0/24"},
+						Gateway:   "10.128.0.1",
+					},
+				},
+			},
+			want: &apis.NetworkConfig{
+				SubInterface: &apis.SubInterfaceConfig{
+					IPRanges: []apis.IPRangeConfig{{StartIP: "10.24.3.1", EndIP: "10.24.3.254"}},
+				},
+			},
+		},
+		{
+			name: "IPv6 instance type with missing gateway",
+			mac:  "00:11:22:33:44:55",
+			instance: &GCEInstance{
+				Type: "machine-type-a",
+				Interfaces: []gceNetworkInterface{
+					{
+						Mac:  "00:11:22:33:44:55",
+						IPv6: []string{"2001:db8:1234:5678::/64"},
+					},
+				},
+			},
+			want: &apis.NetworkConfig{
+				SubInterface: &apis.SubInterfaceConfig{
+					IPRanges: []apis.IPRangeConfig{{StartIP: "2001:db8:1234:5678:c0de::1", EndIP: "2001:db8:1234:5678:c0de:ffff:ffff:fffe"}},
+				},
+			},
+		},
+		{
+			name: "dual stack instance type with both IPv4 alias and IPv6 range",
+			mac:  "00:11:22:33:44:55",
+			instance: &GCEInstance{
+				Type: "machine-type-a",
+				Interfaces: []gceNetworkInterface{
+					{
+						Mac:       "00:11:22:33:44:55",
+						IPAliases: []string{"10.24.3.0/24"},
+						IPv6:      []string{"2001:db8:1234:5678::/64"},
+					},
+				},
+			},
+			want: &apis.NetworkConfig{
+				SubInterface: &apis.SubInterfaceConfig{
+					IPRanges: []apis.IPRangeConfig{{StartIP: "2001:db8:1234:5678:c0de::1", EndIP: "2001:db8:1234:5678:c0de:ffff:ffff:fffe"}, {StartIP: "10.24.3.1", EndIP: "10.24.3.254"}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.instance.GetDeviceConfig(cloudprovider.DeviceIdentifiers{MAC: tt.mac})
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("GetDeviceConfig() returned unexpected diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetIPv6Range(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseIPStr string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "valid CIDR prefix /64",
+			baseIPStr: "2001:db8:1234:5678::/64",
+			want:      "2001:db8:1234:5678:c0de::/80",
+			wantErr:   false,
+		},
+		{
+			name:      "too large CIDR prefix /112",
+			baseIPStr: "2001:db8:1234:5678:abcd:ef01:2345::/112",
+			wantErr:   true,
+		},
+		{
+			name:      "plain IP, no CIDR prefix",
+			baseIPStr: "2001:db8:1234:5678:abcd:ef01:2345:6789",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid IP format",
+			baseIPStr: "invalid-ip",
+			wantErr:   true,
+		},
+		{
+			name:      "IPv4 CIDR input",
+			baseIPStr: "192.168.1.0/24",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getIPv6Range(tt.baseIPStr)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("getIPv6Range() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("getIPv6Range() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/pkg/cloudprovider/gce/gce_test.go
+++ b/pkg/cloudprovider/gce/gce_test.go
@@ -19,7 +19,9 @@ package gce
 import (
 	"testing"
 
+	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
+	"sigs.k8s.io/dranet/pkg/ipam"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -152,5 +154,296 @@ func TestGetDeviceAttributes(t *testing.T) {
 				t.Errorf("GetDeviceAttributes() returned unexpected diff (-want, +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestGetProfileConfig(t *testing.T) {
+	const mac = "00:11:22:33:44:55"
+	dualStackIface := gceNetworkInterface{
+		Mac:       mac,
+		IPAliases: []string{"10.24.3.0/24"},
+		IPv6:      []string{"2001:db8:1234:5678::/64"},
+	}
+	bareIface := gceNetworkInterface{Mac: mac}
+	ipvlanConfig := func() *apis.NetworkConfig {
+		return &apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN}}
+	}
+
+	tests := []struct {
+		name      string
+		mac       string
+		iface     gceNetworkInterface
+		config    *apis.NetworkConfig
+		wantAddrs int
+		wantErr   bool
+		nilIPAM   bool
+	}{
+		{
+			name:      "dual-stack subinterface allocates one address per family",
+			mac:       mac,
+			iface:     dualStackIface,
+			config:    ipvlanConfig(),
+			wantAddrs: 2,
+		},
+		{
+			name:   "empty MAC returns nil",
+			mac:    "",
+			iface:  dualStackIface,
+			config: ipvlanConfig(),
+		},
+		{
+			name:   "MAC not found returns nil",
+			mac:    "aa:bb:cc:dd:ee:ff",
+			iface:  dualStackIface,
+			config: ipvlanConfig(),
+		},
+		{
+			name:   "non-subinterface config returns nil",
+			mac:    mac,
+			iface:  dualStackIface,
+			config: &apis.NetworkConfig{},
+		},
+		{
+			name:    "subinterface without cloud ranges returns error",
+			mac:     mac,
+			iface:   bareIface,
+			config:  ipvlanConfig(),
+			wantErr: true,
+		},
+		{
+			name:    "subinterface without IPAM returns error",
+			mac:     mac,
+			iface:   dualStackIface,
+			config:  ipvlanConfig(),
+			nilIPAM: true,
+			wantErr: true,
+		},
+		{
+			name:      "static addresses are reserved not allocated",
+			mac:       mac,
+			iface:     dualStackIface,
+			config:    &apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN, Addresses: []string{"10.24.3.5/32"}}},
+			wantAddrs: 0,
+		},
+		{
+			name:    "invalid IPv6 metadata returns error",
+			mac:     mac,
+			iface:   gceNetworkInterface{Mac: mac, IPv6: []string{"not-an-ip"}},
+			config:  ipvlanConfig(),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &GCEInstance{Interfaces: []gceNetworkInterface{tt.iface}}
+			if !tt.nilIPAM {
+				instance.localIPAM = ipam.NewLocalIPAM(nil)
+			}
+
+			got, err := instance.GetProfileConfig(cloudprovider.DeviceIdentifiers{MAC: tt.mac}, nil, tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetProfileConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if tt.wantAddrs == 0 {
+				if got != nil {
+					t.Fatalf("GetProfileConfig() = %#v, want nil", got)
+				}
+				return
+			}
+			if got == nil || len(got.Interface.Addresses) != tt.wantAddrs {
+				t.Fatalf("GetProfileConfig() addresses = %v, want %d", got, tt.wantAddrs)
+			}
+		})
+	}
+}
+
+// TestGetProfileConfigSourceRouting verifies that when the VM metadata carries
+// the gateways, the profile returns the full policy based routing configuration
+// (per-device table routes plus per-address source rules) through the existing
+// Routes/Rules API, so the driver applies it with no special casing.
+func TestGetProfileConfigSourceRouting(t *testing.T) {
+	const mac = "00:11:22:33:44:55"
+	iface := gceNetworkInterface{
+		Mac:         mac,
+		IPAliases:   []string{"10.24.3.0/24"},
+		IPv6:        []string{"2001:db8:1234:5678::/64"},
+		Gateway:     "10.24.3.1",
+		GatewayIPv6: "fe80::1",
+	}
+	instance := &GCEInstance{Interfaces: []gceNetworkInterface{iface}, localIPAM: ipam.NewLocalIPAM(nil)}
+	ipvlanConfig := &apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN}}
+
+	got, err := instance.GetProfileConfig(cloudprovider.DeviceIdentifiers{MAC: mac}, nil, ipvlanConfig)
+	if err != nil {
+		t.Fatalf("GetProfileConfig() error = %v", err)
+	}
+	if got == nil || len(got.Interface.Addresses) != 2 {
+		t.Fatalf("GetProfileConfig() = %#v, want 2 allocated addresses", got)
+	}
+
+	table := apis.TableIDForName(mac)
+	wantRoutes := []apis.RouteConfig{
+		{Destination: "10.24.3.1/32", Scope: 253, Table: table},
+		{Destination: "0.0.0.0/0", Gateway: "10.24.3.1", Table: table},
+		{Destination: "fe80::1/128", Scope: 253, Table: table},
+		{Destination: "::/0", Gateway: "fe80::1", Table: table},
+	}
+	if diff := cmp.Diff(wantRoutes, got.Routes); diff != "" {
+		t.Errorf("Routes mismatch (-want +got):\n%s", diff)
+	}
+
+	if len(got.Rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d: %+v", len(got.Rules), got.Rules)
+	}
+	// Allocated addresses are already host prefixes, so rule sources match them.
+	for i, rule := range got.Rules {
+		if rule.Source != got.Interface.Addresses[i] || rule.Table != table || rule.Priority != apis.SourceRoutingRulePriority {
+			t.Errorf("rule[%d] = %+v, want source %s table %d priority %d", i, rule, got.Interface.Addresses[i], table, apis.SourceRoutingRulePriority)
+		}
+	}
+
+	// A config that already carries routes or rules owns its routing:
+	// the profile must only return the allocated addresses.
+	userOwned := &apis.NetworkConfig{
+		Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN},
+		Routes:    []apis.RouteConfig{{Destination: "0.0.0.0/0", Gateway: "10.24.3.1"}},
+	}
+	got, err = instance.GetProfileConfig(cloudprovider.DeviceIdentifiers{MAC: mac}, nil, userOwned)
+	if err != nil {
+		t.Fatalf("GetProfileConfig() error = %v", err)
+	}
+	if got == nil || len(got.Interface.Addresses) != 2 {
+		t.Fatalf("GetProfileConfig() = %#v, want 2 allocated addresses", got)
+	}
+	if len(got.Routes) != 0 || len(got.Rules) != 0 {
+		t.Errorf("expected no synthesized routes/rules for user-owned routing, got routes %+v rules %+v", got.Routes, got.Rules)
+	}
+}
+
+func TestGetIPv6Range(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseIPStr string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "valid CIDR prefix /64",
+			baseIPStr: "2001:db8:1234:5678::/64",
+			want:      "2001:db8:1234:5678:c0de::/80",
+			wantErr:   false,
+		},
+		{
+			name:      "too large CIDR prefix /112",
+			baseIPStr: "2001:db8:1234:5678:abcd:ef01:2345::/112",
+			wantErr:   true,
+		},
+		{
+			name:      "plain IP, no CIDR prefix",
+			baseIPStr: "2001:db8:1234:5678:abcd:ef01:2345:6789",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid IP format",
+			baseIPStr: "invalid-ip",
+			wantErr:   true,
+		},
+		{
+			name:      "IPv4 CIDR input",
+			baseIPStr: "192.168.1.0/24",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getIPv6Range(tt.baseIPStr)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("getIPv6Range() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("getIPv6Range() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubinterfaceRanges(t *testing.T) {
+	tests := []struct {
+		name    string
+		iface   gceNetworkInterface
+		want    [][2]string // {start, end} per range, in order.
+		wantErr bool
+	}{
+		{
+			name:  "IPv4 alias only",
+			iface: gceNetworkInterface{IPAliases: []string{"10.24.3.0/24"}},
+			want:  [][2]string{{"10.24.3.1", "10.24.3.254"}},
+		},
+		{
+			name:  "IPv6 only",
+			iface: gceNetworkInterface{IPv6: []string{"2001:db8:1234:5678::/64"}},
+			want:  [][2]string{{"2001:db8:1234:5678:c0de::1", "2001:db8:1234:5678:c0de:ffff:ffff:fffe"}},
+		},
+		{
+			name:  "dual stack orders IPv6 before IPv4",
+			iface: gceNetworkInterface{IPAliases: []string{"10.24.3.0/24"}, IPv6: []string{"2001:db8:1234:5678::/64"}},
+			want: [][2]string{
+				{"2001:db8:1234:5678:c0de::1", "2001:db8:1234:5678:c0de:ffff:ffff:fffe"},
+				{"10.24.3.1", "10.24.3.254"},
+			},
+		},
+		{
+			name:  "no IPv6 or aliases yields no ranges",
+			iface: gceNetworkInterface{Mac: "00:11:22:33:44:55"},
+			want:  nil,
+		},
+		{
+			name:    "invalid IPv6 base returns error",
+			iface:   gceNetworkInterface{IPv6: []string{"not-an-ip"}},
+			wantErr: true,
+		},
+		{
+			name:    "invalid IPv4 alias returns error",
+			iface:   gceNetworkInterface{IPAliases: []string{"bad-cidr"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GCEInstance{}
+			got, err := g.subinterfaceRanges(tt.iface)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("subinterfaceRanges() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("subinterfaceRanges() got %d ranges, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for i, r := range got {
+				if r.Start.String() != tt.want[i][0] || r.End.String() != tt.want[i][1] {
+					t.Errorf("range[%d] = [%s, %s], want [%s, %s]", i, r.Start, r.End, tt.want[i][0], tt.want[i][1])
+				}
+			}
+		})
+	}
+}
+
+func TestWithReservedAddresses(t *testing.T) {
+	g := &GCEInstance{localIPAM: ipam.NewLocalIPAM(nil)}
+	WithReservedAddresses([]string{"10.0.0.5/32"})(g)
+
+	if err := g.localIPAM.Reserve([]string{"10.0.0.5/32"}); err == nil {
+		t.Errorf("expected 10.0.0.5/32 to already be reserved, but it was accepted again")
+	}
+	if err := g.localIPAM.Reserve([]string{"10.0.0.6/32"}); err != nil {
+		t.Errorf("expected 10.0.0.6/32 to be free, got error: %v", err)
 	}
 }

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/netip"
 	"slices"
 	"sort"
 	"strings"
@@ -398,6 +399,19 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			deviceCfg.NetworkInterfaceConfigInPod.Ethtool.Features = ethtoolFeatures
 		}
 
+		// Preserve custom routes and rules, if existing,
+		// before appending the host network namespace routes and rules.
+		var customRoutes []apis.RouteConfig
+		if len(deviceCfg.NetworkInterfaceConfigInPod.Routes) > 0 {
+			customRoutes = make([]apis.RouteConfig, len(deviceCfg.NetworkInterfaceConfigInPod.Routes))
+			copy(customRoutes, deviceCfg.NetworkInterfaceConfigInPod.Routes)
+		}
+		var customRules []apis.RuleConfig
+		if len(deviceCfg.NetworkInterfaceConfigInPod.Rules) > 0 {
+			customRules = make([]apis.RuleConfig, len(deviceCfg.NetworkInterfaceConfigInPod.Rules))
+			copy(customRules, deviceCfg.NetworkInterfaceConfigInPod.Rules)
+		}
+
 		// Obtain the routes and rules associated with the interface.
 		routes, tables, err := getRouteInfo(nlHandle, ifName, link)
 		if err != nil {
@@ -437,6 +451,46 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 				HardwareAddr: neigh.HardwareAddr.String(),
 			}
 			deviceCfg.NetworkInterfaceConfigInPod.Neighbors = append(deviceCfg.NetworkInterfaceConfigInPod.Neighbors, neighCfg)
+		}
+
+		// If subinterface is enabled, configure the subinterface properties,
+		// including interface name, IP address, and source-based routing rules.
+		if deviceCfg.NetworkInterfaceConfigInPod.SubInterface != nil {
+			// Derive the subinterface name by adding a type prefix to the parent interface
+			if deviceCfg.NetworkInterfaceConfigInPod.SubInterface.Name == "" {
+				subInterfaceType := deviceCfg.NetworkInterfaceConfigInPod.SubInterface.Type
+				deviceCfg.NetworkInterfaceConfigInPod.SubInterface.Name = string(subInterfaceType) + "-" + ifName
+			}
+
+			// If not specified, assign an IP address from the configured IP ranges using node local IPAM.
+			if len(deviceCfg.NetworkInterfaceConfigInPod.SubInterface.Addresses) == 0 {
+				ipRanges := deviceCfg.NetworkInterfaceConfigInPod.SubInterface.IPRanges
+				if len(ipRanges) == 0 {
+					errorList = append(errorList, fmt.Errorf("can't assign IP for subinterface %s, no IPRanges specified", ifName))
+					continue
+				}
+				if np.localIPAM == nil {
+					errorList = append(errorList, fmt.Errorf("can't assign IP for subinterface %s, IPAM database not initialized", ifName))
+					continue
+				}
+				// Allocate at most one IP per IP family from the configured ranges.
+				addresses, err := np.localIPAM.Allocate(ipRanges)
+				if err != nil {
+					errorList = append(errorList, fmt.Errorf("can't assign IP for subinterface %s: %w", ifName, err))
+					continue
+				}
+				deviceCfg.NetworkInterfaceConfigInPod.SubInterface.Addresses = addresses
+			}
+
+			// If the user has already configured custom routes or rules, we
+			// preserve and skip automatic source-based routing. Otherwise,
+			// we perform source-based routing.
+			if len(customRoutes) > 0 || len(customRules) > 0 {
+				deviceCfg.NetworkInterfaceConfigInPod.Routes = customRoutes
+				deviceCfg.NetworkInterfaceConfigInPod.Rules = customRules
+			} else if len(deviceCfg.NetworkInterfaceConfigInPod.SubInterface.Addresses) != 0 {
+				addSourceBasedRouting(&deviceCfg, link.Attrs().Index)
+			}
 		}
 
 		// Get RDMA configuration: link and char devices
@@ -517,6 +571,7 @@ func (np *NetworkDriver) unprepareResourceClaims(ctx context.Context, claims []k
 }
 
 func (np *NetworkDriver) unprepareResourceClaim(_ context.Context, claim kubeletplugin.NamespacedObject) error {
+	var ipsToRelease []string
 	for _, podUID := range np.podConfigStore.ListPods() {
 		podCfg, ok := np.podConfigStore.GetPodConfig(podUID)
 		if !ok {
@@ -524,6 +579,10 @@ func (np *NetworkDriver) unprepareResourceClaim(_ context.Context, claim kubelet
 		}
 		for deviceName, devCfg := range podCfg.DeviceConfigs {
 			if devCfg.Claim.Namespace == claim.Namespace && devCfg.Claim.Name == claim.Name {
+				if devCfg.NetworkInterfaceConfigInPod.SubInterface != nil {
+					ipsToRelease = append(ipsToRelease, devCfg.NetworkInterfaceConfigInPod.SubInterface.Addresses...)
+				}
+
 				if devCfg.NetworkInterfaceConfigInPod.Profile != "" {
 					if err := np.netdb.ReleaseProfileConfig(deviceName, claim.UID, &devCfg.NetworkInterfaceConfigInPod); err != nil {
 						klog.Errorf("failed to release profile config for claim %v: %v", claim.NamespacedName, err)
@@ -534,6 +593,12 @@ func (np *NetworkDriver) unprepareResourceClaim(_ context.Context, claim kubelet
 	}
 
 	np.podConfigStore.DeleteClaim(claim.NamespacedName)
+
+	if np.localIPAM != nil {
+		for _, ip := range ipsToRelease {
+			np.localIPAM.Release(ip)
+		}
+	}
 	return nil
 }
 
@@ -750,4 +815,83 @@ func mergeDeviceStructs(live, snap resourceapi.Device) resourceapi.Device {
 	}
 
 	return merged
+}
+
+// addSourceBasedRouting sets up source-based routing for the subinterface: each
+// source address egresses via a per-interface table holding an on-link gateway
+// route and a default route. It finds the gateway for each IP family from the
+// interface's configured routes, and mutates deviceCfg to replace the
+// host-copied Routes and Rules.
+func addSourceBasedRouting(deviceCfg *DeviceConfig, linkIndex int) {
+	tableID := 100 + linkIndex
+
+	// Parse the interface routes to find the gateway.
+	// gateways stores the gateway IP addresses, keyed by "ipv4" and "ipv6".
+	gateways := make(map[string]netip.Addr)
+	for _, r := range deviceCfg.NetworkInterfaceConfigInPod.Routes {
+		if r.Gateway != "" {
+			if gatewayAddr, err := netip.ParseAddr(r.Gateway); err == nil {
+				if gatewayAddr.Is6() {
+					gateways["ipv6"] = gatewayAddr
+				} else if gatewayAddr.Is4() {
+					gateways["ipv4"] = gatewayAddr
+				}
+			}
+		}
+	}
+	if len(gateways) == 0 {
+		klog.Warningf("Unable to configure source-based routing: no gateway found on interface %s", deviceCfg.NetworkInterfaceConfigInPod.Interface.Name)
+		return
+	}
+
+	// Clean up the routes and rules in the pod namespace copied from the host.
+	deviceCfg.NetworkInterfaceConfigInPod.Routes = nil
+	deviceCfg.NetworkInterfaceConfigInPod.Rules = nil
+
+	// Iterate through IP addresses to inject the gateway and default routes into the
+	// custom table, and add a source-based routing rule for each IP targeting the custom table.
+	// addedRoutes records whether the gateway and default routes are added for "ipv4" and "ipv6".
+	addedRoutes := make(map[string]bool)
+	for _, ipStr := range deviceCfg.NetworkInterfaceConfigInPod.SubInterface.Addresses {
+		prefix, _ := netip.ParsePrefix(ipStr)
+		var stack string
+		var defaultPrefix netip.Prefix
+		switch {
+		case prefix.Addr().Is6():
+			stack = "ipv6"
+			defaultPrefix = netip.PrefixFrom(netip.IPv6Unspecified(), 0)
+		case prefix.Addr().Is4():
+			stack = "ipv4"
+			defaultPrefix = netip.PrefixFrom(netip.IPv4Unspecified(), 0)
+		default:
+			continue
+		}
+		gwAddr, hasGw := gateways[stack]
+		if !hasGw {
+			continue
+		}
+
+		if !addedRoutes[stack] {
+			// Add link route for the gateway.
+			gwPrefix := netip.PrefixFrom(gwAddr, gwAddr.BitLen())
+			deviceCfg.NetworkInterfaceConfigInPod.Routes = append(deviceCfg.NetworkInterfaceConfigInPod.Routes, apis.RouteConfig{
+				Destination: gwPrefix.String(),
+				Scope:       253, // ScopeLink
+				Table:       tableID,
+			})
+			// Add default route in the custom table.
+			deviceCfg.NetworkInterfaceConfigInPod.Routes = append(deviceCfg.NetworkInterfaceConfigInPod.Routes, apis.RouteConfig{
+				Destination: defaultPrefix.String(),
+				Gateway:     gwAddr.String(),
+				Table:       tableID,
+			})
+			addedRoutes[stack] = true
+		}
+		// Add source-based routing rule for the current IP address.
+		deviceCfg.NetworkInterfaceConfigInPod.Rules = append(deviceCfg.NetworkInterfaceConfigInPod.Rules, apis.RuleConfig{
+			Source:   ipStr,
+			Table:    tableID,
+			Priority: 32000,
+		})
+	}
 }

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -337,7 +337,7 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 
 		// If DHCP is requested, do a DHCP request to gather the network parameters (IPs and Routes)
 		// ... but we DO NOT apply them in the root namespace
-		if deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP != nil && *deviceCfg.NetworkInterfaceConfigInPod.Interface.DHCP {
+		if deviceCfg.NetworkInterfaceConfigInPod.Interface.Addressing == apis.AddressingModeDHCP {
 			klog.V(2).Infof("trying to get network configuration via DHCP")
 			contextCancel, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
@@ -348,8 +348,8 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 				deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses = []string{ip}
 				deviceCfg.NetworkInterfaceConfigInPod.Routes = append(deviceCfg.NetworkInterfaceConfigInPod.Routes, routes...)
 			}
-		} else if len(deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses) == 0 {
-			// If there is no custom addresses and no DHCP, then use the existing ones
+		} else if !deviceCfg.NetworkInterfaceConfigInPod.Interface.IsSubinterface() && len(deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses) == 0 {
+			// For a passthrough interface with no custom addresses and no DHCP, then use the existing ones
 			// get the existing IP addresses
 			nlAddresses, err := nlHandle.AddrList(link, netlink.FAMILY_ALL)
 			if err != nil {
@@ -397,23 +397,25 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			deviceCfg.NetworkInterfaceConfigInPod.Ethtool.Features = ethtoolFeatures
 		}
 
-		// Obtain the routes and rules associated with the interface.
-		routes, tables, err := getRouteInfo(nlHandle, ifName, link)
-		if err != nil {
-			errorList = append(errorList, err)
-			continue
-		}
-		deviceCfg.NetworkInterfaceConfigInPod.Routes = append(deviceCfg.NetworkInterfaceConfigInPod.Routes, routes...)
+		// For non-subinterface type, obtain the routes and rules associated with the interface.
+		if !deviceCfg.NetworkInterfaceConfigInPod.Interface.IsSubinterface() {
+			routes, tables, err := getRouteInfo(nlHandle, ifName, link)
+			if err != nil {
+				errorList = append(errorList, err)
+				continue
+			}
+			deviceCfg.NetworkInterfaceConfigInPod.Routes = append(deviceCfg.NetworkInterfaceConfigInPod.Routes, routes...)
 
-		// If VRF is enabled, we do not need to copy the rules from the host
-		// because the VRF handles the routing table lookup.
-		if deviceCfg.NetworkInterfaceConfigInPod.Interface.VRF == nil {
-			for _, table := range tables.UnsortedList() {
-				if rules, ok := rulesByTable[table]; ok {
-					klog.V(5).Infof("Adding %d rules for table %d associated with interface %s", len(rules), table, ifName)
-					deviceCfg.NetworkInterfaceConfigInPod.Rules = append(deviceCfg.NetworkInterfaceConfigInPod.Rules, rules...)
-					// Avoid adding the same rule twice
-					delete(rulesByTable, table)
+			// If VRF is enabled, we do not need to copy the rules from the host
+			// because the VRF handles the routing table lookup.
+			if deviceCfg.NetworkInterfaceConfigInPod.Interface.VRF == nil {
+				for _, table := range tables.UnsortedList() {
+					if rules, ok := rulesByTable[table]; ok {
+						klog.V(5).Infof("Adding %d rules for table %d associated with interface %s", len(rules), table, ifName)
+						deviceCfg.NetworkInterfaceConfigInPod.Rules = append(deviceCfg.NetworkInterfaceConfigInPod.Rules, rules...)
+						// Avoid adding the same rule twice
+						delete(rulesByTable, table)
+					}
 				}
 			}
 		}
@@ -438,8 +440,28 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			deviceCfg.NetworkInterfaceConfigInPod.Neighbors = append(deviceCfg.NetworkInterfaceConfigInPod.Neighbors, neighCfg)
 		}
 
+		// A subinterface has no host addresses to inherit, so its addresses must
+		// come from the user config, a profile, or be explicitly waived via
+		// Addressing: Unnumbered. Routing (including any policy based routing) is
+		// owned by the user or the provider profile; the driver never synthesizes
+		// routes or rules.
+		if deviceCfg.NetworkInterfaceConfigInPod.Interface.IsSubinterface() {
+			iface := &deviceCfg.NetworkInterfaceConfigInPod.Interface
+			if len(iface.Addresses) == 0 && iface.Addressing != apis.AddressingModeUnnumbered {
+				errorList = append(errorList, fmt.Errorf("device %s: interface type %q resolved with no addresses; set interface.addresses, reference a profile that allocates them, or set interface.addressing: Unnumbered", result.Device, iface.Type))
+				continue
+			}
+			if iface.Addressing == apis.AddressingModeUnnumbered {
+				klog.V(2).Infof("device %s: unnumbered %s interface requested; skipping address and route configuration", result.Device, iface.Type)
+			}
+		}
+
 		// Get RDMA configuration: link and char devices
 		if rdmaDev, err := inventory.GetRdmaDevice(ifName); err == nil && rdmaDev != "" {
+			if deviceCfg.NetworkInterfaceConfigInPod.Interface.IsSubinterface() && !np.rdmaSharedMode {
+				errorList = append(errorList, fmt.Errorf("device %s: interface type %q (subinterface) is not supported with exclusive RDMA mode; use shared RDMA mode", result.Device, deviceCfg.NetworkInterfaceConfigInPod.Interface.Type))
+				continue
+			}
 			klog.V(2).Infof("RunPodSandbox processing RDMA device: %s", rdmaDev)
 			deviceCfg.RDMADevice = buildRDMAConfig(rdmaDev)
 		}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -155,9 +155,10 @@ func TestPrepareResourceClaimsMetrics(t *testing.T) {
 		draPluginRequestsLatencySeconds.Reset()
 
 		np := &NetworkDriver{
-			netdb:         newFakeInventoryDB(),
-			driverName:    "test.driver",
-			eventRecorder: record.NewFakeRecorder(100),
+			netdb:          newFakeInventoryDB(),
+			driverName:     "test.driver",
+			eventRecorder:  record.NewFakeRecorder(100),
+			podConfigStore: mustNewPodConfigStore(),
 		}
 
 		claims := []*resourcev1.ResourceClaim{
@@ -1215,6 +1216,164 @@ func testPrepareResourceClaim_Namespaced(t *testing.T) {
 				}
 			},
 			wantErr: "failed to get network interface name for device net-dev-0",
+		},
+		{
+			name: "subinterface resolving with no addresses returns error",
+			claim: &resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{UID: "claim-uid-subif-noaddr", Namespace: "default", Name: "claim-subif-noaddr"},
+				Status: resourcev1.ResourceClaimStatus{
+					ReservedFor: []resourcev1.ResourceClaimConsumerReference{
+						{APIGroup: "", Resource: "pods", Name: "test-pod", UID: "pod-uid-subif-noaddr"},
+					},
+					Allocation: &resourcev1.AllocationResult{
+						Devices: resourcev1.DeviceAllocationResult{
+							Results: []resourcev1.DeviceRequestAllocationResult{
+								{Driver: testDriverName, Device: "net-dev-0", Request: "req-0"},
+							},
+						},
+					},
+				},
+			},
+			setupDB: func(db *fakeInventoryDB) {
+				db.IsIBOnlyDeviceFunc = func(deviceName string) bool { return false }
+				db.GetNetInterfaceNameFunc = func(deviceName string) (string, error) { return "dummy0", nil }
+				db.GetDeviceFunc = func(deviceName string) (resourcev1.Device, bool) {
+					return resourcev1.Device{Name: deviceName}, true
+				}
+				// Cloud advertises an ipvlan subinterface but resolves no addresses.
+				db.GetDeviceConfigFunc = func(deviceName string) (*apis.NetworkConfig, bool) {
+					return &apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: "IPVLAN"}}, true
+				}
+			},
+			wantErr: "resolved with no addresses",
+		},
+		{
+			name: "unnumbered subinterface is allowed without addresses",
+			claim: &resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{UID: "claim-uid-subif-unnum", Namespace: "default", Name: "claim-subif-unnum"},
+				Status: resourcev1.ResourceClaimStatus{
+					ReservedFor: []resourcev1.ResourceClaimConsumerReference{
+						{APIGroup: "", Resource: "pods", Name: "test-pod", UID: "pod-uid-subif-unnum"},
+					},
+					Allocation: &resourcev1.AllocationResult{
+						Devices: resourcev1.DeviceAllocationResult{
+							Results: []resourcev1.DeviceRequestAllocationResult{
+								{Driver: testDriverName, Device: "net-dev-0", Request: "req-0"},
+							},
+						},
+					},
+				},
+			},
+			setupDB: func(db *fakeInventoryDB) {
+				db.IsIBOnlyDeviceFunc = func(deviceName string) bool { return false }
+				db.GetNetInterfaceNameFunc = func(deviceName string) (string, error) { return "dummy0", nil }
+				db.GetDeviceFunc = func(deviceName string) (resourcev1.Device, bool) {
+					return resourcev1.Device{Name: deviceName}, true
+				}
+				// Cloud advertises an unnumbered ipvlan subinterface.
+				db.GetDeviceConfigFunc = func(deviceName string) (*apis.NetworkConfig, bool) {
+					return &apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: "IPVLAN", Addressing: apis.AddressingModeUnnumbered}}, true
+				}
+			},
+			wantPodConfig: &PodConfig{
+				DeviceConfigs: map[string]DeviceConfig{
+					"net-dev-0": {
+						Claim: types.NamespacedName{
+							Namespace: "default",
+							Name:      "claim-subif-unnum",
+						},
+						DeviceSnapshot: &resourcev1.Device{Name: "net-dev-0"},
+						NetworkInterfaceConfigInHost: apis.NetworkConfig{
+							Interface: apis.InterfaceConfig{
+								Name: "dummy0",
+							},
+						},
+						NetworkInterfaceConfigInPod: apis.NetworkConfig{
+							Interface: apis.InterfaceConfig{
+								Name:       "dummy0",
+								Type:       "IPVLAN",
+								Addressing: apis.AddressingModeUnnumbered,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "subinterface with provider-advertised profile resolves addresses and PBR",
+			claim: &resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{UID: "claim-uid-subif-implicit", Namespace: "default", Name: "claim-subif-implicit"},
+				Status: resourcev1.ResourceClaimStatus{
+					ReservedFor: []resourcev1.ResourceClaimConsumerReference{
+						{APIGroup: "", Resource: "pods", Name: "test-pod", UID: "pod-uid-subif-implicit"},
+					},
+					Allocation: &resourcev1.AllocationResult{
+						Devices: resourcev1.DeviceAllocationResult{
+							Results: []resourcev1.DeviceRequestAllocationResult{
+								{Driver: testDriverName, Device: "net-dev-0", Request: "req-0"},
+							},
+						},
+					},
+				},
+			},
+			setupDB: func(db *fakeInventoryDB) {
+				db.IsIBOnlyDeviceFunc = func(deviceName string) bool { return false }
+				db.GetNetInterfaceNameFunc = func(deviceName string) (string, error) { return "dummy0", nil }
+				db.GetDeviceFunc = func(deviceName string) (resourcev1.Device, bool) {
+					return resourcev1.Device{Name: deviceName}, true
+				}
+				// The cloud advertises an ipvlan subinterface and its own managed
+				// profile, so resolution runs without the user setting profile.
+				db.GetDeviceConfigFunc = func(deviceName string) (*apis.NetworkConfig, bool) {
+					return &apis.NetworkConfig{Profile: "cloud-managed", Interface: apis.InterfaceConfig{Type: "IPVLAN"}}, true
+				}
+				db.GetProfileConfigFunc = func(deviceName string, claimUID types.UID, config *apis.NetworkConfig) (*apis.NetworkConfig, error) {
+					if !config.Interface.IsSubinterface() {
+						return nil, nil
+					}
+					return &apis.NetworkConfig{
+						Interface: apis.InterfaceConfig{Addresses: []string{"10.24.3.5/32"}},
+						Routes: []apis.RouteConfig{
+							{Destination: "10.24.3.1/32", Scope: 253, Table: 1100},
+							{Destination: "0.0.0.0/0", Gateway: "10.24.3.1", Table: 1100},
+						},
+						Rules: []apis.RuleConfig{
+							{Source: "10.24.3.5/32", Table: 1100, Priority: apis.SourceRoutingRulePriority},
+						},
+					}, nil
+				}
+			},
+			wantPodConfig: &PodConfig{
+				DeviceConfigs: map[string]DeviceConfig{
+					"net-dev-0": {
+						Claim: types.NamespacedName{
+							Namespace: "default",
+							Name:      "claim-subif-implicit",
+						},
+						DeviceSnapshot: &resourcev1.Device{Name: "net-dev-0"},
+						NetworkInterfaceConfigInHost: apis.NetworkConfig{
+							Interface: apis.InterfaceConfig{
+								Name: "dummy0",
+							},
+						},
+						NetworkInterfaceConfigInPod: apis.NetworkConfig{
+							Profile: "cloud-managed",
+							Interface: apis.InterfaceConfig{
+								Name:      "dummy0",
+								Type:      "IPVLAN",
+								Addresses: []string{"10.24.3.5/32"},
+							},
+							Routes: []apis.RouteConfig{
+								{Destination: "10.24.3.1/32", Scope: 253, Table: 1100},
+								{Destination: "0.0.0.0/0", Gateway: "10.24.3.1", Table: 1100},
+							},
+							Rules: []apis.RuleConfig{
+								{Source: "10.24.3.5/32", Table: 1100, Priority: apis.SourceRoutingRulePriority},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1327,7 +1327,7 @@ func testPrepareResourceClaim_Namespaced(t *testing.T) {
 				db.GetDeviceConfigFunc = func(deviceName string) (*apis.NetworkConfig, bool) {
 					return &apis.NetworkConfig{Profile: "cloud-managed", Interface: apis.InterfaceConfig{Type: "IPVLAN"}}, true
 				}
-				db.GetProfileConfigFunc = func(deviceName string, claimUID types.UID, config *apis.NetworkConfig) (*apis.NetworkConfig, error) {
+				db.GetProfileConfigFunc = func(deviceName string, claim *resourcev1.ResourceClaim, config *apis.NetworkConfig) (*apis.NetworkConfig, error) {
 					if !config.Interface.IsSubinterface() {
 						return nil, nil
 					}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -904,7 +904,7 @@ func TestMergeDevices(t *testing.T) {
 			expected: []resourcev1.Device{pciDevSnapshot},
 		},
 		{
-			name:      "Live device attribute takes precedence over snapshot",
+			name: "Live device attribute takes precedence over snapshot",
 			live: []resourcev1.Device{{
 				Name: "0000:c0:14.0",
 				Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
@@ -926,7 +926,7 @@ func TestMergeDevices(t *testing.T) {
 				},
 				Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
 					"network-bandwidth": qtyCap("1G"),
-					"other-capacity":     qtyCap("50"),
+					"other-capacity":    qtyCap("50"),
 				},
 			}},
 			expected: []resourcev1.Device{{
@@ -939,7 +939,7 @@ func TestMergeDevices(t *testing.T) {
 				},
 				Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
 					"network-bandwidth": qtyCap("10G"),
-					"other-capacity":     qtyCap("50"),
+					"other-capacity":    qtyCap("50"),
 				},
 			}},
 		},
@@ -950,6 +950,148 @@ func TestMergeDevices(t *testing.T) {
 			result := mergeDevices(tc.live, tc.snapshot)
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
 				t.Errorf("mergeDevices result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAddSourceBasedRoutingRule(t *testing.T) {
+	tests := []struct {
+		name       string
+		deviceCfg  DeviceConfig
+		wantRules  []apis.RuleConfig
+		wantRoutes []apis.RouteConfig
+	}{
+		{
+			name: "IPv4 no route containing gateway, source-based routing should not be added",
+			deviceCfg: DeviceConfig{
+				NetworkInterfaceConfigInPod: apis.NetworkConfig{
+					Interface: apis.InterfaceConfig{},
+					SubInterface: &apis.SubInterfaceConfig{
+						Type:      "ipvlan",
+						Addresses: []string{"192.168.1.3/32"},
+					},
+					Routes: []apis.RouteConfig{
+						{Destination: "192.168.1.0/24", Table: 0},
+					},
+				},
+			},
+			wantRules: nil,
+			wantRoutes: []apis.RouteConfig{
+				{Destination: "192.168.1.0/24", Table: 0},
+			},
+		},
+		{
+			name: "IPv6 default route in main table, source-based routing should be added",
+			deviceCfg: DeviceConfig{
+				NetworkInterfaceConfigInPod: apis.NetworkConfig{
+					Interface: apis.InterfaceConfig{},
+					SubInterface: &apis.SubInterfaceConfig{
+						Type:      "ipvlan",
+						Addresses: []string{"2001:db8::3/128"},
+					},
+					Routes: []apis.RouteConfig{
+						{Destination: "::/0", Gateway: "fe80::1", Table: 0},
+					},
+				},
+			},
+			wantRules: []apis.RuleConfig{
+				{Source: "2001:db8::3/128", Table: 101, Priority: 32000},
+			},
+			wantRoutes: []apis.RouteConfig{
+				{Destination: "fe80::1/128", Table: 101, Scope: 253},
+				{Destination: "::/0", Gateway: "fe80::1", Table: 101},
+			},
+		},
+		{
+			name: "dual-stack routes with gateways, both IPv4 and IPv6 routes and rules should be added",
+			deviceCfg: DeviceConfig{
+				NetworkInterfaceConfigInPod: apis.NetworkConfig{
+					Interface: apis.InterfaceConfig{},
+					SubInterface: &apis.SubInterfaceConfig{
+						Type:      "ipvlan",
+						Addresses: []string{"192.168.1.3/32", "2001:db8::3/128"},
+					},
+					Routes: []apis.RouteConfig{
+						{Destination: "192.168.1.0/24", Gateway: "192.168.1.1", Table: 100},
+						{Destination: "2001:db8::/64", Gateway: "fe80::1", Table: 0},
+					},
+				},
+			},
+			wantRules: []apis.RuleConfig{
+				{Source: "192.168.1.3/32", Table: 101, Priority: 32000},
+				{Source: "2001:db8::3/128", Table: 101, Priority: 32000},
+			},
+			wantRoutes: []apis.RouteConfig{
+				{Destination: "192.168.1.1/32", Table: 101, Scope: 253},
+				{Destination: "0.0.0.0/0", Gateway: "192.168.1.1", Table: 101},
+				{Destination: "fe80::1/128", Table: 101, Scope: 253},
+				{Destination: "::/0", Gateway: "fe80::1", Table: 101},
+			},
+		},
+		{
+			name: "multiple IPv6 addresses with the default route, two rules and one set of custom table routes should be added",
+			deviceCfg: DeviceConfig{
+				NetworkInterfaceConfigInPod: apis.NetworkConfig{
+					Interface: apis.InterfaceConfig{},
+					SubInterface: &apis.SubInterfaceConfig{
+						Type:      "ipvlan",
+						Addresses: []string{"2001:db8::3/128", "2001:db8::4/128"},
+					},
+					Routes: []apis.RouteConfig{
+						{Destination: "::/0", Gateway: "fe80::1", Table: 0},
+					},
+				},
+			},
+			wantRules: []apis.RuleConfig{
+				{Source: "2001:db8::3/128", Table: 101, Priority: 32000},
+				{Source: "2001:db8::4/128", Table: 101, Priority: 32000},
+			},
+			wantRoutes: []apis.RouteConfig{
+				{Destination: "fe80::1/128", Table: 101, Scope: 253},
+				{Destination: "::/0", Gateway: "fe80::1", Table: 101},
+			},
+		},
+		{
+			name: "family present but no matching gateway, source-based routing should not be added",
+			deviceCfg: DeviceConfig{
+				NetworkInterfaceConfigInPod: apis.NetworkConfig{
+					Interface: apis.InterfaceConfig{},
+					SubInterface: &apis.SubInterfaceConfig{
+						Type:      "ipvlan",
+						Addresses: []string{"2001:db8::3/128"}, // IPv6 address
+					},
+					Routes: []apis.RouteConfig{
+						{Destination: "0.0.0.0/0", Gateway: "192.168.1.1", Table: 0}, // only an IPv4 gateway
+					},
+				},
+			},
+			wantRules:  nil,
+			wantRoutes: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addSourceBasedRouting(&tt.deviceCfg, 1)
+			gotRules := tt.deviceCfg.NetworkInterfaceConfigInPod.Rules
+			if len(gotRules) != len(tt.wantRules) {
+				t.Fatalf("Expected %d rules, got %d", len(tt.wantRules), len(gotRules))
+			}
+			for i := range gotRules {
+				if gotRules[i].Source != tt.wantRules[i].Source || gotRules[i].Table != tt.wantRules[i].Table || gotRules[i].Priority != tt.wantRules[i].Priority {
+					t.Errorf("gotRules[%d] = %+v, want %+v", i, gotRules[i], tt.wantRules[i])
+				}
+			}
+
+			gotRoutes := tt.deviceCfg.NetworkInterfaceConfigInPod.Routes
+			if len(gotRoutes) != len(tt.wantRoutes) {
+				t.Fatalf("Expected %d routes, got %d", len(tt.wantRoutes), len(gotRoutes))
+			}
+			for i := range gotRoutes {
+				if gotRoutes[i].Destination != tt.wantRoutes[i].Destination || gotRoutes[i].Gateway != tt.wantRoutes[i].Gateway || gotRoutes[i].Table != tt.wantRoutes[i].Table || gotRoutes[i].Scope != tt.wantRoutes[i].Scope {
+					t.Errorf("gotRoutes[%d] = %+v, want %+v", i, gotRoutes[i], tt.wantRoutes[i])
+				}
 			}
 		})
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -85,14 +85,6 @@ func WithInventory(db inventoryDB) Option {
 	}
 }
 
-// WithDBPath sets the path for the persistent pod config database.
-// If not set, an in-memory store is used.
-func WithDBPath(path string) Option {
-	return func(o *NetworkDriver) {
-		o.dbPath = path
-	}
-}
-
 // WithKubeletRootDir sets the kubelet data directory (its --root-dir). The
 // driver's registration socket lives under <dir>/plugins_registry and its
 // dra.sock under <dir>/plugins. Set this when the kubelet runs with a
@@ -118,7 +110,6 @@ type NetworkDriver struct {
 	// Cache the rdma shared mode state
 	rdmaSharedMode bool
 	podConfigStore *PodConfigStore
-	dbPath         string // path for persistent bbolt database; empty means in-memory
 
 	// kubeletRootDir is the kubelet data directory (its --root-dir). Set when the
 	// kubelet runs with a non-default --root-dir.
@@ -129,7 +120,7 @@ type NetworkDriver struct {
 
 type Option func(*NetworkDriver)
 
-func Start(ctx context.Context, driverName string, kubeClient kubernetes.Interface, nodeName string, opts ...Option) (*NetworkDriver, error) {
+func Start(ctx context.Context, driverName string, kubeClient kubernetes.Interface, nodeName string, podConfigStore *PodConfigStore, opts ...Option) (*NetworkDriver, error) {
 	registerMetrics()
 
 	rdmaNetnsMode, err := nlwrap.RdmaSystemGetNetnsMode()
@@ -152,29 +143,12 @@ func Start(ctx context.Context, driverName string, kubeClient kubernetes.Interfa
 		rdmaSharedMode: rdmaNetnsMode == apis.RdmaNetnsModeShared,
 		clock:          clock.RealClock{},
 		eventRecorder:  eventRecorder,
+		podConfigStore: podConfigStore,
 	}
 
 	for _, o := range opts {
 		o(plugin)
 	}
-
-	// Initialize the pod config store with optional bbolt checkpoint backend.
-	var checkpointer Checkpointer
-	if plugin.dbPath != "" {
-		var err error
-		checkpointer, err = newBoltCheckpointer(plugin.dbPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open pod config database at %s: %v", plugin.dbPath, err)
-		}
-	}
-	store, err := NewPodConfigStore(checkpointer)
-	if err != nil {
-		if checkpointer != nil {
-			checkpointer.Close()
-		}
-		return nil, fmt.Errorf("failed to initialize pod config store: %v", err)
-	}
-	plugin.podConfigStore = store
 
 	driverPluginPath := filepath.Join(plugin.kubeletRootDir, "plugins", driverName)
 	err = os.MkdirAll(driverPluginPath, 0750)
@@ -367,11 +341,6 @@ func (np *NetworkDriver) Stop(ctxCancel context.CancelFunc) {
 	ctxCancel()
 
 	np.nriPlugin.Stop()
-
-	// Close the pod config store.
-	if err := np.podConfigStore.Close(); err != nil {
-		klog.Errorf("Failed to close pod config database: %v", err)
-	}
 
 	klog.Info("Driver stopped.")
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -24,9 +24,10 @@ import (
 	"time"
 
 	"github.com/google/cel-go/cel"
-	"sigs.k8s.io/dranet/pkg/apis"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/inventory"
+	"sigs.k8s.io/dranet/pkg/ipam"
 
 	"github.com/containerd/nri/pkg/stub"
 	"sigs.k8s.io/dranet/internal/nlwrap"
@@ -118,6 +119,7 @@ type NetworkDriver struct {
 	// Cache the rdma shared mode state
 	rdmaSharedMode bool
 	podConfigStore *PodConfigStore
+	localIPAM      *ipam.LocalIPAM
 	dbPath         string // path for persistent bbolt database; empty means in-memory
 
 	// kubeletRootDir is the kubelet data directory (its --root-dir). Set when the
@@ -175,6 +177,7 @@ func Start(ctx context.Context, driverName string, kubeClient kubernetes.Interfa
 		return nil, fmt.Errorf("failed to initialize pod config store: %v", err)
 	}
 	plugin.podConfigStore = store
+	plugin.localIPAM = ipam.NewLocalIPAM(store.GetAllocatedIPs())
 
 	driverPluginPath := filepath.Join(plugin.kubeletRootDir, "plugins", driverName)
 	err = os.MkdirAll(driverPluginPath, 0750)

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -176,7 +176,16 @@ func (np *NetworkDriver) runPodSandbox(ctx context.Context, pod *api.PodSandbox,
 
 		// Block 1: netdev operations — only when a network interface is present.
 		if ifName != "" {
-			if err := attachNetdevToNS(ctx, ns, deviceName, config, resourceClaimStatusDevice); err != nil {
+			if config.NetworkInterfaceConfigInPod.SubInterface != nil {
+				// If subinterface is configured, create the subinterface based on
+				// the current interface.
+				if err := createSubinterfaceInNS(ctx, ns, deviceName, config, resourceClaimStatusDevice); err != nil {
+					np.eventRecorder.Eventf(podObjectRef(pod), v1.EventTypeWarning, "NetworkDeviceCreateFailed",
+						"failed to create subinterface on network device %s to pod %s/%s: %v", deviceName, pod.GetNamespace(), pod.GetName(), err)
+					return err
+				}
+			} else if err := attachNetdevToNS(ctx, ns, deviceName, config, resourceClaimStatusDevice); err != nil {
+				// Otherwise, move the interface into the pod network namespace.
 				np.eventRecorder.Eventf(podObjectRef(pod), v1.EventTypeWarning, "NetworkDeviceAttachFailed",
 					"failed to attach network device %s to pod %s/%s: %v", deviceName, pod.GetNamespace(), pod.GetName(), err)
 				return err
@@ -278,8 +287,44 @@ func attachNetdevToNS(ctx context.Context, ns, deviceName string, config DeviceC
 		WithIPs(networkData.IPs...),
 	) // End of WithNetworkData
 
-	// The interface name inside the container's namespace.
-	ifNameInNs := networkData.InterfaceName
+	// Configure the moved device (ethtool, vrf, routes, neighbors, rules)
+	return configureNetdevInNS(ctx, ns, deviceName, config, networkData.InterfaceName, resourceClaimStatusDevice)
+}
+
+// createSubinterfaceInNS creates a subinterface in the pod network namespace,
+// applies all associated configurations, and records the status conditions.
+func createSubinterfaceInNS(ctx context.Context, ns, deviceName string, config DeviceConfig, resourceClaimStatusDevice *resourceapply.AllocatedDeviceStatusApplyConfiguration) error {
+	logger := klog.FromContext(ctx)
+	hostIfName := config.NetworkInterfaceConfigInHost.Interface.Name
+	logger.V(2).Info("RunPodSandbox creating subinterface on parent device", "parentDevice", hostIfName)
+
+	networkData, err := nsCreateSubinterface(hostIfName, ns, config.NetworkInterfaceConfigInPod.SubInterface)
+	if err != nil {
+		logger.Error(err, "RunPodSandbox error creating subinterface", "parentDevice", hostIfName, "netns", ns)
+		return fmt.Errorf("error creating subinterface on parent %s in namespace %s: %v", hostIfName, ns, err)
+	}
+
+	resourceClaimStatusDevice.WithConditions(
+		metav1apply.Condition().
+			WithType("Ready").
+			WithReason("NetworkDeviceReady").
+			WithStatus(metav1.ConditionTrue).
+			WithLastTransitionTime(metav1.Now()),
+	).WithNetworkData(resourceapply.NetworkDeviceData().
+		WithInterfaceName(networkData.InterfaceName).
+		WithHardwareAddress(networkData.HardwareAddress).
+		WithIPs(networkData.IPs...),
+	)
+
+	// Configure the subinterface (ethtool, vrf, routes, neighbors, rules)
+	return configureNetdevInNS(ctx, ns, deviceName, config, networkData.InterfaceName, resourceClaimStatusDevice)
+}
+
+// configureNetdevInNS applies common L3 configurations (ethtool, eBPF, VRF, routes, rules, and neighbors)
+// to a network interface inside the container's network namespace and marks the claim status as NetworkReady.
+func configureNetdevInNS(ctx context.Context, ns, deviceName string, config DeviceConfig, ifNameInNs string, resourceClaimStatusDevice *resourceapply.AllocatedDeviceStatusApplyConfiguration) error {
+	logger := klog.FromContext(ctx)
+	var err error
 
 	// Apply Ethtool configurations
 	if config.NetworkInterfaceConfigInPod.Ethtool != nil {
@@ -293,7 +338,7 @@ func attachNetdevToNS(ctx context.Context, ns, deviceName string, config DeviceC
 	// Check if the ebpf programs should be disabled
 	if config.NetworkInterfaceConfigInPod.Interface.DisableEBPFPrograms != nil &&
 		*config.NetworkInterfaceConfigInPod.Interface.DisableEBPFPrograms {
-		err := detachEBPFPrograms(ns, ifNameInNs)
+		err = detachEBPFPrograms(ns, ifNameInNs)
 		if err != nil {
 			logger.Error(err, "Error disabling ebpf programs", "podInterface", ifNameInNs)
 			return fmt.Errorf("error disabling ebpf programs for %s in ns %s: %v", ifNameInNs, ns, err)
@@ -403,10 +448,17 @@ func (np *NetworkDriver) stopPodSandbox(ctx context.Context, pod *api.PodSandbox
 		netdevDetached := false
 		ifName := config.NetworkInterfaceConfigInPod.Interface.Name
 		if ifName != "" {
-			if err := nsDetachNetdev(ns, ifName, config.NetworkInterfaceConfigInHost.Interface.Name); err != nil {
-				logger.Error(err, "Failed to return network device", "device", deviceName)
+			if config.NetworkInterfaceConfigInPod.SubInterface != nil {
+				subIfName := config.NetworkInterfaceConfigInPod.SubInterface.Name
+				if err := nsDeleteSubinterface(ns, subIfName); err != nil {
+					klog.Errorf("fail to delete subinterface %s for device %s: %v", subIfName, deviceName, err)
+				}
 			} else {
-				netdevDetached = true
+				if err := nsDetachNetdev(ns, ifName, config.NetworkInterfaceConfigInHost.Interface.Name); err != nil {
+					klog.Errorf("fail to return network device %s : %v", deviceName, err)
+				} else {
+					netdevDetached = true
+				}
 			}
 		}
 

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -176,7 +176,13 @@ func (np *NetworkDriver) runPodSandbox(ctx context.Context, pod *api.PodSandbox,
 
 		// Block 1: netdev operations — only when a network interface is present.
 		if ifName != "" {
-			if err := attachNetdevToNS(ctx, ns, deviceName, config, resourceClaimStatusDevice); err != nil {
+			if config.NetworkInterfaceConfigInPod.Interface.IsSubinterface() {
+				if err := createSubinterfaceInNS(ctx, ns, deviceName, config, resourceClaimStatusDevice); err != nil {
+					np.eventRecorder.Eventf(podObjectRef(pod), v1.EventTypeWarning, "NetworkDeviceCreateFailed",
+						"failed to create subinterface on network device %s to pod %s/%s: %v", deviceName, pod.GetNamespace(), pod.GetName(), err)
+					return err
+				}
+			} else if err := attachNetdevToNS(ctx, ns, deviceName, config, resourceClaimStatusDevice); err != nil {
 				np.eventRecorder.Eventf(podObjectRef(pod), v1.EventTypeWarning, "NetworkDeviceAttachFailed",
 					"failed to attach network device %s to pod %s/%s: %v", deviceName, pod.GetNamespace(), pod.GetName(), err)
 				return err
@@ -278,8 +284,44 @@ func attachNetdevToNS(ctx context.Context, ns, deviceName string, config DeviceC
 		WithIPs(networkData.IPs...),
 	) // End of WithNetworkData
 
-	// The interface name inside the container's namespace.
-	ifNameInNs := networkData.InterfaceName
+	// Configure the moved device (ethtool, vrf, routes, neighbors, rules)
+	return configureNetdevInNS(ctx, ns, deviceName, config, networkData.InterfaceName, resourceClaimStatusDevice)
+}
+
+// createSubinterfaceInNS creates a subinterface in the pod network namespace,
+// applies all associated configurations, and records the status conditions.
+func createSubinterfaceInNS(ctx context.Context, ns, deviceName string, config DeviceConfig, resourceClaimStatusDevice *resourceapply.AllocatedDeviceStatusApplyConfiguration) error {
+	logger := klog.FromContext(ctx)
+	hostIfName := config.NetworkInterfaceConfigInHost.Interface.Name
+	logger.V(2).Info("RunPodSandbox creating subinterface on parent device", "parentDevice", hostIfName)
+
+	networkData, err := nsCreateSubinterface(hostIfName, ns, config.NetworkInterfaceConfigInPod.Interface)
+	if err != nil {
+		logger.Error(err, "RunPodSandbox error creating subinterface", "parentDevice", hostIfName, "netns", ns)
+		return fmt.Errorf("error creating subinterface on parent %s in namespace %s: %v", hostIfName, ns, err)
+	}
+
+	resourceClaimStatusDevice.WithConditions(
+		metav1apply.Condition().
+			WithType("Ready").
+			WithReason("NetworkDeviceReady").
+			WithStatus(metav1.ConditionTrue).
+			WithLastTransitionTime(metav1.Now()),
+	).WithNetworkData(resourceapply.NetworkDeviceData().
+		WithInterfaceName(networkData.InterfaceName).
+		WithHardwareAddress(networkData.HardwareAddress).
+		WithIPs(networkData.IPs...),
+	)
+
+	// Configure the subinterface (ethtool, vrf, routes, neighbors, rules)
+	return configureNetdevInNS(ctx, ns, deviceName, config, networkData.InterfaceName, resourceClaimStatusDevice)
+}
+
+// configureNetdevInNS applies common L3 configurations (ethtool, eBPF, VRF, routes, rules, and neighbors)
+// to a network interface inside the container's network namespace and marks the claim status as NetworkReady.
+func configureNetdevInNS(ctx context.Context, ns, deviceName string, config DeviceConfig, ifNameInNs string, resourceClaimStatusDevice *resourceapply.AllocatedDeviceStatusApplyConfiguration) error {
+	logger := klog.FromContext(ctx)
+	var err error
 
 	// Apply Ethtool configurations
 	if config.NetworkInterfaceConfigInPod.Ethtool != nil {
@@ -293,7 +335,7 @@ func attachNetdevToNS(ctx context.Context, ns, deviceName string, config DeviceC
 	// Check if the ebpf programs should be disabled
 	if config.NetworkInterfaceConfigInPod.Interface.DisableEBPFPrograms != nil &&
 		*config.NetworkInterfaceConfigInPod.Interface.DisableEBPFPrograms {
-		err := detachEBPFPrograms(ns, ifNameInNs)
+		err = detachEBPFPrograms(ns, ifNameInNs)
 		if err != nil {
 			logger.Error(err, "Error disabling ebpf programs", "podInterface", ifNameInNs)
 			return fmt.Errorf("error disabling ebpf programs for %s in ns %s: %v", ifNameInNs, ns, err)
@@ -403,10 +445,17 @@ func (np *NetworkDriver) stopPodSandbox(ctx context.Context, pod *api.PodSandbox
 		netdevDetached := false
 		ifName := config.NetworkInterfaceConfigInPod.Interface.Name
 		if ifName != "" {
-			if err := nsDetachNetdev(ns, ifName, config.NetworkInterfaceConfigInHost.Interface.Name); err != nil {
-				logger.Error(err, "Failed to return network device", "device", deviceName)
+			if config.NetworkInterfaceConfigInPod.Interface.IsSubinterface() {
+				subIfName := config.NetworkInterfaceConfigInPod.Interface.Name
+				if err := nsDeleteSubinterface(ns, subIfName); err != nil {
+					logger.Error(err, "Failed to delete subinterface", "subInterface", subIfName, "device", deviceName)
+				}
 			} else {
-				netdevDetached = true
+				if err := nsDetachNetdev(ns, ifName, config.NetworkInterfaceConfigInHost.Interface.Name); err != nil {
+					logger.Error(err, "Failed to return network device", "device", deviceName)
+				} else {
+					netdevDetached = true
+				}
 			}
 		}
 

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -189,6 +189,59 @@ func TestRunPodSandboxUsesPersistedConfigAfterRestart(t *testing.T) {
 	}
 }
 
+// TestRunPodSandboxSubinterfaceCreation tests the subinterface creation
+// during RunPodSandbox. It verifies the creation call by checking
+// the expected error message is returned from nsCreateSubinterface.
+func TestRunPodSandboxSubinterfaceCreation(t *testing.T) {
+	podUID := types.UID("test-pod-subinterface")
+	store := mustNewPodConfigStore()
+
+	deviceCfg := DeviceConfig{
+		Claim: types.NamespacedName{Namespace: "ns", Name: "claim1"},
+		NetworkInterfaceConfigInHost: apis.NetworkConfig{
+			Interface: apis.InterfaceConfig{Name: "nonexistent-parent"},
+		},
+		NetworkInterfaceConfigInPod: apis.NetworkConfig{
+			Interface: apis.InterfaceConfig{
+				Name:      "eth0",
+				Type:      apis.InterfaceTypeIPVLAN,
+				Addresses: []string{"2001:db8::10/64"},
+			},
+		},
+	}
+
+	if err := store.SetDeviceConfig(podUID, "eth0", deviceCfg); err != nil {
+		t.Fatalf("SetDeviceConfig() error: %v", err)
+	}
+
+	np := &NetworkDriver{
+		podConfigStore: store,
+		netdb:          inventory.New(),
+		eventRecorder:  record.NewFakeRecorder(100),
+	}
+	pod := &api.PodSandbox{
+		Uid:       string(podUID),
+		Name:      "test-pod-subinterface",
+		Namespace: "test-ns",
+		Linux: &api.LinuxPodSandbox{
+			Namespaces: []*api.LinuxNamespace{
+				{Type: "network", Path: "/proc/self/ns/net"},
+			},
+		},
+	}
+
+	// Verify that the subinterface creation path is called by passing a non-existent parent interface
+	// and asserting that the call fails with a "could not find parent interface on host" error.
+	err := np.RunPodSandbox(context.Background(), pod)
+	if err == nil {
+		t.Fatal("expected RunPodSandbox to error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "could not find parent interface nonexistent-parent on host") {
+		t.Errorf("expected error to contain 'could not find parent interface nonexistent-parent on host', got: %v", err)
+	}
+}
+
 func TestSynchronizeStoresNetNSOnlyForConfiguredPods(t *testing.T) {
 	store := mustNewPodConfigStore()
 
@@ -570,6 +623,19 @@ func TestStopPodSandboxRescanGating(t *testing.T) {
 			deviceConfig:      DeviceConfig{RDMADevice: RDMAConfig{LinkDev: "mlx5_0"}},
 			setupNetNs:        true,
 		},
+		{
+			name:              "subinterface configured: no rescan triggered",
+			setupDeviceConfig: true,
+			deviceConfig: DeviceConfig{
+				NetworkInterfaceConfigInPod: apis.NetworkConfig{
+					Interface: apis.InterfaceConfig{
+						Name: "ipvl-eth0",
+						Type: apis.InterfaceTypeIPVLAN,
+					},
+				},
+			},
+			setupNetNs: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -669,5 +735,54 @@ func TestRemovePodSandboxMetrics(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCreateContainerSubinterfaceRDMAInjection verifies that the
+// RDMA character devices are correctly injected into the container
+// adjustment when the pod is configured to use a subinterface.
+func TestCreateContainerSubinterfaceRDMAInjection(t *testing.T) {
+	podUID := types.UID("test-pod-subinterface")
+	deviceCfg := DeviceConfig{
+		NetworkInterfaceConfigInPod: apis.NetworkConfig{
+			Interface: apis.InterfaceConfig{
+				Name:      "ipvl-eth0",
+				Type:      apis.InterfaceTypeIPVLAN,
+				Addresses: []string{"2001:db8::10/64"},
+			},
+		},
+		RDMADevice: RDMAConfig{
+			DevChars: []LinuxDevice{
+				{Path: "/dev/infiniband/uverbs0", Type: "c", Major: 231, Minor: 192},
+				{Path: "/dev/infiniband/rdma_cm", Type: "c", Major: 10, Minor: 58},
+			},
+		},
+	}
+
+	store := mustNewPodConfigStore()
+	if err := store.SetDeviceConfig(podUID, "eth0", deviceCfg); err != nil {
+		t.Fatalf("SetDeviceConfig() error: %v", err)
+	}
+
+	np := &NetworkDriver{podConfigStore: store}
+	pod := &api.PodSandbox{Uid: string(podUID), Name: "test-pod-subinterface", Namespace: "test-ns"}
+	ctr := &api.Container{Name: "test-container"}
+
+	adjust, _, err := np.CreateContainer(context.Background(), pod, ctr)
+	if err != nil {
+		t.Fatalf("CreateContainer failed: %v", err)
+	}
+	if adjust == nil || adjust.Linux == nil {
+		t.Fatalf("CreateContainer returned nil container adjustment")
+	}
+	if len(adjust.Linux.Devices) != 2 {
+		t.Fatalf("expected 2 injected RDMA char devices, got %d", len(adjust.Linux.Devices))
+	}
+
+	expectedPaths := []string{"/dev/infiniband/uverbs0", "/dev/infiniband/rdma_cm"}
+	for i, expectedPath := range expectedPaths {
+		if got := adjust.Linux.Devices[i].Path; got != expectedPath {
+			t.Errorf("expected device %d path to be %q, got %q", i, expectedPath, got)
+		}
 	}
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -84,7 +84,7 @@ func TestCreateContainerUsesPersistedConfigAfterRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newBoltCheckpointer() error: %v", err)
 	}
-	store1, err := NewPodConfigStore(cp1)
+	store1, err := newPodConfigStoreWithCheckpointer(cp1)
 	if err != nil {
 		t.Fatalf("NewPodConfigStore() error: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestCreateContainerUsesPersistedConfigAfterRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newBoltCheckpointer() after restart error: %v", err)
 	}
-	storeAfterRestart, err := NewPodConfigStore(cp2)
+	storeAfterRestart, err := newPodConfigStoreWithCheckpointer(cp2)
 	if err != nil {
 		t.Fatalf("NewPodConfigStore() after restart error: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestRunPodSandboxUsesPersistedConfigAfterRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newBoltCheckpointer() error: %v", err)
 	}
-	store1, err := NewPodConfigStore(cp1)
+	store1, err := newPodConfigStoreWithCheckpointer(cp1)
 	if err != nil {
 		t.Fatalf("NewPodConfigStore() error: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestRunPodSandboxUsesPersistedConfigAfterRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newBoltCheckpointer() after restart error: %v", err)
 	}
-	storeAfterRestart, err := NewPodConfigStore(cp2)
+	storeAfterRestart, err := newPodConfigStoreWithCheckpointer(cp2)
 	if err != nil {
 		t.Fatalf("NewPodConfigStore() after restart error: %v", err)
 	}

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -189,6 +189,59 @@ func TestRunPodSandboxUsesPersistedConfigAfterRestart(t *testing.T) {
 	}
 }
 
+// TestRunPodSandboxSubinterfaceCreation tests the creation of a subinterface during
+// RunPodSandbox when SubInterface is configured. It verifies the creation call
+// by checking the expected error message is returned from nsCreateSubinterface.
+func TestRunPodSandboxSubinterfaceCreation(t *testing.T) {
+	podUID := types.UID("test-pod-subinterface")
+	store := mustNewPodConfigStore()
+
+	deviceCfg := DeviceConfig{
+		Claim: types.NamespacedName{Namespace: "ns", Name: "claim1"},
+		NetworkInterfaceConfigInHost: apis.NetworkConfig{
+			Interface: apis.InterfaceConfig{Name: "nonexistent-parent"},
+		},
+		NetworkInterfaceConfigInPod: apis.NetworkConfig{
+			SubInterface: &apis.SubInterfaceConfig{
+				Type:      "ipvlan",
+				Name:      "ipvlan-eth0",
+				Addresses: []string{"2001:db8::10/64"},
+				IPRanges:  []apis.IPRangeConfig{{CIDR: "2001:db8::/64"}},
+			},
+		},
+	}
+
+	if err := store.SetDeviceConfig(podUID, "eth0", deviceCfg); err != nil {
+		t.Fatalf("SetDeviceConfig() error: %v", err)
+	}
+
+	np := &NetworkDriver{
+		podConfigStore: store,
+		netdb:          inventory.New(),
+		eventRecorder:  record.NewFakeRecorder(100),
+	}
+	pod := &api.PodSandbox{
+		Uid:       string(podUID),
+		Name:      "test-pod-subinterface",
+		Namespace: "test-ns",
+		Linux: &api.LinuxPodSandbox{
+			Namespaces: []*api.LinuxNamespace{
+				{Type: "network", Path: "/proc/self/ns/net"},
+			},
+		},
+	}
+
+	// Verify that the subinterface creation path is called by passing a non-existent parent interface
+	// and asserting that the call fails with a "could not find parent interface on host" error.
+	err := np.RunPodSandbox(context.Background(), pod)
+	if err == nil {
+		t.Fatal("expected RunPodSandbox to error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "could not find parent interface nonexistent-parent on host") {
+		t.Errorf("expected error to contain 'could not find parent interface nonexistent-parent on host', got: %v", err)
+	}
+}
 
 func TestSynchronizeStoresNetNSOnlyForConfiguredPods(t *testing.T) {
 	store := mustNewPodConfigStore()
@@ -571,6 +624,19 @@ func TestStopPodSandboxRescanGating(t *testing.T) {
 			deviceConfig:      DeviceConfig{RDMADevice: RDMAConfig{LinkDev: "mlx5_0"}},
 			setupNetNs:        true,
 		},
+		{
+			name:              "subinterface configured: no rescan triggered",
+			setupDeviceConfig: true,
+			deviceConfig: DeviceConfig{
+				NetworkInterfaceConfigInPod: apis.NetworkConfig{
+					SubInterface: &apis.SubInterfaceConfig{
+						Name: "ipvlan-eth0",
+						Type: "ipvlan",
+					},
+				},
+			},
+			setupNetNs: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -670,5 +736,55 @@ func TestRemovePodSandboxMetrics(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCreateContainerSubinterfaceRDMAInjection verifies that the
+// RDMA character devices are correctly injected into the container
+// adjustment when the pod is configured to use a subinterface.
+func TestCreateContainerSubinterfaceRDMAInjection(t *testing.T) {
+	podUID := types.UID("test-pod-subinterface")
+	deviceCfg := DeviceConfig{
+		NetworkInterfaceConfigInPod: apis.NetworkConfig{
+			SubInterface: &apis.SubInterfaceConfig{
+				Type:      "ipvlan",
+				Name:      "ipvlan-eth0",
+				Addresses: []string{"2001:db8::10/64"},
+				IPRanges:  []apis.IPRangeConfig{{CIDR: "2001:db8::/64"}},
+			},
+		},
+		RDMADevice: RDMAConfig{
+			DevChars: []LinuxDevice{
+				{Path: "/dev/infiniband/uverbs0", Type: "c", Major: 231, Minor: 192},
+				{Path: "/dev/infiniband/rdma_cm", Type: "c", Major: 10, Minor: 58},
+			},
+		},
+	}
+
+	store := mustNewPodConfigStore()
+	if err := store.SetDeviceConfig(podUID, "eth0", deviceCfg); err != nil {
+		t.Fatalf("SetDeviceConfig() error: %v", err)
+	}
+
+	np := &NetworkDriver{podConfigStore: store}
+	pod := &api.PodSandbox{Uid: string(podUID), Name: "test-pod-subinterface", Namespace: "test-ns"}
+	ctr := &api.Container{Name: "test-container"}
+
+	adjust, _, err := np.CreateContainer(context.Background(), pod, ctr)
+	if err != nil {
+		t.Fatalf("CreateContainer failed: %v", err)
+	}
+	if adjust == nil || adjust.Linux == nil {
+		t.Fatalf("CreateContainer returned nil container adjustment")
+	}
+	if len(adjust.Linux.Devices) != 2 {
+		t.Fatalf("expected 2 injected RDMA char devices, got %d", len(adjust.Linux.Devices))
+	}
+
+	expectedPaths := []string{"/dev/infiniband/uverbs0", "/dev/infiniband/rdma_cm"}
+	for i, expectedPath := range expectedPaths {
+		if got := adjust.Linux.Devices[i].Path; got != expectedPath {
+			t.Errorf("expected device %d path to be %q, got %q", i, expectedPath, got)
+		}
 	}
 }

--- a/pkg/driver/pod_device_config.go
+++ b/pkg/driver/pod_device_config.go
@@ -220,9 +220,9 @@ func (s *PodConfigStore) GetDeviceConfig(podUID types.UID, deviceName string) (D
 // regardless of checkpoint outcome. This asymmetry with SetDeviceConfig
 // (which aborts on checkpoint failure) is intentional:
 //   - A failed Set leaving stale RAM would silently lose config on restart (#89).
-//   - A failed Delete leaving a stale checkpoint is harmless: Synchronize()
-//     prunes orphaned checkpoint entries on the next startup by diffing
-//     against live pods from the container runtime.
+//   - A failed Delete leaving a stale checkpoint is harmless: Kubelet's DRA manager
+//     is guaranteed to retry UnprepareResourceClaims (which triggers DeletePod)
+//     until it succeeds, ensuring that the checkpoint is eventually cleaned up.
 //
 // Skipping the RAM delete would be worse — the driver would keep processing
 // a pod that the runtime has already removed.
@@ -287,8 +287,8 @@ func (s *PodConfigStore) SetPodNetNs(podUID types.UID, netns string) {
 	s.configs[podUID] = podCfg
 }
 
-// DeleteClaim removes all configurations associated with a given claim and
-// returns the list of Pod UIDs that were associated with it.
+// DeleteClaim removes all configurations and allocated IPs associated with a given
+// claim and returns the list of Pod UIDs that were associated with it.
 // Like DeletePod, checkpoint failures do not prevent in-memory cleanup.
 // See DeletePod for rationale on this intentional asymmetry with SetDeviceConfig.
 func (s *PodConfigStore) DeleteClaim(claim types.NamespacedName) []types.UID {
@@ -330,4 +330,21 @@ func (s *PodConfigStore) GetAllocatedDeviceSnapshots() []resourceapi.Device {
 		}
 	}
 	return allocated
+}
+
+// GetAllocatedIPs returns all currently allocated IP addresses from the stored configs.
+// This is used at driver startup to populate the IPAM database.
+func (s *PodConfigStore) GetAllocatedIPs() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var ips []string
+	for _, podCfg := range s.configs {
+		for _, devCfg := range podCfg.DeviceConfigs {
+			if devCfg.NetworkInterfaceConfigInPod.SubInterface != nil {
+				ips = append(ips, devCfg.NetworkInterfaceConfigInPod.SubInterface.Addresses...)
+			}
+		}
+	}
+	return ips
 }

--- a/pkg/driver/pod_device_config.go
+++ b/pkg/driver/pod_device_config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driver
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -120,11 +121,35 @@ type PodConfigStore struct {
 	checkpointer Checkpointer // nil when no persistence is configured
 }
 
-// NewPodConfigStore creates a new PodConfigStore. If a Checkpointer is
-// provided, existing device configs are loaded from the checkpoint into memory.
-// Pod-level state is not persisted; NetNS is rebuilt through Synchronize() on
-// driver startup, while LastNRIActivity resets to its zero value.
-func NewPodConfigStore(checkpointer Checkpointer) (*PodConfigStore, error) {
+// NewPodConfigStore creates a new PodConfigStore. If dbPath is non-empty, it
+// initializes a bbolt checkpoint backend at that path; otherwise the store is
+// in-memory only.
+func NewPodConfigStore(dbPath string) (*PodConfigStore, error) {
+	var checkpointer Checkpointer
+	if dbPath != "" {
+		cp, err := newBoltCheckpointer(dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open pod config database at %s: %w", dbPath, err)
+		}
+		checkpointer = cp
+	}
+
+	s, err := newPodConfigStoreWithCheckpointer(checkpointer)
+	if err != nil {
+		if checkpointer != nil {
+			checkpointer.Close()
+		}
+		return nil, err
+	}
+	return s, nil
+}
+
+// newPodConfigStoreWithCheckpointer creates a PodConfigStore backed by the given
+// checkpointer, useful for injecting a fake in tests. If a checkpointer is provided,
+// existing device configs are loaded from the checkpoint into memory. Pod-level state
+// is not persisted; NetNS is rebuilt through Synchronize() on driver startup, while
+// LastNRIActivity resets to its zero value.
+func newPodConfigStoreWithCheckpointer(checkpointer Checkpointer) (*PodConfigStore, error) {
 	s := &PodConfigStore{
 		configs:      make(map[types.UID]PodConfig),
 		checkpointer: checkpointer,
@@ -220,9 +245,9 @@ func (s *PodConfigStore) GetDeviceConfig(podUID types.UID, deviceName string) (D
 // regardless of checkpoint outcome. This asymmetry with SetDeviceConfig
 // (which aborts on checkpoint failure) is intentional:
 //   - A failed Set leaving stale RAM would silently lose config on restart (#89).
-//   - A failed Delete leaving a stale checkpoint is harmless: Synchronize()
-//     prunes orphaned checkpoint entries on the next startup by diffing
-//     against live pods from the container runtime.
+//   - A failed Delete leaving a stale checkpoint is harmless: Kubelet's DRA manager
+//     is guaranteed to retry UnprepareResourceClaims (which triggers DeletePod)
+//     until it succeeds, ensuring that the checkpoint is eventually cleaned up.
 //
 // Skipping the RAM delete would be worse — the driver would keep processing
 // a pod that the runtime has already removed.
@@ -287,8 +312,8 @@ func (s *PodConfigStore) SetPodNetNs(podUID types.UID, netns string) {
 	s.configs[podUID] = podCfg
 }
 
-// DeleteClaim removes all configurations associated with a given claim and
-// returns the list of Pod UIDs that were associated with it.
+// DeleteClaim removes all configurations and allocated IPs associated with a given
+// claim and returns the list of Pod UIDs that were associated with it.
 // Like DeletePod, checkpoint failures do not prevent in-memory cleanup.
 // See DeletePod for rationale on this intentional asymmetry with SetDeviceConfig.
 func (s *PodConfigStore) DeleteClaim(claim types.NamespacedName) []types.UID {
@@ -330,4 +355,23 @@ func (s *PodConfigStore) GetAllocatedDeviceSnapshots() []resourceapi.Device {
 		}
 	}
 	return allocated
+}
+
+// GetInUseSubinterfaceIPs returns all subinterface IP addresses
+// that are in use, collected from the stored pod configs.
+// When the node-local IPAM is initialized, this seeding ensures
+// that in-use addresses will not be reallocated again.
+func (s *PodConfigStore) GetInUseSubinterfaceIPs() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var ips []string
+	for _, podCfg := range s.configs {
+		for _, devCfg := range podCfg.DeviceConfigs {
+			if devCfg.NetworkInterfaceConfigInPod.Interface.IsSubinterface() {
+				ips = append(ips, devCfg.NetworkInterfaceConfigInPod.Interface.Addresses...)
+			}
+		}
+	}
+	return ips
 }

--- a/pkg/driver/pod_device_config_bolt_test.go
+++ b/pkg/driver/pod_device_config_bolt_test.go
@@ -43,7 +43,7 @@ func newTestBoltCheckpointer(t *testing.T) *boltCheckpointer {
 func newTestStoreWithBolt(t *testing.T) (*PodConfigStore, *boltCheckpointer) {
 	t.Helper()
 	cp := newTestBoltCheckpointer(t)
-	store, err := NewPodConfigStore(cp)
+	store, err := newPodConfigStoreWithCheckpointer(cp)
 	if err != nil {
 		t.Fatalf("NewPodConfigStore() error: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestPodConfigStore_Persistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newBoltCheckpointer() error: %v", err)
 	}
-	store1, err := NewPodConfigStore(cp1)
+	store1, err := newPodConfigStoreWithCheckpointer(cp1)
 	if err != nil {
 		t.Fatalf("NewPodConfigStore() error: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestPodConfigStore_Persistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newBoltCheckpointer() reopen error: %v", err)
 	}
-	store2, err := NewPodConfigStore(cp2)
+	store2, err := newPodConfigStoreWithCheckpointer(cp2)
 	if err != nil {
 		t.Fatalf("NewPodConfigStore() reopen error: %v", err)
 	}
@@ -363,9 +363,9 @@ func TestBoltCheckpointer_Errors(t *testing.T) {
 // TestPodConfigStore_NoCheckpointer verifies that PodConfigStore works
 // correctly without a checkpointer (pure in-memory).
 func TestPodConfigStore_NoCheckpointer(t *testing.T) {
-	store, err := NewPodConfigStore(nil)
+	store, err := newPodConfigStoreWithCheckpointer(nil)
 	if err != nil {
-		t.Fatalf("NewPodConfigStore(nil) error: %v", err)
+		t.Fatalf("newPodConfigStoreWithCheckpointer(nil) error: %v", err)
 	}
 
 	store.SetDeviceConfig("pod-1", "eth0", DeviceConfig{

--- a/pkg/driver/pod_device_config_test.go
+++ b/pkg/driver/pod_device_config_test.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 
@@ -32,9 +33,9 @@ import (
 
 // mustNewPodConfigStore creates a PodConfigStore with no checkpointer for use in tests.
 func mustNewPodConfigStore() *PodConfigStore {
-	s, err := NewPodConfigStore(nil)
+	s, err := newPodConfigStoreWithCheckpointer(nil)
 	if err != nil {
-		panic(fmt.Sprintf("NewPodConfigStore(nil) should never fail: %v", err))
+		panic(fmt.Sprintf("newPodConfigStoreWithCheckpointer(nil) should never fail: %v", err))
 	}
 	return s
 }
@@ -460,5 +461,91 @@ func TestPodConfigStore_GetAllocatedDeviceSnapshots(t *testing.T) {
 	}
 	if diff := cmp.Diff(snapDev, allocated[0]); diff != "" {
 		t.Errorf("allocated device snapshot mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestPodConfigStore_GetInUseSubinterfaceIPs verifies GetInUseSubinterfaceIPs collects sub-interface
+// IPs (primary interface addresses are ignored). It is called once at startup, so we
+// test it statelessly.
+func TestPodConfigStore_GetInUseSubinterfaceIPs(t *testing.T) {
+	type deviceEntry struct {
+		podUID     types.UID
+		deviceName string
+		netConfig  apis.NetworkConfig
+	}
+	tests := []struct {
+		name     string
+		devices  []deviceEntry
+		expected []string
+	}{
+		{
+			name:     "empty store",
+			devices:  nil,
+			expected: []string{},
+		},
+		{
+			name: "only collect sub-interface IP",
+			devices: []deviceEntry{
+				{
+					podUID:     "pod-1",
+					deviceName: "eth0",
+					netConfig:  apis.NetworkConfig{Interface: apis.InterfaceConfig{Addresses: []string{"2001:db8::2/128"}}},
+				},
+				{
+					podUID:     "pod-1",
+					deviceName: "eth1",
+					netConfig:  apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN, Addresses: []string{"2001:db8::3/128"}}},
+				},
+			},
+			expected: []string{"2001:db8::3/128"},
+		},
+		{
+			name: "multiple devices on one pod",
+			devices: []deviceEntry{
+				{
+					podUID:     "pod-1",
+					deviceName: "eth0",
+					netConfig:  apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN, Addresses: []string{"192.168.1.100/24"}}},
+				},
+				{
+					podUID:     "pod-1",
+					deviceName: "eth1",
+					netConfig:  apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN, Addresses: []string{"192.168.2.100/24"}}},
+				},
+			},
+			expected: []string{"192.168.1.100/24", "192.168.2.100/24"},
+		},
+		{
+			name: "device configuration without IPs",
+			devices: []deviceEntry{{
+				podUID:     "pod-1",
+				deviceName: "eth0",
+				netConfig:  apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN, Addresses: nil}},
+			}},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := mustNewPodConfigStore()
+			for _, d := range tt.devices {
+				if err := store.SetDeviceConfig(d.podUID, d.deviceName, DeviceConfig{
+					NetworkInterfaceConfigInPod: d.netConfig,
+				}); err != nil {
+					t.Fatalf("SetDeviceConfig(%s, %s) failed: %v", d.podUID, d.deviceName, err)
+				}
+			}
+			got := store.GetInUseSubinterfaceIPs()
+			sort.Strings(got)
+			sort.Strings(tt.expected)
+			if len(got) == 0 && len(tt.expected) == 0 {
+				// avoid nil vs empty slice issues in DeepEqual
+				return
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("GetInUseSubinterfaceIPs() = %+v, want %+v", got, tt.expected)
+			}
+		})
 	}
 }

--- a/pkg/driver/pod_device_config_test.go
+++ b/pkg/driver/pod_device_config_test.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 
@@ -446,7 +447,7 @@ func TestPodConfigStore_GetAllocatedDeviceSnapshots(t *testing.T) {
 		},
 	}
 	err = store.SetDeviceConfig(podUID2, "0000:c0:14.0", DeviceConfig{
-		Claim:  types.NamespacedName{Namespace: "default", Name: "claim-2"},
+		Claim:          types.NamespacedName{Namespace: "default", Name: "claim-2"},
 		DeviceSnapshot: &snapDev,
 	})
 	if err != nil {
@@ -460,5 +461,87 @@ func TestPodConfigStore_GetAllocatedDeviceSnapshots(t *testing.T) {
 	}
 	if diff := cmp.Diff(snapDev, allocated[0]); diff != "" {
 		t.Errorf("allocated device snapshot mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestPodConfigStore_GetAllocatedIPs verifies GetAllocatedIPs collects sub-interface
+// IPs (primary interface addresses are ignored). It is called once at startup, so we
+// test it statelessly.
+func TestPodConfigStore_GetAllocatedIPs(t *testing.T) {
+	type deviceEntry struct {
+		podUID     types.UID
+		deviceName string
+		netConfig  apis.NetworkConfig
+	}
+	tests := []struct {
+		name     string
+		devices  []deviceEntry
+		expected []string
+	}{
+		{
+			name:     "empty store",
+			devices:  nil,
+			expected: []string{},
+		},
+		{
+			name: "primary and sub-interface IPv6 allocations",
+			devices: []deviceEntry{{
+				podUID:     "pod-1",
+				deviceName: "eth0",
+				netConfig: apis.NetworkConfig{
+					Interface:    apis.InterfaceConfig{Addresses: []string{"2001:db8::1/64"}},
+					SubInterface: &apis.SubInterfaceConfig{Addresses: []string{"2001:db8::3/128"}},
+				},
+			}},
+			expected: []string{"2001:db8::3/128"},
+		},
+		{
+			name: "multiple devices on one pod",
+			devices: []deviceEntry{
+				{
+					podUID:     "pod-1",
+					deviceName: "eth0",
+					netConfig:  apis.NetworkConfig{SubInterface: &apis.SubInterfaceConfig{Addresses: []string{"192.168.1.100/24"}}},
+				},
+				{
+					podUID:     "pod-1",
+					deviceName: "eth1",
+					netConfig:  apis.NetworkConfig{SubInterface: &apis.SubInterfaceConfig{Addresses: []string{"192.168.2.100/24"}}},
+				},
+			},
+			expected: []string{"192.168.1.100/24", "192.168.2.100/24"},
+		},
+		{
+			name: "device configuration without IPs",
+			devices: []deviceEntry{{
+				podUID:     "pod-1",
+				deviceName: "eth0",
+				netConfig:  apis.NetworkConfig{SubInterface: &apis.SubInterfaceConfig{Addresses: nil}},
+			}},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := mustNewPodConfigStore()
+			for _, d := range tt.devices {
+				if err := store.SetDeviceConfig(d.podUID, d.deviceName, DeviceConfig{
+					NetworkInterfaceConfigInPod: d.netConfig,
+				}); err != nil {
+					t.Fatalf("SetDeviceConfig(%s, %s) failed: %v", d.podUID, d.deviceName, err)
+				}
+			}
+			got := store.GetAllocatedIPs()
+			sort.Strings(got)
+			sort.Strings(tt.expected)
+			if len(got) == 0 && len(tt.expected) == 0 {
+				// avoid nil vs empty slice issues in DeepEqual
+				return
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("GetAllocatedIPs() = %+v, want %+v", got, tt.expected)
+			}
+		})
 	}
 }

--- a/pkg/driver/subinterfaces.go
+++ b/pkg/driver/subinterfaces.go
@@ -18,16 +18,20 @@ package driver
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/dranet/internal/nlwrap"
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
-func addMacVlan(containerNsPAth string, devName string, mode netlink.MacvlanMode) error {
-	containerNs, err := netns.GetFromPath(containerNsPAth)
+func addMacVlan(containerNsPath string, devName string, mode netlink.MacvlanMode) error {
+	containerNs, err := netns.GetFromPath(containerNsPath)
 	if err != nil {
-		return fmt.Errorf("could not get network namespace from path %s for network device %s : %w", containerNsPAth, devName, err)
+		return fmt.Errorf("could not get network namespace from path %s for network device %s : %w", containerNsPath, devName, err)
 	}
 	defer containerNs.Close()
 
@@ -52,31 +56,147 @@ func addMacVlan(containerNsPAth string, devName string, mode netlink.MacvlanMode
 	return nil
 }
 
-func addIPVlan(containerNsPAth string, devName string, mode netlink.IPVlanMode) error {
-	containerNs, err := netns.GetFromPath(containerNsPAth)
-	if err != nil {
-		return fmt.Errorf("could not get network namespace from path %s for network device %s : %w", containerNsPAth, devName, err)
-	}
-	defer containerNs.Close()
+func addIPVlan(ifName string, parentLink netlink.Link, containerNs netns.NsHandle, config *apis.SubInterfaceConfig) (*resourceapi.NetworkDeviceData, error) {
+	var mode netlink.IPVlanMode
+	var flag netlink.IPVlanFlag
+	if config != nil && config.IPVlan != nil {
+		switch config.IPVlan.Mode {
+		case "", "l2":
+			mode = netlink.IPVLAN_MODE_L2
+		default:
+			return nil, fmt.Errorf("unsupported ipvlan mode: %s", config.IPVlan.Mode)
+		}
 
-	parentLink, err := nlwrap.LinkByName(devName)
-	if err != nil {
-		return fmt.Errorf("could not find parent interface %s : %w", devName, err)
+		switch config.IPVlan.Flag {
+		case "", "bridge":
+			flag = netlink.IPVLAN_FLAG_BRIDGE
+		default:
+			return nil, fmt.Errorf("unsupported ipvlan flag: %s", config.IPVlan.Flag)
+		}
+	} else {
+		mode = netlink.IPVLAN_MODE_L2
+		flag = netlink.IPVLAN_FLAG_BRIDGE
 	}
 
 	ipvlan := &netlink.IPVlan{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:        "ipvlan-" + devName,
+			Name:        ifName,
 			ParentIndex: parentLink.Attrs().Index,
-			NetNsID:     int(containerNs),
+			Namespace:   netlink.NsFd(int(containerNs)),
 		},
 		Mode: mode,
+		Flag: flag,
 	}
 
 	if err := netlink.LinkAdd(ipvlan); err != nil {
 		// If a user creates a macvlan and ipvlan on same parent, only one slave iface can be active at a time.
-		return fmt.Errorf("failed to create the %s ipvlan interface: %v", ipvlan.Name, err)
+		return nil, fmt.Errorf("failed to create the %s ipvlan interface: %v", ipvlan.Name, err)
 	}
 
+	// Get handle in container namespace to configure IPs and bring the link UP.
+	nhNs, err := nlwrap.NewHandleAt(containerNs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get netlink handle: %w", err)
+	}
+	defer nhNs.Close()
+
+	nsLink, err := nhNs.LinkByName(ifName)
+	if err != nil {
+		return nil, fmt.Errorf("link not found for interface %s: %w", ifName, err)
+	}
+
+	networkData := &resourceapi.NetworkDeviceData{
+		InterfaceName:   nsLink.Attrs().Name,
+		HardwareAddress: nsLink.Attrs().HardwareAddr.String(),
+	}
+
+	for _, address := range config.Addresses {
+		ip, ipnet, err := net.ParseCIDR(address)
+		if err != nil {
+			klog.Infof("failed to parse address %s : %v", address, err)
+			continue
+		}
+		err = nhNs.AddrAdd(nsLink, &netlink.Addr{IPNet: &net.IPNet{IP: ip, Mask: ipnet.Mask}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up address %s: %w", address, err)
+		}
+		networkData.IPs = append(networkData.IPs, address)
+	}
+
+	err = nhNs.LinkSetUp(nsLink)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set up interface %s: %w", nsLink.Attrs().Name, err)
+	}
+
+	return networkData, nil
+}
+
+// nsCreateSubinterface creates a subinterface (currently supports IPVLAN) of hostIfName
+// directly in the container network namespace and configures it with the specified addresses.
+func nsCreateSubinterface(hostIfName string, containerNsPath string, subInterfaceConfig *apis.SubInterfaceConfig) (*resourceapi.NetworkDeviceData, error) {
+	containerNs, err := netns.GetFromPath(containerNsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container network namespace %s: %w", containerNsPath, err)
+	}
+	defer containerNs.Close()
+
+	parentLink, err := nlwrap.LinkByName(hostIfName)
+	if err != nil {
+		return nil, fmt.Errorf("could not find parent interface %s on host: %w", hostIfName, err)
+	}
+
+	// Make sure the parent link is up on the host, otherwise subinterfaces cannot transmit traffic.
+	if err := netlink.LinkSetUp(parentLink); err != nil {
+		return nil, fmt.Errorf("failed to bring parent interface %s UP on host: %w", hostIfName, err)
+	}
+
+	// ifName should be the interface name configured in Pod, which has
+	// the subInterface type prefix. It falls back to use the name configured
+	// in host, if the config in Pod doesn't specify the interface name.
+	ifName := hostIfName
+	if subInterfaceConfig.Name != "" {
+		ifName = subInterfaceConfig.Name
+	}
+
+	var networkData *resourceapi.NetworkDeviceData
+	// We only support creating IPVlan subinterface right now.
+	if subInterfaceConfig.Type == apis.SubInterfaceTypeIPVlan {
+		networkData, err = addIPVlan(ifName, parentLink, containerNs, subInterfaceConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the %s ipvlan interface on namespace %s: %w", ifName, containerNsPath, err)
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported subinterface type: %v", subInterfaceConfig.Type)
+	}
+
+	return networkData, nil
+}
+
+// nsDeleteSubinterface deletes a subinterface inside the container namespace.
+func nsDeleteSubinterface(containerNsPath string, devName string) error {
+	containerNs, err := netns.GetFromPath(containerNsPath)
+	if err != nil {
+		return fmt.Errorf("could not get container network namespace %s: %w", containerNsPath, err)
+	}
+	defer containerNs.Close()
+
+	nhNs, err := nlwrap.NewHandleAt(containerNs)
+	if err != nil {
+		return fmt.Errorf("could not get network namespace handle: %w", err)
+	}
+	defer nhNs.Close()
+
+	link, err := nhNs.LinkByName(devName)
+	if err != nil {
+		// If the link is already gone, return nil (idempotent cleanup).
+		if _, ok := err.(netlink.LinkNotFoundError); ok {
+			return nil
+		}
+		return fmt.Errorf("link not found for interface %s on namespace %s: %w", devName, containerNsPath, err)
+	}
+
+	if err := nhNs.LinkDel(link); err != nil {
+		return fmt.Errorf("failed to delete subinterface %s inside namespace %s: %w", devName, containerNsPath, err)
+	}
 	return nil
 }

--- a/pkg/driver/subinterfaces.go
+++ b/pkg/driver/subinterfaces.go
@@ -17,66 +17,166 @@ limitations under the License.
 package driver
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
+	"net"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/dranet/internal/nlwrap"
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
-func addMacVlan(containerNsPAth string, devName string, mode netlink.MacvlanMode) error {
-	containerNs, err := netns.GetFromPath(containerNsPAth)
-	if err != nil {
-		return fmt.Errorf("could not get network namespace from path %s for network device %s : %w", containerNsPAth, devName, err)
-	}
-	defer containerNs.Close()
-
-	parentLink, err := nlwrap.LinkByName(devName)
-	if err != nil {
-		return fmt.Errorf("could not find parent interface %s : %w", devName, err)
-	}
-
-	macvlan := &netlink.Macvlan{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:        "macvlan-" + devName,
-			ParentIndex: parentLink.Attrs().Index,
-			NetNsID:     int(containerNs),
-		},
-		Mode: mode,
-	}
-	if err := netlink.LinkAdd(macvlan); err != nil {
-		// If a user creates a macvlan and ipvlan on same parent, only one slave iface can be active at a time.
-		return fmt.Errorf("failed to create the %s macvlan interface: %v", macvlan.Name, err)
-	}
-
-	return nil
+// ipvlanModeToNetlink translates the API IPVLAN mode to its netlink constant.
+var ipvlanModeToNetlink = map[apis.IPVlanMode]netlink.IPVlanMode{
+	apis.IPVlanModeL2: netlink.IPVLAN_MODE_L2,
 }
 
-func addIPVlan(containerNsPAth string, devName string, mode netlink.IPVlanMode) error {
-	containerNs, err := netns.GetFromPath(containerNsPAth)
-	if err != nil {
-		return fmt.Errorf("could not get network namespace from path %s for network device %s : %w", containerNsPAth, devName, err)
-	}
-	defer containerNs.Close()
+// ipvlanFlagToNetlink translates the API IPVLAN flag to its netlink constant.
+var ipvlanFlagToNetlink = map[apis.IPVlanFlag]netlink.IPVlanFlag{
+	apis.IPVlanFlagBridge: netlink.IPVLAN_FLAG_BRIDGE,
+}
 
-	parentLink, err := nlwrap.LinkByName(devName)
-	if err != nil {
-		return fmt.Errorf("could not find parent interface %s : %w", devName, err)
+func addIPVlan(ifName string, parentLink netlink.Link, containerNs netns.NsHandle, config apis.InterfaceConfig) (*resourceapi.NetworkDeviceData, error) {
+	mode := netlink.IPVLAN_MODE_L2
+	flag := netlink.IPVLAN_FLAG_BRIDGE
+	if config.IPVlan != nil {
+		var ok bool
+		if mode, ok = ipvlanModeToNetlink[config.IPVlan.Mode]; !ok {
+			return nil, fmt.Errorf("unsupported ipvlan mode: %s", config.IPVlan.Mode)
+		}
+		if flag, ok = ipvlanFlagToNetlink[config.IPVlan.Flag]; !ok {
+			return nil, fmt.Errorf("unsupported ipvlan flag: %s", config.IPVlan.Flag)
+		}
 	}
+
+	// Older kernels reject creating a link directly in another netns if the name
+	// collides in the host netns, so use a random temp name and rename it later.
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return nil, fmt.Errorf("failed to generate temporary interface name: %w", err)
+	}
+	tempName := hex.EncodeToString(b)
 
 	ipvlan := &netlink.IPVlan{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:        "ipvlan-" + devName,
+			Name:        tempName,
 			ParentIndex: parentLink.Attrs().Index,
-			NetNsID:     int(containerNs),
+			Namespace:   netlink.NsFd(int(containerNs)),
 		},
 		Mode: mode,
+		Flag: flag,
 	}
 
 	if err := netlink.LinkAdd(ipvlan); err != nil {
 		// If a user creates a macvlan and ipvlan on same parent, only one slave iface can be active at a time.
-		return fmt.Errorf("failed to create the %s ipvlan interface: %v", ipvlan.Name, err)
+		return nil, fmt.Errorf("failed to create the %s ipvlan interface: %v", ifName, err)
 	}
 
+	// Get handle in container namespace to configure IPs and bring the link UP.
+	nhNs, err := nlwrap.NewHandleAt(containerNs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get netlink handle: %w", err)
+	}
+	defer nhNs.Close()
+
+	nsLink, err := nhNs.LinkByName(tempName)
+	if err != nil {
+		return nil, fmt.Errorf("link not found for interface %s: %w", tempName, err)
+	}
+
+	// Rename back to ifName now that the link is created in the pod netns.
+	if err := nhNs.LinkSetName(nsLink, ifName); err != nil {
+		return nil, fmt.Errorf("failed to rename interface %s to %s: %w", tempName, ifName, err)
+	}
+
+	networkData := &resourceapi.NetworkDeviceData{
+		InterfaceName:   ifName,
+		HardwareAddress: nsLink.Attrs().HardwareAddr.String(),
+	}
+
+	for _, address := range config.Addresses {
+		ip, ipnet, err := net.ParseCIDR(address)
+		if err != nil {
+			klog.Infof("failed to parse address %s : %v", address, err)
+			continue
+		}
+		err = nhNs.AddrAdd(nsLink, &netlink.Addr{IPNet: &net.IPNet{IP: ip, Mask: ipnet.Mask}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up address %s: %w", address, err)
+		}
+		networkData.IPs = append(networkData.IPs, address)
+	}
+
+	err = nhNs.LinkSetUp(nsLink)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set up interface %s: %w", ifName, err)
+	}
+
+	return networkData, nil
+}
+
+// nsCreateSubinterface creates a subinterface (currently supports IPVLAN) of hostIfName
+// directly in the container network namespace and configures it with the specified addresses.
+func nsCreateSubinterface(hostIfName string, containerNsPath string, config apis.InterfaceConfig) (*resourceapi.NetworkDeviceData, error) {
+	containerNs, err := netns.GetFromPath(containerNsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container network namespace %s: %w", containerNsPath, err)
+	}
+	defer containerNs.Close()
+
+	parentLink, err := nlwrap.LinkByName(hostIfName)
+	if err != nil {
+		return nil, fmt.Errorf("could not find parent interface %s on host: %w", hostIfName, err)
+	}
+
+	// Make sure the parent link is up on the host, otherwise subinterfaces cannot transmit traffic.
+	if err := netlink.LinkSetUp(parentLink); err != nil {
+		return nil, fmt.Errorf("failed to bring parent interface %s UP on host: %w", hostIfName, err)
+	}
+
+	var networkData *resourceapi.NetworkDeviceData
+	// We only support creating IPVLAN subinterface right now.
+	if config.Type == apis.InterfaceTypeIPVLAN {
+		networkData, err = addIPVlan(config.Name, parentLink, containerNs, config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the %s ipvlan interface on namespace %s: %w", config.Name, containerNsPath, err)
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported interface type: %v", config.Type)
+	}
+
+	return networkData, nil
+}
+
+// nsDeleteSubinterface deletes a subinterface inside the container namespace.
+func nsDeleteSubinterface(containerNsPath string, devName string) error {
+	containerNs, err := netns.GetFromPath(containerNsPath)
+	if err != nil {
+		return fmt.Errorf("could not get container network namespace %s: %w", containerNsPath, err)
+	}
+	defer containerNs.Close()
+
+	nhNs, err := nlwrap.NewHandleAt(containerNs)
+	if err != nil {
+		return fmt.Errorf("could not get network namespace handle: %w", err)
+	}
+	defer nhNs.Close()
+
+	link, err := nhNs.LinkByName(devName)
+	if err != nil {
+		// If the link is already gone, return nil (idempotent cleanup).
+		if _, ok := err.(netlink.LinkNotFoundError); ok {
+			return nil
+		}
+		return fmt.Errorf("link not found for interface %s on namespace %s: %w", devName, containerNsPath, err)
+	}
+
+	if err := nhNs.LinkDel(link); err != nil {
+		return fmt.Errorf("failed to delete subinterface %s inside namespace %s: %w", devName, containerNsPath, err)
+	}
 	return nil
 }

--- a/pkg/driver/subinterfaces_test.go
+++ b/pkg/driver/subinterfaces_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"sigs.k8s.io/dranet/internal/nlwrap"
+	"sigs.k8s.io/dranet/pkg/apis"
+)
+
+func TestSubinterface_IPVlan(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test requires root privileges.")
+	}
+
+	// Phase 1: Initialize the network namespaces.
+	// Save the host network namespace to restore it at the end of the test.
+	origns, err := netns.Get()
+	if err != nil {
+		t.Fatalf("unexpected error trying to get namespace: %v", err)
+	}
+	defer origns.Close()
+
+	// Create a dedicated target container network namespace.
+	rndString := make([]byte, 4)
+	_, err = rand.Read(rndString)
+	if err != nil {
+		t.Fatalf("fail to generate random name: %v", err)
+	}
+	nsName := fmt.Sprintf("ns%x", rndString)
+	testNS, err := netns.NewNamed(nsName)
+	if err != nil {
+		t.Fatalf("Failed to create network namespace: %v", err)
+	}
+	defer netns.DeleteNamed(nsName)
+	defer testNS.Close()
+
+	// Switch back to the original namespace.
+	netns.Set(origns)
+
+	// Open a netlink handle inside the container namespace to manage the loopback interface.
+	nhNs, err := nlwrap.NewHandleAt(testNS)
+	if err != nil {
+		t.Fatalf("fail to open netlink handle: %v", err)
+	}
+	defer nhNs.Close()
+
+	loLink, err := nhNs.LinkByName("lo")
+	if err != nil {
+		t.Fatalf("Failed to get loopback interface: %v", err)
+	}
+	if err := nhNs.LinkSetUp(loLink); err != nil {
+		t.Fatalf("Failed to set up loopback interface: %v", err)
+	}
+
+	// Phase 2: Create the host parent interface.
+	// Define a parent dummy host interface with a custom MAC and MTU.
+	// We use custom attributes to ensure the child IPVlan subinterface correctly inherits them.
+	ifaceName := "testdummy-0"
+	la := netlink.NewLinkAttrs()
+	la.Name = ifaceName
+	la.HardwareAddr = net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	la.MTU = 1400
+
+	link := &netlink.Dummy{
+		LinkAttrs: la,
+	}
+	if err := netlink.LinkAdd(link); err != nil {
+		t.Fatalf("Failed to add dummy link %s in ns %s: %v", ifaceName, nsName, err)
+	}
+
+	// Ensure the parent link is cleaned up at teardown.
+	t.Cleanup(func() {
+		link, err := nlwrap.LinkByName(ifaceName)
+		if err == nil {
+			_ = netlink.LinkDel(link)
+		}
+	})
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("Failed to set up dummy link %s on host: %v", ifaceName, err)
+	}
+
+	// Phase 3: Call nsCreateSubinterface.
+	// Create the IPVlan subinterface in the target container
+	// namespace and assert driver-reported device data.
+	config := &apis.SubInterfaceConfig{
+		Name:      "dranet0",
+		Addresses: []string{"2001:db8::3/128"},
+		Type:      "ipvlan",
+	}
+
+	deviceData, err := nsCreateSubinterface(ifaceName, path.Join("/run/netns", nsName), config)
+	if err != nil {
+		t.Fatalf("fail to create subinterface: %v", err)
+	}
+
+	if deviceData.InterfaceName != config.Name {
+		t.Errorf("Expected reported InterfaceName %q, got %q", config.Name, deviceData.InterfaceName)
+	}
+	if deviceData.HardwareAddress != "00:11:22:33:44:55" {
+		t.Errorf("Expected reported HardwareAddress %q, got %q", "00:11:22:33:44:55", deviceData.HardwareAddress)
+	}
+	if len(deviceData.IPs) != 1 || deviceData.IPs[0] != config.Addresses[0] {
+		t.Errorf("Expected reported IPs %v, got %v", config.Addresses, deviceData.IPs)
+	}
+
+	// Verify that the parent interface still exists in the host namespace (was not moved).
+	_, err = nlwrap.LinkByName(ifaceName)
+	if err != nil {
+		t.Errorf("expected parent interface %s to still exist in the host namespace: %v", ifaceName, err)
+	}
+
+	// Phase 4: Inspect the state of the interface in the container namespace.
+	// Switch thread into the container namespace to query the interface directly.
+	func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		err := netns.Set(testNS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer netns.Set(origns)
+
+		cmd := exec.Command("ip", "-d", "link", "show", config.Name)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed to show link properties: %v", err)
+		}
+		outputStr := string(output)
+
+		// Assert that the created subinterface is indeed of type ipvlan with mode l2 and flag bridge.
+		if !strings.Contains(outputStr, "ipvlan") {
+			t.Errorf("expected link type to be 'ipvlan', link status output:\n%s", outputStr)
+		}
+		if !strings.Contains(outputStr, "mode l2") {
+			t.Errorf("expected ipvlan mode to be 'l2', link status output:\n%s", outputStr)
+		}
+		if !strings.Contains(outputStr, "bridge") {
+			t.Errorf("expected ipvlan flag to be 'bridge', link status output:\n%s", outputStr)
+		}
+
+		// Assert that the child subinterface inherited the parent's MTU configuration (1400).
+		if !strings.Contains(outputStr, "mtu 1400") {
+			t.Errorf("expected MTU 1400 to be inherited, link status output:\n%s", outputStr)
+		}
+
+		// Assert that the child subinterface inherited the parent's MAC configuration.
+		if !strings.Contains(outputStr, "link/ether 00:11:22:33:44:55") {
+			t.Errorf("expected Hardware MAC 00:11:22:33:44:55 to be inherited, link status output:\n%s", outputStr)
+		}
+
+		// Assert that the assigned IP address is correctly configured.
+		cmd = exec.Command("ip", "addr", "show", config.Name)
+		output, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed to show interface addresses: %v", err)
+		}
+		outputStr = string(output)
+
+		for _, addr := range config.Addresses {
+			if !strings.Contains(outputStr, addr) {
+				t.Errorf("expected address %s not found in ip addr show:\n%s", addr, outputStr)
+			}
+		}
+	}()
+
+	// Phase 5: Call nsDeleteSubinterface for teardown.
+	// Verify that the subinterface is successfully deleted inside the test namespace.
+	err = nsDeleteSubinterface(path.Join("/run/netns", nsName), config.Name)
+	if err != nil {
+		t.Fatalf("fail to delete subinterface: %v", err)
+	}
+
+	func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		err := netns.Set(testNS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer netns.Set(origns)
+
+		cmd := exec.Command("ip", "link", "show", config.Name)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Errorf("expected subinterface %s to be deleted, but it still exists: %s", config.Name, string(output))
+		}
+	}()
+}

--- a/pkg/driver/subinterfaces_test.go
+++ b/pkg/driver/subinterfaces_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"sigs.k8s.io/dranet/internal/nlwrap"
+	"sigs.k8s.io/dranet/pkg/apis"
+)
+
+func TestSubinterface_IPVlan(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test requires root privileges.")
+	}
+
+	// Phase 1: Initialize the network namespaces.
+	// Save the host network namespace to restore it at the end of the test.
+	origns, err := netns.Get()
+	if err != nil {
+		t.Fatalf("unexpected error trying to get namespace: %v", err)
+	}
+	defer origns.Close()
+
+	// Create a dedicated target container network namespace.
+	rndString := make([]byte, 4)
+	_, err = rand.Read(rndString)
+	if err != nil {
+		t.Fatalf("fail to generate random name: %v", err)
+	}
+	nsName := fmt.Sprintf("ns%x", rndString)
+	testNS, err := netns.NewNamed(nsName)
+	if err != nil {
+		t.Fatalf("Failed to create network namespace: %v", err)
+	}
+	defer netns.DeleteNamed(nsName)
+	defer testNS.Close()
+
+	// Switch back to the original namespace.
+	netns.Set(origns)
+
+	// Open a netlink handle inside the container namespace to manage the loopback interface.
+	nhNs, err := nlwrap.NewHandleAt(testNS)
+	if err != nil {
+		t.Fatalf("fail to open netlink handle: %v", err)
+	}
+	defer nhNs.Close()
+
+	loLink, err := nhNs.LinkByName("lo")
+	if err != nil {
+		t.Fatalf("Failed to get loopback interface: %v", err)
+	}
+	if err := nhNs.LinkSetUp(loLink); err != nil {
+		t.Fatalf("Failed to set up loopback interface: %v", err)
+	}
+
+	// Phase 2: Create the host parent interface.
+	// Define a parent dummy host interface with a custom MAC and MTU.
+	// We use custom attributes to ensure the child IPVLAN subinterface correctly inherits them.
+	ifaceName := "testdummy-0"
+	la := netlink.NewLinkAttrs()
+	la.Name = ifaceName
+	la.HardwareAddr = net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	la.MTU = 1400
+
+	link := &netlink.Dummy{
+		LinkAttrs: la,
+	}
+	if err := netlink.LinkAdd(link); err != nil {
+		t.Fatalf("Failed to add dummy link %s in ns %s: %v", ifaceName, nsName, err)
+	}
+
+	// Ensure the parent link is cleaned up at teardown.
+	t.Cleanup(func() {
+		link, err := nlwrap.LinkByName(ifaceName)
+		if err == nil {
+			_ = netlink.LinkDel(link)
+		}
+	})
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("Failed to set up dummy link %s on host: %v", ifaceName, err)
+	}
+
+	// Phase 3: Call nsCreateSubinterface.
+	// Create the IPVLAN subinterface in the target container
+	// namespace and assert driver-reported device data.
+	config := apis.InterfaceConfig{
+		Name:      "dranet0",
+		Type:      apis.InterfaceTypeIPVLAN,
+		Addresses: []string{"2001:db8::3/128"},
+	}
+
+	deviceData, err := nsCreateSubinterface(ifaceName, path.Join("/run/netns", nsName), config)
+	if err != nil {
+		t.Fatalf("fail to create subinterface: %v", err)
+	}
+
+	if deviceData.InterfaceName != config.Name {
+		t.Errorf("Expected reported InterfaceName %q, got %q", config.Name, deviceData.InterfaceName)
+	}
+	if deviceData.HardwareAddress != "00:11:22:33:44:55" {
+		t.Errorf("Expected reported HardwareAddress %q, got %q", "00:11:22:33:44:55", deviceData.HardwareAddress)
+	}
+	if len(deviceData.IPs) != 1 || deviceData.IPs[0] != config.Addresses[0] {
+		t.Errorf("Expected reported IPs %v, got %v", config.Addresses, deviceData.IPs)
+	}
+
+	// Verify that the parent interface still exists in the host namespace (was not moved).
+	_, err = nlwrap.LinkByName(ifaceName)
+	if err != nil {
+		t.Errorf("expected parent interface %s to still exist in the host namespace: %v", ifaceName, err)
+	}
+
+	// Phase 4: Inspect the state of the interface in the container namespace.
+	// Switch thread into the container namespace to query the interface directly.
+	func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		err := netns.Set(testNS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer netns.Set(origns)
+
+		cmd := exec.Command("ip", "-d", "link", "show", config.Name)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed to show link properties: %v", err)
+		}
+		outputStr := string(output)
+
+		// Assert that the created subinterface is indeed of type ipvlan with mode l2 and flag bridge.
+		if !strings.Contains(outputStr, "ipvlan") {
+			t.Errorf("expected link type to be 'ipvlan', link status output:\n%s", outputStr)
+		}
+		if !strings.Contains(outputStr, "mode l2") {
+			t.Errorf("expected ipvlan mode to be 'l2', link status output:\n%s", outputStr)
+		}
+		if !strings.Contains(outputStr, "bridge") {
+			t.Errorf("expected ipvlan flag to be 'bridge', link status output:\n%s", outputStr)
+		}
+
+		// Assert that the child subinterface inherited the parent's MTU configuration (1400).
+		if !strings.Contains(outputStr, "mtu 1400") {
+			t.Errorf("expected MTU 1400 to be inherited, link status output:\n%s", outputStr)
+		}
+
+		// Assert that the child subinterface inherited the parent's MAC configuration.
+		if !strings.Contains(outputStr, "link/ether 00:11:22:33:44:55") {
+			t.Errorf("expected Hardware MAC 00:11:22:33:44:55 to be inherited, link status output:\n%s", outputStr)
+		}
+
+		// Assert that the assigned IP address is correctly configured.
+		cmd = exec.Command("ip", "addr", "show", config.Name)
+		output, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed to show interface addresses: %v", err)
+		}
+		outputStr = string(output)
+
+		for _, addr := range config.Addresses {
+			if !strings.Contains(outputStr, addr) {
+				t.Errorf("expected address %s not found in ip addr show:\n%s", addr, outputStr)
+			}
+		}
+	}()
+
+	// Phase 5: Call nsDeleteSubinterface for teardown.
+	// Verify that the subinterface is successfully deleted inside the test namespace.
+	err = nsDeleteSubinterface(path.Join("/run/netns", nsName), config.Name)
+	if err != nil {
+		t.Fatalf("fail to delete subinterface: %v", err)
+	}
+
+	func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		err := netns.Set(testNS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer netns.Set(origns)
+
+		cmd := exec.Command("ip", "link", "show", config.Name)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Errorf("expected subinterface %s to be deleted, but it still exists: %s", config.Name, string(output))
+		}
+	}()
+}

--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -585,6 +585,15 @@ func (db *DB) updateDeviceStore(devices []resourceapi.Device) {
 			}
 
 			if conf := db.instance.GetDeviceConfig(id); conf != nil {
+				// A provider-advertised profile is only honored when a profile
+				// provider is wired (e.g. --profile-provider=cloud); drop it
+				// otherwise so claims don't fail resolving it. A user-specified
+				// profile is still a hard requirement.
+				if conf.Profile != "" && db.getProfileProvider() == nil {
+					confCopy := *conf
+					confCopy.Profile = ""
+					conf = &confCopy
+				}
 				deviceConfigStore[device.Name] = conf
 			}
 		}

--- a/pkg/ipam/local_ipam.go
+++ b/pkg/ipam/local_ipam.go
@@ -1,0 +1,312 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"net/netip"
+	"sync"
+
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/dranet/pkg/apis"
+)
+
+// based on existing Kindnet IP allocator:
+// https://github.com/kubernetes-sigs/kindnet/blob/main/cmd/cni-kindnet/netconf.go
+
+// LocalIPAM is a node-local IP allocator. It hands out addresses from
+// caller-provided ranges while avoiding collisions with addresses already in use
+// on the node.
+type LocalIPAM struct {
+	mu sync.Mutex
+	// allocatedIPs is the set of addresses currently in use on the node.
+	allocatedIPs map[netip.Addr]struct{}
+}
+
+func NewLocalIPAM(initialIPs []string) *LocalIPAM {
+	ips := make(map[netip.Addr]struct{})
+	for _, ipStr := range initialIPs {
+		if prefix, err := netip.ParsePrefix(ipStr); err == nil {
+			ips[prefix.Addr()] = struct{}{}
+		} else {
+			klog.Warningf("Failed to parse IP to initialize %q: %v", ipStr, err)
+		}
+	}
+	return &LocalIPAM{
+		allocatedIPs: ips,
+	}
+}
+
+// Allocate allocates at most one IP address per IP family from the given
+// ranges. Ranges are considered in order: the first range that yields an address
+// for a family wins, and subsequent ranges of that same family are skipped. If a
+// range is valid but exhausted, the next range of the same family is tried.
+//
+// It returns the allocated addresses formatted as host CIDRs. If a family has at
+// least one range but no address could be allocated for it, an error is returned.
+func (ipam *LocalIPAM) Allocate(ranges []apis.IPRangeConfig) ([]string, error) {
+	// family key: true for IPv6, false for IPv4.
+	allocated := make(map[bool]string)
+	seen := make(map[bool]bool)
+	lastErr := make(map[bool]error)
+
+	// assigned holds the addresses generated so far by this Allocate invocation
+	var assigned []string
+	// releaseAll frees the addresses this Allocate invocation already generated,
+	// so a mid-way failure leaves no partially-allocated state in the IPAM.
+	releaseAll := func() {
+		for _, ip := range assigned {
+			ipam.Release(ip)
+		}
+	}
+
+	for _, r := range ranges {
+		start, end, err := resolveRange(r)
+		if err != nil {
+			releaseAll()
+			return nil, err
+		}
+		family := start.Is6()
+		seen[family] = true
+		if _, done := allocated[family]; done {
+			continue
+		}
+		ip, err := ipam.allocateForRange(start, end)
+		if err != nil {
+			// Range is valid but exhausted.
+			lastErr[family] = err
+			continue
+		}
+		allocated[family] = ip
+		assigned = append(assigned, ip)
+	}
+
+	// Every family that had at least one range must have produced an address.
+	for family := range seen {
+		if _, done := allocated[family]; !done {
+			releaseAll()
+			return nil, fmt.Errorf("no available IP address for %s in the configured ranges: %w", familyName(family), lastErr[family])
+		}
+	}
+
+	return assigned, nil
+}
+
+// Release removes the specified IP address allocation from the IPAM state.
+// ipStr must be in CIDR prefix form (e.g. "192.168.1.100/32").
+func (ipam *LocalIPAM) Release(ipStr string) {
+	ipam.mu.Lock()
+	defer ipam.mu.Unlock()
+
+	var ip netip.Addr
+	if prefix, err := netip.ParsePrefix(ipStr); err == nil {
+		ip = prefix.Addr()
+	} else {
+		klog.Warningf("Failed to parse IP to release %q: %v", ipStr, err)
+		return
+	}
+
+	delete(ipam.allocatedIPs, ip)
+}
+
+// resolveRange converts an IPRangeConfig into the concrete inclusive [start, end]
+// boundaries used for allocation.
+//
+// When both StartIP and EndIP are set, they are validated and used directly.
+// Otherwise the boundaries are derived from CIDR, spanning every address
+// except the network address and the broadcast address.
+func resolveRange(cfg apis.IPRangeConfig) (start netip.Addr, end netip.Addr, err error) {
+	if err := cfg.Validate(); err != nil {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("ipRange: %w", err)
+	}
+
+	// Mode 1: explicit start/end boundaries take priority.
+	if cfg.StartIP != "" {
+		return netip.MustParseAddr(cfg.StartIP), netip.MustParseAddr(cfg.EndIP), nil
+	}
+
+	// Mode 2: derive boundaries from CIDR.
+	cidr := netip.MustParsePrefix(cfg.CIDR).Masked()
+	broadcast, err := broadcastAddress(cidr)
+	if err != nil {
+		return netip.Addr{}, netip.Addr{}, err
+	}
+	start, end = cidr.Addr().Next(), broadcast.Prev()
+	if start.Compare(end) > 0 {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("ipRange: cidr %q has no allocatable addresses", cfg.CIDR)
+	}
+	return start, end, nil
+}
+
+// allocateForRange finds and returns a free IP address within the inclusive [start, end]
+// range, avoiding conflicts with currently allocated IPs on the node.
+func (ipam *LocalIPAM) allocateForRange(start, end netip.Addr) (string, error) {
+	ipam.mu.Lock()
+	defer ipam.mu.Unlock()
+
+	b, err := randomizedBounds(start, end)
+	if err != nil {
+		return "", err
+	}
+
+	iterator := ipIterator(b)
+	for {
+		ip := iterator()
+		if !ip.IsValid() {
+			break
+		}
+		// Check if IP is already allocated
+		if _, exists := ipam.allocatedIPs[ip]; exists {
+			continue
+		}
+		ipam.allocatedIPs[ip] = struct{}{}
+		prefix := netip.PrefixFrom(ip, ip.BitLen())
+		klog.V(2).Infof("Successfully allocated IP %s from range [%s, %s]", prefix.String(), start, end)
+		return prefix.String(), nil
+	}
+	return "", fmt.Errorf("no more free IP addresses in range [%s, %s]", start, end)
+}
+
+// familyName returns a human-readable name for an IP family.
+func familyName(isV6 bool) string {
+	if isV6 {
+		return "IPv6"
+	}
+	return "IPv4"
+}
+
+// bounds defines the inclusive [ipFirst, ipLast] allocation range together with
+// a random starting offset within it.
+type bounds struct {
+	ipFirst netip.Addr
+	ipLast  netip.Addr
+	offset  uint64
+}
+
+// randomizedBounds builds allocation bounds over the inclusive [first, last] range
+// with a random starting offset to spread allocations across the range.
+func randomizedBounds(first, last netip.Addr) (bounds, error) {
+	rangeSize, err := addressRangeSize(first, last)
+	if err != nil {
+		return bounds{}, err
+	}
+
+	var offset uint64
+	if rangeSize >= math.MaxInt64 {
+		offset = rand.Uint64()
+	} else {
+		offset = uint64(rand.Int63n(int64(rangeSize)))
+	}
+
+	return bounds{
+		ipFirst: first,
+		ipLast:  last,
+		offset:  offset,
+	}, nil
+}
+
+// addressRangeSize returns the number of addresses in the inclusive [first, last]
+// range, capped at math.MaxInt64 to avoid overflow for large IPv6 ranges.
+func addressRangeSize(first, last netip.Addr) (uint64, error) {
+	firstBig := big.NewInt(0).SetBytes(first.AsSlice())
+	lastBig := big.NewInt(0).SetBytes(last.AsSlice())
+	diff := big.NewInt(0).Sub(lastBig, firstBig)
+	diff.Add(diff, big.NewInt(1)) // inclusive count
+	if diff.Sign() <= 0 {
+		return 0, fmt.Errorf("no available addresses in range [%s, %s]", first, last)
+	}
+	if diff.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+		return math.MaxInt64, nil
+	}
+	return diff.Uint64(), nil
+}
+
+// ipIterator allows to iterate over all the IP addresses
+// in a range defined by the start and last address in bounds.
+func ipIterator(b bounds) func() netip.Addr {
+	modulo := func(addr netip.Addr) netip.Addr {
+		if addr.Compare(b.ipLast) == 1 {
+			return b.ipFirst
+		}
+		return addr
+	}
+	next := func(addr netip.Addr) netip.Addr {
+		return modulo(addr.Next())
+	}
+	start, err := addOffsetAddress(b.ipFirst, b.offset)
+	if err != nil {
+		return func() netip.Addr { return netip.Addr{} }
+	}
+	start = modulo(start)
+	ip := start
+	seen := false
+	return func() netip.Addr {
+		value := ip
+		if value == start {
+			if seen {
+				return netip.Addr{}
+			}
+			seen = true
+		}
+		ip = next(ip)
+		return value
+	}
+}
+
+// broadcastAddress returns the broadcast address (last address) of the given CIDR subnet.
+func broadcastAddress(subnet netip.Prefix) (netip.Addr, error) {
+	base := subnet.Masked().Addr()
+	bytes := base.AsSlice()
+	n := 8*len(bytes) - subnet.Bits()
+	for i := len(bytes) - 1; i >= 0 && n > 0; i-- {
+		if n >= 8 {
+			bytes[i] = 0xff
+			n -= 8
+		} else {
+			mask := ^uint8(0) >> (8 - n)
+			bytes[i] |= mask
+			break
+		}
+	}
+	addr, ok := netip.AddrFromSlice(bytes)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", bytes)
+	}
+	return addr, nil
+}
+
+// addOffsetAddress returns the IP address obtained by adding a numeric offset to the given address.
+func addOffsetAddress(address netip.Addr, offset uint64) (netip.Addr, error) {
+	addressBytes := address.AsSlice()
+	addressBig := big.NewInt(0).SetBytes(addressBytes)
+	r := big.NewInt(0).Add(addressBig, new(big.Int).SetUint64(offset)).Bytes()
+	lenDiff := len(addressBytes) - len(r)
+	if lenDiff > 0 {
+		r = append(make([]byte, lenDiff), r...)
+	} else if lenDiff < 0 {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", r)
+	}
+	addr, ok := netip.AddrFromSlice(r)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", r)
+	}
+	return addr, nil
+}

--- a/pkg/ipam/local_ipam.go
+++ b/pkg/ipam/local_ipam.go
@@ -1,0 +1,283 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"net/netip"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+// based on existing Kindnet IP allocator:
+// https://github.com/kubernetes-sigs/kindnet/blob/main/cmd/cni-kindnet/netconf.go
+
+// LocalIPAM is a node-local IP allocator. It hands out addresses from
+// caller-provided ranges while avoiding collisions with addresses already in use
+// on the node.
+type LocalIPAM struct {
+	mu sync.Mutex
+	// allocatedIPs is the set of addresses currently in use on the node.
+	allocatedIPs map[netip.Addr]struct{}
+}
+
+func NewLocalIPAM(initialIPs []string) *LocalIPAM {
+	ips := make(map[netip.Addr]struct{})
+	for _, ipStr := range initialIPs {
+		if prefix, err := netip.ParsePrefix(ipStr); err == nil {
+			ips[prefix.Addr()] = struct{}{}
+		} else {
+			klog.Warningf("Failed to parse IP to initialize %q: %v", ipStr, err)
+		}
+	}
+	return &LocalIPAM{
+		allocatedIPs: ips,
+	}
+}
+
+// IPRange is an inclusive [Start, End] IP allocation range supplied by a caller
+// (typically a cloud provider). Both bounds must be valid addresses of the same
+// IP family with Start <= End.
+type IPRange struct {
+	Start netip.Addr
+	End   netip.Addr
+}
+
+// Allocate allocates one IP address for each range provided. It returns the
+// allocated addresses formatted as host CIDRs (IPv4 first).
+// At most one range per IP family may be supplied. If any range is invalid or
+// cannot yield a free address, every address already allocated by this call is
+// released and an error is returned.
+func (ipam *LocalIPAM) Allocate(ranges []IPRange) ([]string, error) {
+	var allocatedV4, allocatedV6 string
+	releaseAll := func() {
+		for _, ip := range []string{allocatedV4, allocatedV6} {
+			if ip != "" {
+				ipam.Release(ip)
+			}
+		}
+	}
+
+	for _, r := range ranges {
+		start, end := r.Start, r.End
+		if !start.IsValid() || !end.IsValid() || start.Is6() != end.Is6() || start.Compare(end) > 0 {
+			releaseAll()
+			return nil, fmt.Errorf("invalid ip range [%s, %s]", start, end)
+		}
+
+		familyName := "ipv4"
+		if start.Is6() {
+			familyName = "ipv6"
+		}
+		if (start.Is6() && allocatedV6 != "") || (start.Is4() && allocatedV4 != "") {
+			releaseAll()
+			return nil, fmt.Errorf("more than one %s range provided; at most one range per IP family is allowed", familyName)
+		}
+
+		ip, err := ipam.allocateForRange(start, end)
+		if err != nil {
+			releaseAll()
+			return nil, fmt.Errorf("no available IP address for %s in range [%s, %s]: %w", familyName, start, end, err)
+		}
+		if start.Is6() {
+			allocatedV6 = ip
+		} else {
+			allocatedV4 = ip
+		}
+	}
+
+	var assigned []string
+	if allocatedV4 != "" {
+		assigned = append(assigned, allocatedV4)
+	}
+	if allocatedV6 != "" {
+		assigned = append(assigned, allocatedV6)
+	}
+	return assigned, nil
+}
+
+// Release removes the specified IP address allocation from the IPAM state.
+// ipStr must be in CIDR prefix form (e.g. "192.168.1.100/32").
+func (ipam *LocalIPAM) Release(ipStr string) {
+	ipam.mu.Lock()
+	defer ipam.mu.Unlock()
+
+	var ip netip.Addr
+	if prefix, err := netip.ParsePrefix(ipStr); err == nil {
+		ip = prefix.Addr()
+	} else {
+		klog.Warningf("Failed to parse IP to release %q: %v", ipStr, err)
+		return
+	}
+
+	delete(ipam.allocatedIPs, ip)
+}
+
+// Reserve records the given addresses as in-use to avoid allocation conflict.
+// Reserve is atomic: if any address is invalid or already in use, nothing is
+// recorded and an error is returned.
+func (ipam *LocalIPAM) Reserve(addrs []string) error {
+	ipam.mu.Lock()
+	defer ipam.mu.Unlock()
+
+	parsed := make([]netip.Addr, 0, len(addrs))
+	for _, addrStr := range addrs {
+		prefix, err := netip.ParsePrefix(addrStr)
+		if err != nil {
+			return fmt.Errorf("failed to parse address %q: %w", addrStr, err)
+		}
+		ip := prefix.Addr()
+		if _, exists := ipam.allocatedIPs[ip]; exists {
+			return fmt.Errorf("address %q is already in use", addrStr)
+		}
+		parsed = append(parsed, ip)
+	}
+	for _, ip := range parsed {
+		ipam.allocatedIPs[ip] = struct{}{}
+		klog.V(2).Infof("Successfully reserved in-use IP %s", ip)
+	}
+	return nil
+}
+
+// allocateForRange finds and returns a free IP address within the inclusive [start, end]
+// range, avoiding conflicts with currently allocated IPs on the node.
+func (ipam *LocalIPAM) allocateForRange(start, end netip.Addr) (string, error) {
+	ipam.mu.Lock()
+	defer ipam.mu.Unlock()
+
+	b, err := randomizedBounds(start, end)
+	if err != nil {
+		return "", err
+	}
+
+	iterator := ipIterator(b)
+	for {
+		ip := iterator()
+		if !ip.IsValid() {
+			break
+		}
+		// Check if IP is already allocated
+		if _, exists := ipam.allocatedIPs[ip]; exists {
+			continue
+		}
+		ipam.allocatedIPs[ip] = struct{}{}
+		prefix := netip.PrefixFrom(ip, ip.BitLen())
+		klog.V(2).Infof("Successfully allocated IP %s from range [%s, %s]", prefix.String(), start, end)
+		return prefix.String(), nil
+	}
+	return "", fmt.Errorf("no more free IP addresses in range [%s, %s]", start, end)
+}
+
+// bounds defines the inclusive [ipFirst, ipLast] allocation range together with
+// a random starting offset within it.
+type bounds struct {
+	ipFirst netip.Addr
+	ipLast  netip.Addr
+	offset  uint64
+}
+
+// randomizedBounds builds allocation bounds over the inclusive [first, last] range
+// with a random starting offset to spread allocations across the range.
+func randomizedBounds(first, last netip.Addr) (bounds, error) {
+	rangeSize, err := addressRangeSize(first, last)
+	if err != nil {
+		return bounds{}, err
+	}
+
+	var offset uint64
+	if rangeSize >= math.MaxInt64 {
+		offset = rand.Uint64()
+	} else {
+		offset = uint64(rand.Int63n(int64(rangeSize)))
+	}
+
+	return bounds{
+		ipFirst: first,
+		ipLast:  last,
+		offset:  offset,
+	}, nil
+}
+
+// addressRangeSize returns the number of addresses in the inclusive [first, last]
+// range, capped at math.MaxInt64 to avoid overflow for large IPv6 ranges.
+func addressRangeSize(first, last netip.Addr) (uint64, error) {
+	firstBig := big.NewInt(0).SetBytes(first.AsSlice())
+	lastBig := big.NewInt(0).SetBytes(last.AsSlice())
+	diff := big.NewInt(0).Sub(lastBig, firstBig)
+	diff.Add(diff, big.NewInt(1)) // inclusive count
+	if diff.Sign() <= 0 {
+		return 0, fmt.Errorf("no available addresses in range [%s, %s]", first, last)
+	}
+	if diff.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+		return math.MaxInt64, nil
+	}
+	return diff.Uint64(), nil
+}
+
+// ipIterator allows to iterate over all the IP addresses
+// in a range defined by the start and last address in bounds.
+func ipIterator(b bounds) func() netip.Addr {
+	modulo := func(addr netip.Addr) netip.Addr {
+		if addr.Compare(b.ipLast) == 1 {
+			return b.ipFirst
+		}
+		return addr
+	}
+	next := func(addr netip.Addr) netip.Addr {
+		return modulo(addr.Next())
+	}
+	start, err := addOffsetAddress(b.ipFirst, b.offset)
+	if err != nil {
+		return func() netip.Addr { return netip.Addr{} }
+	}
+	start = modulo(start)
+	ip := start
+	seen := false
+	return func() netip.Addr {
+		value := ip
+		if value == start {
+			if seen {
+				return netip.Addr{}
+			}
+			seen = true
+		}
+		ip = next(ip)
+		return value
+	}
+}
+
+// addOffsetAddress returns the IP address obtained by adding a numeric offset to the given address.
+func addOffsetAddress(address netip.Addr, offset uint64) (netip.Addr, error) {
+	addressBytes := address.AsSlice()
+	addressBig := big.NewInt(0).SetBytes(addressBytes)
+	r := big.NewInt(0).Add(addressBig, new(big.Int).SetUint64(offset)).Bytes()
+	lenDiff := len(addressBytes) - len(r)
+	if lenDiff > 0 {
+		r = append(make([]byte, lenDiff), r...)
+	} else if lenDiff < 0 {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", r)
+	}
+	addr, ok := netip.AddrFromSlice(r)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", r)
+	}
+	return addr, nil
+}

--- a/pkg/ipam/local_ipam_test.go
+++ b/pkg/ipam/local_ipam_test.go
@@ -1,0 +1,499 @@
+package ipam
+
+import (
+	"net/netip"
+	"sync"
+	"testing"
+
+	"sigs.k8s.io/dranet/pkg/apis"
+)
+
+func TestAllocateForRange(t *testing.T) {
+	t.Run("IPv6 range returns a /128 host address", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		start := netip.MustParseAddr("2001:db8::1")
+		end := netip.MustParseAddr("2001:db8::5")
+
+		ip, err := ipam.allocateForRange(start, end)
+		if err != nil {
+			t.Fatalf("allocateForRange() unexpected error = %v", err)
+		}
+		parsedIP, err := netip.ParsePrefix(ip)
+		if err != nil {
+			t.Fatalf("failed to parse returned IP %q: %v", ip, err)
+		}
+		if parsedIP.Bits() != 128 {
+			t.Errorf("allocateForRange() returned IP %s, want a /128 host address", ip)
+		}
+		if parsedIP.Addr().Compare(start) < 0 || parsedIP.Addr().Compare(end) > 0 {
+			t.Errorf("allocateForRange() returned IP %s outside range [%s, %s]", ip, start, end)
+		}
+	})
+
+	t.Run("IPv4 range returns a /32 host address", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		start := netip.MustParseAddr("10.0.0.5")
+		end := netip.MustParseAddr("10.0.0.10")
+
+		ip, err := ipam.allocateForRange(start, end)
+		if err != nil {
+			t.Fatalf("allocateForRange() unexpected error = %v", err)
+		}
+		parsedIP, err := netip.ParsePrefix(ip)
+		if err != nil {
+			t.Fatalf("failed to parse returned IP %q: %v", ip, err)
+		}
+		if parsedIP.Bits() != 32 {
+			t.Errorf("allocateForRange() returned IP %s, want a /32 host address", ip)
+		}
+		if parsedIP.Addr().Compare(start) < 0 || parsedIP.Addr().Compare(end) > 0 {
+			t.Errorf("allocateForRange() returned IP %s outside range [%s, %s]", ip, start, end)
+		}
+	})
+
+	t.Run("collision avoidance - skips occupied IP", func(t *testing.T) {
+		// Usable range 2001:db8::1 - 2001:db8::2; occupy ::1 so ::2 is the only free IP.
+		ipam := NewLocalIPAM([]string{"2001:db8::1/128"})
+		ip, err := ipam.allocateForRange(netip.MustParseAddr("2001:db8::1"), netip.MustParseAddr("2001:db8::2"))
+		if err != nil {
+			t.Fatalf("allocateForRange() unexpected error = %v", err)
+		}
+		if ip != "2001:db8::2/128" {
+			t.Errorf("allocateForRange() = %s, want 2001:db8::2/128 (the only free usable IP)", ip)
+		}
+	})
+
+	t.Run("single-address range (start == end), then exhausted", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		addr := netip.MustParseAddr("10.0.0.5")
+
+		ip, err := ipam.allocateForRange(addr, addr)
+		if err != nil {
+			t.Fatalf("allocateForRange() unexpected error = %v", err)
+		}
+		if ip != "10.0.0.5/32" {
+			t.Errorf("allocateForRange() = %s, want 10.0.0.5/32", ip)
+		}
+		// The single address is now taken; a second allocation must fail.
+		if _, err := ipam.allocateForRange(addr, addr); err == nil {
+			t.Fatal("second allocateForRange() expected error, but got nil")
+		}
+	})
+
+	t.Run("invalid range: start after end", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		_, err := ipam.allocateForRange(netip.MustParseAddr("10.0.0.10"), netip.MustParseAddr("10.0.0.5"))
+		if err == nil {
+			t.Fatal("allocateForRange() expected error for start > end, got nil")
+		}
+	})
+}
+
+func TestResolveRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       apis.IPRangeConfig
+		wantErr   bool
+		wantStart string
+		wantEnd   string
+	}{
+		{
+			name:      "CIDR only (IPv4 /24)",
+			cfg:       apis.IPRangeConfig{CIDR: "192.168.1.0/24"},
+			wantStart: "192.168.1.1",
+			wantEnd:   "192.168.1.254",
+		},
+		{
+			name:      "CIDR only (IPv6 /64)",
+			cfg:       apis.IPRangeConfig{CIDR: "2001:db8::/64"},
+			wantStart: "2001:db8::1",
+			wantEnd:   "2001:db8::ffff:ffff:ffff:fffe",
+		},
+		{
+			name:      "explicit start/end only",
+			cfg:       apis.IPRangeConfig{StartIP: "10.0.0.5", EndIP: "10.0.0.10"},
+			wantStart: "10.0.0.5",
+			wantEnd:   "10.0.0.10",
+		},
+		{
+			name:      "all three: start/end take priority and are within CIDR",
+			cfg:       apis.IPRangeConfig{CIDR: "10.0.0.0/24", StartIP: "10.0.0.5", EndIP: "10.0.0.10"},
+			wantStart: "10.0.0.5",
+			wantEnd:   "10.0.0.10",
+		},
+		{
+			name:    "CIDR too small to have allocatable addresses (/31)",
+			cfg:     apis.IPRangeConfig{CIDR: "192.168.1.0/31"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, err := resolveRange(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveRange() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if start.String() != tt.wantStart {
+				t.Errorf("resolveRange() start = %s, want %s", start, tt.wantStart)
+			}
+			if end.String() != tt.wantEnd {
+				t.Errorf("resolveRange() end = %s, want %s", end, tt.wantEnd)
+			}
+		})
+	}
+}
+
+func TestAllocate(t *testing.T) {
+	t.Run("single family: one IP even with multiple ranges", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		ranges := []apis.IPRangeConfig{
+			{CIDR: "10.0.0.0/29"},
+			{CIDR: "10.0.1.0/29"},
+		}
+		ips, err := ipam.Allocate(ranges)
+		if err != nil {
+			t.Fatalf("Allocate() unexpected error = %v", err)
+		}
+		if len(ips) != 1 {
+			t.Fatalf("Allocate() returned %d addresses, want 1: %v", len(ips), ips)
+		}
+		// The address must come from the first range; the second is skipped.
+		first := netip.MustParsePrefix("10.0.0.0/29")
+		got := netip.MustParsePrefix(ips[0])
+		if got.Bits() != 32 || !first.Contains(got.Addr()) {
+			t.Errorf("Allocate() = %v, want a /32 within 10.0.0.0/29", ips)
+		}
+	})
+
+	t.Run("dual stack: one IP per family", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		ranges := []apis.IPRangeConfig{
+			{CIDR: "10.0.0.0/29"},
+			{CIDR: "2001:db8::/120"},
+		}
+		ips, err := ipam.Allocate(ranges)
+		if err != nil {
+			t.Fatalf("Allocate() unexpected error = %v", err)
+		}
+		if len(ips) != 2 {
+			t.Fatalf("Allocate() returned %d addresses, want 2: %v", len(ips), ips)
+		}
+		var haveV4, haveV6 bool
+		for _, ip := range ips {
+			p := netip.MustParsePrefix(ip)
+			if p.Addr().Is6() {
+				haveV6 = true
+			} else {
+				haveV4 = true
+			}
+		}
+		if !haveV4 || !haveV6 {
+			t.Errorf("Allocate() = %v, want one IPv4 and one IPv6 address", ips)
+		}
+	})
+
+	t.Run("fallback to next range of same family when exhausted", func(t *testing.T) {
+		ipam := NewLocalIPAM([]string{"10.0.0.5/32"}) // occupy the only address of rangeA
+		ranges := []apis.IPRangeConfig{
+			{StartIP: "10.0.0.5", EndIP: "10.0.0.5"},
+			{StartIP: "10.0.0.6", EndIP: "10.0.0.6"},
+		}
+		ips, err := ipam.Allocate(ranges)
+		if err != nil {
+			t.Fatalf("Allocate() unexpected error = %v", err)
+		}
+		if len(ips) != 1 || ips[0] != "10.0.0.6/32" {
+			t.Errorf("Allocate() = %v, want [10.0.0.6/32]", ips)
+		}
+	})
+
+	t.Run("error when all ranges of a family are exhausted", func(t *testing.T) {
+		ipam := NewLocalIPAM([]string{"10.0.0.5/32"})
+		ranges := []apis.IPRangeConfig{
+			{StartIP: "10.0.0.5", EndIP: "10.0.0.5"},
+			{StartIP: "10.0.0.5", EndIP: "10.0.0.5"},
+		}
+		if _, err := ipam.Allocate(ranges); err == nil {
+			t.Fatal("Allocate() expected error for exhausted family, got nil")
+		}
+	})
+
+	t.Run("no leak: addresses released when a later range fails", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		ranges := []apis.IPRangeConfig{
+			{StartIP: "10.0.0.5", EndIP: "10.0.0.5"}, // succeeds first
+			{CIDR: "not-a-cidr"},                     // then hard error
+		}
+		if _, err := ipam.Allocate(ranges); err == nil {
+			t.Fatal("Allocate() expected error, got nil")
+		}
+		// The previously allocated 10.0.0.5 must have been released, so a fresh
+		// allocation of the same address now succeeds.
+		ips, err := ipam.Allocate([]apis.IPRangeConfig{{StartIP: "10.0.0.5", EndIP: "10.0.0.5"}})
+		if err != nil {
+			t.Fatalf("Allocate() after cleanup unexpected error = %v", err)
+		}
+		if len(ips) != 1 || ips[0] != "10.0.0.5/32" {
+			t.Errorf("Allocate() = %v, want [10.0.0.5/32] (proving prior alloc was released)", ips)
+		}
+	})
+}
+
+// TestAllocateConcurrent is a stress test for the concurrency-safety of Allocate.
+// The allocator's whole purpose is to never hand the same address to two callers,
+// so these tests exercise that under simultaneous access. Run with -race to also
+// catch data races on the shared state.
+func TestAllocateConcurrent(t *testing.T) {
+	t.Run("two pods contending for the same address: one succeeds, the other fails", func(t *testing.T) {
+		// Seed every address in [10.0.0.1, 10.0.0.5] except 10.0.0.3, so both pods
+		// must converge on 10.0.0.3.
+		initial := []string{
+			"10.0.0.1/32", "10.0.0.2/32", "10.0.0.4/32", "10.0.0.5/32",
+		}
+		ipam := NewLocalIPAM(initial)
+		ranges := []apis.IPRangeConfig{{StartIP: "10.0.0.1", EndIP: "10.0.0.5"}}
+
+		var wg sync.WaitGroup
+		results := make([][]string, 2)
+		errs := make([]error, 2)
+
+		// Line both goroutines up on a barrier so they race to allocate together.
+		start := make(chan struct{})
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				results[i], errs[i] = ipam.Allocate(ranges)
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		// Exactly one pod gets 10.0.0.3; the other must fail because it was the only
+		// free address and it gets skipped once taken.
+		succeeded, failed := 0, 0
+		for i := 0; i < 2; i++ {
+			if errs[i] == nil {
+				succeeded++
+				if len(results[i]) != 1 || results[i][0] != "10.0.0.3/32" {
+					t.Errorf("pod %d: successful Allocate() = %v, want [10.0.0.3/32]", i, results[i])
+				}
+			} else {
+				failed++
+			}
+		}
+		if succeeded != 1 || failed != 1 {
+			t.Errorf("got %d successful and %d failed allocations, want exactly 1 each (double-allocation or a lost skip)", succeeded, failed)
+		}
+	})
+
+	t.Run("50 concurrent allocations on a 10-address range: only 10 succeeds, exhausting the range", func(t *testing.T) {
+		// A range with exactly 10 allocatable addresses ([.1, .10]).
+		ranges := []apis.IPRangeConfig{{StartIP: "10.0.0.1", EndIP: "10.0.0.10"}}
+		const capacity = 10
+		const workers = 50
+
+		ipam := NewLocalIPAM(nil)
+
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		counts := make(map[string]int) // allocated IP -> number of times handed out
+		successes := 0
+
+		start := make(chan struct{})
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				ips, err := ipam.Allocate(ranges)
+				if err != nil {
+					return // expected once the range is exhausted
+				}
+				mu.Lock()
+				defer mu.Unlock()
+				successes++
+				for _, ip := range ips {
+					counts[ip]++
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		if successes != capacity {
+			t.Errorf("got %d successful allocations, want %d", successes, capacity)
+		}
+		if len(counts) != capacity {
+			t.Errorf("got %d unique IPs, want %d", len(counts), capacity)
+		}
+		for ip, n := range counts {
+			if n != 1 {
+				t.Errorf("IP %q was handed out %d times, want exactly 1 (double-allocation under concurrency)", ip, n)
+			}
+		}
+	})
+}
+
+func TestBroadcastAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		subnet  netip.Prefix
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "IPv6 /64 CIDR",
+			subnet: netip.MustParsePrefix("2001:db8::/64"),
+			want:   "2001:db8::ffff:ffff:ffff:ffff",
+		},
+		{
+			name:   "IPv4 /22 CIDR",
+			subnet: netip.MustParsePrefix("192.168.0.0/22"),
+			want:   "192.168.3.255",
+		},
+		{
+			name:    "invalid zero prefix",
+			subnet:  netip.Prefix{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := broadcastAddress(tt.subnet)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("broadcastAddress() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Errorf("broadcastAddress() = %s, want %s", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestAddOffsetAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    netip.Addr
+		offset  uint64
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "IPv4 add offset",
+			addr:   netip.MustParseAddr("192.168.1.1"),
+			offset: 10,
+			want:   "192.168.1.11",
+		},
+		{
+			name:    "IPv4 add offset overflow",
+			addr:    netip.MustParseAddr("255.255.255.255"),
+			offset:  1,
+			wantErr: true,
+		},
+		{
+			name:    "invalid zero address",
+			addr:    netip.Addr{},
+			offset:  5,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := addOffsetAddress(tt.addr, tt.offset)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("addOffsetAddress() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Errorf("addOffsetAddress() = %s, want %s", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestIPIterator(t *testing.T) {
+	t.Run("iteration with offset", func(t *testing.T) {
+		b := bounds{
+			ipFirst: netip.MustParseAddr("192.168.1.1"),
+			ipLast:  netip.MustParseAddr("192.168.1.3"),
+			offset:  1,
+		}
+		it := ipIterator(b)
+		var ips []string
+		for {
+			ip := it()
+			if !ip.IsValid() {
+				break
+			}
+			ips = append(ips, ip.String())
+		}
+		expected := []string{"192.168.1.2", "192.168.1.3", "192.168.1.1"}
+		if len(ips) != len(expected) {
+			t.Fatalf("expected %d IPs, got %d: %v", len(expected), len(ips), ips)
+		}
+		for i, v := range expected {
+			if ips[i] != v {
+				t.Errorf("at index %d: expected %s, got %s", i, v, ips[i])
+			}
+		}
+	})
+
+	t.Run("iteration with offset larger than range wrapping to ipFirst", func(t *testing.T) {
+		b := bounds{
+			ipFirst: netip.MustParseAddr("192.168.1.1"),
+			ipLast:  netip.MustParseAddr("192.168.1.3"),
+			offset:  10, // rangeSize is 2. offset 10 > 2. modulo(start) will wrap to ipFirst.
+		}
+		it := ipIterator(b)
+		var ips []string
+		for {
+			ip := it()
+			if !ip.IsValid() {
+				break
+			}
+			ips = append(ips, ip.String())
+		}
+		expected := []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"}
+		if len(ips) != len(expected) {
+			t.Fatalf("expected %d IPs, got %d: %v", len(expected), len(ips), ips)
+		}
+		for i, v := range expected {
+			if ips[i] != v {
+				t.Errorf("at index %d: expected %s, got %s", i, v, ips[i])
+			}
+		}
+	})
+
+	t.Run("iteration error path with invalid bounds", func(t *testing.T) {
+		b := bounds{
+			ipFirst: netip.Addr{},
+			offset:  5,
+		}
+		it := ipIterator(b)
+		ip := it()
+		if ip.IsValid() {
+			t.Errorf("expected invalid IP, got %s", ip)
+		}
+	})
+}
+
+func TestRelease(t *testing.T) {
+	addr := netip.MustParseAddr("192.168.1.10")
+	initialIPs := []string{
+		"192.168.1.10/24",
+	}
+	ipam := NewLocalIPAM(initialIPs)
+
+	ipam.Release("192.168.1.10/24")
+
+	if _, exists := ipam.allocatedIPs[addr]; exists {
+		t.Errorf("Expected address %s to be released from in-memory map", addr)
+	}
+}

--- a/pkg/ipam/local_ipam_test.go
+++ b/pkg/ipam/local_ipam_test.go
@@ -1,0 +1,449 @@
+package ipam
+
+import (
+	"net/netip"
+	"sync"
+	"testing"
+)
+
+func TestAllocateForRange(t *testing.T) {
+	t.Run("IPv6 range returns a /128 host address", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		start := netip.MustParseAddr("2001:db8::1")
+		end := netip.MustParseAddr("2001:db8::5")
+
+		ip, err := ipam.allocateForRange(start, end)
+		if err != nil {
+			t.Fatalf("allocateForRange() unexpected error = %v", err)
+		}
+		parsedIP, err := netip.ParsePrefix(ip)
+		if err != nil {
+			t.Fatalf("failed to parse returned IP %q: %v", ip, err)
+		}
+		if parsedIP.Bits() != 128 {
+			t.Errorf("allocateForRange() returned IP %s, want a /128 host address", ip)
+		}
+		if parsedIP.Addr().Compare(start) < 0 || parsedIP.Addr().Compare(end) > 0 {
+			t.Errorf("allocateForRange() returned IP %s outside range [%s, %s]", ip, start, end)
+		}
+	})
+
+	t.Run("IPv4 range returns a /32 host address", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		start := netip.MustParseAddr("10.0.0.5")
+		end := netip.MustParseAddr("10.0.0.10")
+
+		ip, err := ipam.allocateForRange(start, end)
+		if err != nil {
+			t.Fatalf("allocateForRange() unexpected error = %v", err)
+		}
+		parsedIP, err := netip.ParsePrefix(ip)
+		if err != nil {
+			t.Fatalf("failed to parse returned IP %q: %v", ip, err)
+		}
+		if parsedIP.Bits() != 32 {
+			t.Errorf("allocateForRange() returned IP %s, want a /32 host address", ip)
+		}
+		if parsedIP.Addr().Compare(start) < 0 || parsedIP.Addr().Compare(end) > 0 {
+			t.Errorf("allocateForRange() returned IP %s outside range [%s, %s]", ip, start, end)
+		}
+	})
+
+	t.Run("collision avoidance - skips occupied IP", func(t *testing.T) {
+		// Usable range 2001:db8::1 - 2001:db8::2; occupy ::1 so ::2 is the only free IP.
+		ipam := NewLocalIPAM([]string{"2001:db8::1/128"})
+		ip, err := ipam.allocateForRange(netip.MustParseAddr("2001:db8::1"), netip.MustParseAddr("2001:db8::2"))
+		if err != nil {
+			t.Fatalf("allocateForRange() unexpected error = %v", err)
+		}
+		if ip != "2001:db8::2/128" {
+			t.Errorf("allocateForRange() = %s, want 2001:db8::2/128 (the only free usable IP)", ip)
+		}
+	})
+
+	t.Run("single-address range (start == end), then exhausted", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		addr := netip.MustParseAddr("10.0.0.5")
+
+		ip, err := ipam.allocateForRange(addr, addr)
+		if err != nil {
+			t.Fatalf("allocateForRange() unexpected error = %v", err)
+		}
+		if ip != "10.0.0.5/32" {
+			t.Errorf("allocateForRange() = %s, want 10.0.0.5/32", ip)
+		}
+		// The single address is now taken; a second allocation must fail.
+		if _, err := ipam.allocateForRange(addr, addr); err == nil {
+			t.Fatal("second allocateForRange() expected error, but got nil")
+		}
+	})
+
+	t.Run("invalid range: start after end", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		_, err := ipam.allocateForRange(netip.MustParseAddr("10.0.0.10"), netip.MustParseAddr("10.0.0.5"))
+		if err == nil {
+			t.Fatal("allocateForRange() expected error for start > end, got nil")
+		}
+	})
+}
+
+func TestAllocate(t *testing.T) {
+	t.Run("single range yields one host IP", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		ranges := []IPRange{
+			{Start: netip.MustParseAddr("10.0.0.1"), End: netip.MustParseAddr("10.0.0.6")},
+		}
+		ips, err := ipam.Allocate(ranges)
+		if err != nil {
+			t.Fatalf("Allocate() unexpected error = %v", err)
+		}
+		if len(ips) != 1 {
+			t.Fatalf("Allocate() returned %d addresses, want 1: %v", len(ips), ips)
+		}
+		within := netip.MustParsePrefix("10.0.0.0/29")
+		got := netip.MustParsePrefix(ips[0])
+		if got.Bits() != 32 || !within.Contains(got.Addr()) {
+			t.Errorf("Allocate() = %v, want a /32 within 10.0.0.0/29", ips)
+		}
+	})
+
+	t.Run("dual stack: one IP per family", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		ranges := []IPRange{
+			{Start: netip.MustParseAddr("10.0.0.1"), End: netip.MustParseAddr("10.0.0.6")},
+			{Start: netip.MustParseAddr("2001:db8::1"), End: netip.MustParseAddr("2001:db8::fe")},
+		}
+		ips, err := ipam.Allocate(ranges)
+		if err != nil {
+			t.Fatalf("Allocate() unexpected error = %v", err)
+		}
+		if len(ips) != 2 {
+			t.Fatalf("Allocate() returned %d addresses, want 2: %v", len(ips), ips)
+		}
+		var haveV4, haveV6 bool
+		for _, ip := range ips {
+			p := netip.MustParsePrefix(ip)
+			if p.Addr().Is6() {
+				haveV6 = true
+			} else {
+				haveV4 = true
+			}
+		}
+		if !haveV4 || !haveV6 {
+			t.Errorf("Allocate() = %v, want one IPv4 and one IPv6 address", ips)
+		}
+	})
+
+	t.Run("rejects two ranges of the same family", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		ranges := []IPRange{
+			{Start: netip.MustParseAddr("10.0.0.1"), End: netip.MustParseAddr("10.0.0.6")},
+			{Start: netip.MustParseAddr("10.0.1.1"), End: netip.MustParseAddr("10.0.1.6")},
+		}
+		if _, err := ipam.Allocate(ranges); err == nil {
+			t.Fatal("Allocate() expected error for two ranges of the same family, got nil")
+		}
+		// The first range's address must have been rolled back, leaving nothing allocated.
+		ips, err := ipam.Allocate([]IPRange{{Start: netip.MustParseAddr("10.0.0.1"), End: netip.MustParseAddr("10.0.0.1")}})
+		if err != nil || len(ips) != 1 || ips[0] != "10.0.0.1/32" {
+			t.Errorf("re-Allocate after rejected dup-family = (%v, %v), want [10.0.0.1/32], nil (proving rollback)", ips, err)
+		}
+	})
+
+	t.Run("range exhausted yields error", func(t *testing.T) {
+		// Occupy the only address in a single-address range.
+		ipam := NewLocalIPAM([]string{"10.0.0.5/32"})
+		ranges := []IPRange{
+			{Start: netip.MustParseAddr("10.0.0.5"), End: netip.MustParseAddr("10.0.0.5")},
+		}
+		if _, err := ipam.Allocate(ranges); err == nil {
+			t.Fatal("Allocate() expected error for exhausted range, got nil")
+		}
+	})
+
+	t.Run("invalid range rejected", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		ranges := []IPRange{
+			{Start: netip.MustParseAddr("10.0.0.10"), End: netip.MustParseAddr("10.0.0.5")}, // start > end
+		}
+		if _, err := ipam.Allocate(ranges); err == nil {
+			t.Fatal("Allocate() expected error for invalid range, got nil")
+		}
+	})
+
+	t.Run("no leak: addresses released when a later range fails", func(t *testing.T) {
+		// IPv4 succeeds, then the IPv6 range is exhausted -> the whole call fails.
+		ipam := NewLocalIPAM([]string{"2001:db8::1/128"}) // occupy the only IPv6 address
+		ranges := []IPRange{
+			{Start: netip.MustParseAddr("10.0.0.5"), End: netip.MustParseAddr("10.0.0.5")},       // succeeds
+			{Start: netip.MustParseAddr("2001:db8::1"), End: netip.MustParseAddr("2001:db8::1")}, // exhausted -> error
+		}
+		if _, err := ipam.Allocate(ranges); err == nil {
+			t.Fatal("Allocate() expected error, got nil")
+		}
+		// The previously allocated 10.0.0.5 must have been released.
+		ips, err := ipam.Allocate([]IPRange{{Start: netip.MustParseAddr("10.0.0.5"), End: netip.MustParseAddr("10.0.0.5")}})
+		if err != nil {
+			t.Fatalf("Allocate() after cleanup unexpected error = %v", err)
+		}
+		if len(ips) != 1 || ips[0] != "10.0.0.5/32" {
+			t.Errorf("Allocate() = %v, want [10.0.0.5/32] (proving prior alloc was released)", ips)
+		}
+	})
+}
+
+// TestAllocateConcurrent is a stress test for the concurrency-safety of Allocate.
+// The allocator's whole purpose is to never hand the same address to two callers,
+// so these tests exercise that under simultaneous access. Run with -race to also
+// catch data races on the shared state.
+func TestAllocateConcurrent(t *testing.T) {
+	t.Run("two pods contending for the same address: one succeeds, the other fails", func(t *testing.T) {
+		// Seed every address in [10.0.0.1, 10.0.0.5] except 10.0.0.3, so both pods
+		// must converge on 10.0.0.3.
+		initial := []string{
+			"10.0.0.1/32", "10.0.0.2/32", "10.0.0.4/32", "10.0.0.5/32",
+		}
+		ipam := NewLocalIPAM(initial)
+		ranges := []IPRange{{Start: netip.MustParseAddr("10.0.0.1"), End: netip.MustParseAddr("10.0.0.5")}}
+
+		var wg sync.WaitGroup
+		results := make([][]string, 2)
+		errs := make([]error, 2)
+
+		// Line both goroutines up on a barrier so they race to allocate together.
+		start := make(chan struct{})
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				results[i], errs[i] = ipam.Allocate(ranges)
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		// Exactly one pod gets 10.0.0.3; the other must fail because it was the only
+		// free address and it gets skipped once taken.
+		succeeded, failed := 0, 0
+		for i := 0; i < 2; i++ {
+			if errs[i] == nil {
+				succeeded++
+				if len(results[i]) != 1 || results[i][0] != "10.0.0.3/32" {
+					t.Errorf("pod %d: successful Allocate() = %v, want [10.0.0.3/32]", i, results[i])
+				}
+			} else {
+				failed++
+			}
+		}
+		if succeeded != 1 || failed != 1 {
+			t.Errorf("got %d successful and %d failed allocations, want exactly 1 each (double-allocation or a lost skip)", succeeded, failed)
+		}
+	})
+
+	t.Run("50 concurrent allocations on a 10-address range: only 10 succeeds, exhausting the range", func(t *testing.T) {
+		// A range with exactly 10 allocatable addresses ([.1, .10]).
+		ranges := []IPRange{{Start: netip.MustParseAddr("10.0.0.1"), End: netip.MustParseAddr("10.0.0.10")}}
+		const capacity = 10
+		const workers = 50
+
+		ipam := NewLocalIPAM(nil)
+
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		counts := make(map[string]int) // allocated IP -> number of times handed out
+		successes := 0
+
+		start := make(chan struct{})
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				ips, err := ipam.Allocate(ranges)
+				if err != nil {
+					return // expected once the range is exhausted
+				}
+				mu.Lock()
+				defer mu.Unlock()
+				successes++
+				for _, ip := range ips {
+					counts[ip]++
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		if successes != capacity {
+			t.Errorf("got %d successful allocations, want %d", successes, capacity)
+		}
+		if len(counts) != capacity {
+			t.Errorf("got %d unique IPs, want %d", len(counts), capacity)
+		}
+		for ip, n := range counts {
+			if n != 1 {
+				t.Errorf("IP %q was handed out %d times, want exactly 1 (double-allocation under concurrency)", ip, n)
+			}
+		}
+	})
+}
+
+func TestAddOffsetAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    netip.Addr
+		offset  uint64
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "IPv4 add offset",
+			addr:   netip.MustParseAddr("192.168.1.1"),
+			offset: 10,
+			want:   "192.168.1.11",
+		},
+		{
+			name:    "IPv4 add offset overflow",
+			addr:    netip.MustParseAddr("255.255.255.255"),
+			offset:  1,
+			wantErr: true,
+		},
+		{
+			name:    "invalid zero address",
+			addr:    netip.Addr{},
+			offset:  5,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := addOffsetAddress(tt.addr, tt.offset)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("addOffsetAddress() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Errorf("addOffsetAddress() = %s, want %s", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestIPIterator(t *testing.T) {
+	t.Run("iteration with offset", func(t *testing.T) {
+		b := bounds{
+			ipFirst: netip.MustParseAddr("192.168.1.1"),
+			ipLast:  netip.MustParseAddr("192.168.1.3"),
+			offset:  1,
+		}
+		it := ipIterator(b)
+		var ips []string
+		for {
+			ip := it()
+			if !ip.IsValid() {
+				break
+			}
+			ips = append(ips, ip.String())
+		}
+		expected := []string{"192.168.1.2", "192.168.1.3", "192.168.1.1"}
+		if len(ips) != len(expected) {
+			t.Fatalf("expected %d IPs, got %d: %v", len(expected), len(ips), ips)
+		}
+		for i, v := range expected {
+			if ips[i] != v {
+				t.Errorf("at index %d: expected %s, got %s", i, v, ips[i])
+			}
+		}
+	})
+
+	t.Run("iteration with offset larger than range wrapping to ipFirst", func(t *testing.T) {
+		b := bounds{
+			ipFirst: netip.MustParseAddr("192.168.1.1"),
+			ipLast:  netip.MustParseAddr("192.168.1.3"),
+			offset:  10, // rangeSize is 2. offset 10 > 2. modulo(start) will wrap to ipFirst.
+		}
+		it := ipIterator(b)
+		var ips []string
+		for {
+			ip := it()
+			if !ip.IsValid() {
+				break
+			}
+			ips = append(ips, ip.String())
+		}
+		expected := []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"}
+		if len(ips) != len(expected) {
+			t.Fatalf("expected %d IPs, got %d: %v", len(expected), len(ips), ips)
+		}
+		for i, v := range expected {
+			if ips[i] != v {
+				t.Errorf("at index %d: expected %s, got %s", i, v, ips[i])
+			}
+		}
+	})
+
+	t.Run("iteration error path with invalid bounds", func(t *testing.T) {
+		b := bounds{
+			ipFirst: netip.Addr{},
+			offset:  5,
+		}
+		it := ipIterator(b)
+		ip := it()
+		if ip.IsValid() {
+			t.Errorf("expected invalid IP, got %s", ip)
+		}
+	})
+}
+
+func TestRelease(t *testing.T) {
+	addr := netip.MustParseAddr("192.168.1.10")
+	initialIPs := []string{
+		"192.168.1.10/24",
+	}
+	ipam := NewLocalIPAM(initialIPs)
+
+	ipam.Release("192.168.1.10/24")
+
+	if _, exists := ipam.allocatedIPs[addr]; exists {
+		t.Errorf("Expected address %s to be released from in-memory map", addr)
+	}
+}
+
+func TestReserve(t *testing.T) {
+	t.Run("records addresses so Allocate avoids them", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		if err := ipam.Reserve([]string{"10.0.0.5/32"}); err != nil {
+			t.Fatalf("Reserve() unexpected error = %v", err)
+		}
+		// 10.0.0.5 is now the only address in the range and it is reserved.
+		if _, err := ipam.allocateForRange(netip.MustParseAddr("10.0.0.5"), netip.MustParseAddr("10.0.0.5")); err == nil {
+			t.Fatalf("allocateForRange() = nil error, want exhaustion error for reserved address")
+		}
+	})
+
+	t.Run("already in-use address returns error", func(t *testing.T) {
+		ipam := NewLocalIPAM([]string{"10.0.0.5/32"})
+		if err := ipam.Reserve([]string{"10.0.0.5/32"}); err == nil {
+			t.Fatalf("Reserve() = nil error, want already-in-use error")
+		}
+	})
+
+	t.Run("invalid address returns error", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		if err := ipam.Reserve([]string{"not-an-ip"}); err == nil {
+			t.Fatalf("Reserve() = nil error, want parse error")
+		}
+	})
+
+	t.Run("atomic: nothing recorded when one address is invalid", func(t *testing.T) {
+		ipam := NewLocalIPAM(nil)
+		if err := ipam.Reserve([]string{"10.0.0.5/32", "not-an-ip"}); err == nil {
+			t.Fatalf("Reserve() = nil error, want error")
+		}
+		// The valid address must be free (atomic rollback), so a re-reserve succeeds.
+		if err := ipam.Reserve([]string{"10.0.0.5/32"}); err != nil {
+			t.Fatalf("Reserve() after failed atomic call error = %v, want nil", err)
+		}
+	})
+}

--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -73,6 +73,7 @@ cleanup_veth_interfaces() {
       ip link delete vrf-test-pod-2 || true
       ip link delete pbr-test-pod-1 || true
       ip link delete pbr-test-pod-2 || true
+      ip link delete ipvlan-pbr-a || true
     '
   done
 }
@@ -224,6 +225,69 @@ wait_for_ready_pods() {
   assert_output --partial "169.254.169.1"
 }
 
+@test "dummy interface with ipvlan ResourceClaim and address" {
+  docker exec "$CLUSTER_NAME"-worker bash -c "ip link add dummy0 type dummy"
+  docker exec "$CLUSTER_NAME"-worker bash -c "ip link set up dev dummy0"
+
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/deviceclass.yaml
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/resourceclaim_ipvlan.yaml
+  wait_for_ready_pods app=pod-ipvlan 30s
+
+  run kubectl exec pod-ipvlan -- ip -d link show dummy0
+  assert_success
+  assert_output --partial "ipvlan"
+
+  run kubectl exec pod-ipvlan -- ip addr show dummy0
+  assert_success
+  assert_output --partial "169.254.200.10"
+
+  # The parent interface still exists on the host.
+  run docker exec "$CLUSTER_NAME"-worker ip link show dummy0
+  assert_success
+}
+
+@test "validate pbr configuration with ipvlan subinterface" {
+  local NODE_NAME="$CLUSTER_NAME"-worker
+  local TABLE_ID="150"
+
+  # The ipvlan parent is one end of a veth pair; the peer stays on the host
+  # and owns the gateway address plus an address only reachable through the
+  # PBR table (169.254.202.0/24 has no route in the pod's main table).
+  docker exec "$NODE_NAME" bash -c "ip link add ipvlan-pbr-a type veth peer name ipvlan-pbr-b"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev ipvlan-pbr-a"
+  docker exec "$NODE_NAME" bash -c "ip link set up dev ipvlan-pbr-b"
+  docker exec "$NODE_NAME" bash -c "ip addr add 169.254.201.1/24 dev ipvlan-pbr-b"
+  docker exec "$NODE_NAME" bash -c "ip addr add 169.254.202.1/32 dev ipvlan-pbr-b"
+
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/deviceclass.yaml
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/resourceclaim_ipvlan_pbr.yaml
+  wait_for_ready_pods app=pod-ipvlan-pbr 60s
+
+  run kubectl exec pod-ipvlan-pbr -- ip -d link show net1
+  assert_success
+  assert_output --partial "ipvlan"
+
+  # The PBR table holds the gateway link route and the destination route.
+  run kubectl exec pod-ipvlan-pbr -- ip route show table $TABLE_ID
+  assert_success
+  assert_output --partial "169.254.201.1 dev net1 scope link"
+  assert_output --partial "169.254.202.0/24 via 169.254.201.1 dev net1"
+
+  run kubectl exec pod-ipvlan-pbr -- ip rule show
+  assert_success
+  assert_output --regexp "32000:[[:space:]]+from 169.254.201.10 lookup $TABLE_ID"
+  assert_output --regexp "32000:[[:space:]]+from all to 169.254.202.0/24 lookup $TABLE_ID"
+
+  # Connectivity is only possible through the PBR table: the pod's main table
+  # has no route to 169.254.202.1.
+  run kubectl exec pod-ipvlan-pbr -- ping -c 1 -W 2 169.254.202.1
+  assert_success
+
+  # The parent interface still exists on the host.
+  run docker exec "$NODE_NAME" ip link show ipvlan-pbr-a
+  assert_success
+}
+
 @test "test metric server is up and operating on host" {
   # Run a temporary pod to access metrics
   kubectl run test-metrics \
@@ -237,7 +301,6 @@ wait_for_ready_pods() {
   kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/test-metrics --timeout=5s
   assert_equal "$(kubectl logs test-metrics)" "ok"
 }
-
 
 @test "validate advanced network configurations with dummy" {
   docker exec "$CLUSTER_NAME"-worker bash -c "ip link add dummy0 type dummy"

--- a/tests/manifests/resourceclaim_ipvlan.yaml
+++ b/tests/manifests/resourceclaim_ipvlan.yaml
@@ -1,0 +1,51 @@
+# Copyright The Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: resource.k8s.io/v1
+kind:  ResourceClaim
+metadata:
+  name: dummy-interface-ipvlan
+spec:
+  devices:
+    requests:
+    - name: req-dummy-ipvlan
+      exactly:
+        deviceClassName: dra.net
+        selectors:
+          - cel:
+              expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "dummy0"
+    config:
+    - opaque:
+        driver: dra.net
+        parameters:
+          interface:
+            type: "IPVLAN"
+            addresses:
+            - "169.254.200.10/24"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-ipvlan
+  labels:
+    app: pod-ipvlan
+spec:
+  containers:
+  - name: ctr1
+    image: registry.k8s.io/e2e-test-images/agnhost:2.54
+    # Keep the container running
+    command: ["sleep", "infinity"]
+  resourceClaims:
+  - name: dummy1
+    resourceClaimName: dummy-interface-ipvlan

--- a/tests/manifests/resourceclaim_ipvlan_pbr.yaml
+++ b/tests/manifests/resourceclaim_ipvlan_pbr.yaml
@@ -1,0 +1,68 @@
+# Copyright The Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# IPVLAN subinterface with policy based routing: the same shape a cloud
+# provider profile generates (per-device table with an on-link gateway route
+# plus destination route, and source/destination rules pointing at it).
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: ipvlan-pbr
+spec:
+  devices:
+    requests:
+    - name: req-ipvlan-pbr
+      exactly:
+        deviceClassName: dra.net
+        selectors:
+        - cel:
+            expression: has(device.attributes["dra.net"].ifName) && device.attributes["dra.net"].ifName == "ipvlan-pbr-a"
+    config:
+    - opaque:
+        driver: dra.net
+        parameters:
+          interface:
+            type: "IPVLAN"
+            name: "net1"
+            addresses:
+            - "169.254.201.10/24"
+          routes:
+          - destination: "169.254.201.1/32"
+            scope: 253
+            table: 150
+          - destination: "169.254.202.0/24"
+            gateway: "169.254.201.1"
+            table: 150
+          rules:
+          - source: "169.254.201.10/32"
+            table: 150
+            priority: 32000
+          - destination: "169.254.202.0/24"
+            table: 150
+            priority: 32000
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-ipvlan-pbr
+  labels:
+    app: pod-ipvlan-pbr
+spec:
+  containers:
+  - name: ctr1
+    image: registry.k8s.io/e2e-test-images/agnhost:2.54
+    command: ["sleep", "infinity"]
+  resourceClaims:
+  - name: ipvlanpbr
+    resourceClaimName: ipvlan-pbr


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduces support for subinterface provisioning in the DRANET driver, currently implementing IPVLAN as the subinterface type. The feature addresses the networking requirement for #239 by creating a new subinterface inside the pod network namespace without moving the host’s parent interface. It also provides the groundwork for #63 to later enable multiple-subinterface creation on a single NIC.

The key changes include:

*API*
- Add optional `interface.type` to `NetworkConfig` to select how an allocated device is presented to the Pod.
   - `passthrough` (default) moves the device into the Pod's netns; `ipvlan` keeps the device on the host and creates an IPVLAN subinterface inside the Pod.
- Add `IPVlanConfig` to configure the IPVLAN `mode`/`flag` (currently `l2`/`bridge`).
- Add `interface.addressing` (`static`/`dhcp`/`unnumbered`) to select the IP configuration strategy; `unnumbered` covers deliberately addressless subinterfaces. Deprecate the boolean `interface.dhcp` in favor of `addressing: dhcp` (backward compatible — `dhcp: true` is normalized to `addressing: dhcp` when `addressing` is unset).

*IPAM*
- Add a dedicated `pkg/ipam` package with a concurrency-safe node-local `LocalIPAM` that owns the set of in-use addresses and hands out one address per IP family; allocated IPs are released on claim teardown.
- Resolve subinterface addresses from the cloud provider's profile via `GetProfileConfig`, which calls `LocalIPAM`.
- Move pod config store construction into `app.go` (injected as a required `Start()` parameter) and seed its in-use subinterface IPs into the cloud provider via `cloudprovider.InstanceOptions.ReservedAddresses`, so IPAM state is recovered on restart and in-use addresses are not handed out twice.

*Driver*
- During ResourceClaim preparation, assign the subinterface name, resolve its address(es) from `interface.addresses` or a cloud profile, and configure source-based routing.
   - User-configured routes/rules are preserved — automatic source-based routing is skipped when the user already specified them.
   - Fail the claim when a subinterface resolves with no address (and `addressing: unnumbered` is not set) instead of silently bringing up a dead link that still reports Ready.
- Reject subinterfaces on devices in exclusive RDMA mode (shared RDMA mode is required).
- Integrate subinterface create/delete (IPVLAN) inside the Pod network namespace via the NRI run/stop sandbox hooks.

*GCE*
- Derive the subinterface range from GCE VM metadata when resolving a device profile (`GetProfileConfig`, via the `subinterfaceRanges` helper): IPv4 from the primary alias range, IPv6 from the base IPv6 range — using a shared, cloud-agnostic `cloudutil.IPRangeFromCIDR` helper (network and broadcast always excluded; providers specify any additional reserved counts).

#### Which issue(s) this PR is related to:
Fixes #239

#### Special notes for your reviewer:
The code was tested by requesting a subinterface in ResourceClaim. The pod runs successfully with the IPVlan interface (connectivity verified via ping test), and the parent interface remains in the host’s namespace.
`ResourceClaimTemplate` yaml example:
```yaml
apiVersion: resource.k8s.io/v1
kind: ResourceClaimTemplate
metadata:
  name: one-ipvlan
spec:
  spec:
    devices:
      requests:
      - name: one-ipvlan
        exactly:
          deviceClassName: netdev.google.com
          allocationMode: ExactCount
          count: 1
      config:
      - opaque:
          driver: dra.net
          parameters:
            interface:
              type: "IPVLAN"
```

#### Does this PR introduce a user-facing change?
```release-note
Add `interface.type` to select how an allocated network device is presented to a pod.
The default, `Passthrough`, moves the device into the Pod's network namespace as before.
The new `IPVLAN` type leaves the device on the host and creates an IPVLAN (l2 mode, bridge flag) subinterface inside the Pod, enabling use of NICs that cannot be moved (e.g. LACP bonds) and laying the groundwork for NIC sharing across Pods.
Addresses for an `IPVLAN` interface come from `interface.addresses` or from the cloud provider's profile; source-based routing is configured automatically. `IPVLAN` requires the RDMA subsystem to be in shared netns mode.
Add `interface.addressing` to explicitly select the IP configuration strategy: `Static` (default), `DHCP`, or `Unnumbered` (subinterfaces only).
The boolean `interface.dhcp` field is now deprecated in favor of `addressing: DHCP`, and remains backward compatible — `dhcp: true` is normalized to `addressing: dhcp` when `addressing` is unset.
```