### PR TITLE
examples/oci_oke: remove stale orphaned-NIC workarounds + doc cleanup

### DIFF
--- a/examples/oci_oke_examples/BM.GPU.GB200-v3.4/README.md
+++ b/examples/oci_oke_examples/BM.GPU.GB200-v3.4/README.md
@@ -85,26 +85,19 @@ each RDMA NIC receives a globally-routable IPv6 address via Router Advertisement
 This address populates a routable GID in the NIC's GID table, which NCCL uses
 for inter-node communication (`NCCL_IB_GID_INDEX=3`).
 
-**Challenge:** In single-stack IPv4 Kubernetes clusters, the container runtime
-sets `net.ipv6.conf.all.disable_ipv6=1` in pod namespaces. This prevents the
-RA-assigned IPv6 address from being applied to RDMA NICs in the pod, leaving
-only link-local GIDs (which are not routable on the OKE fabric).
-
-**DRANET fix:** The OKE cloud provider returns `EnableIPv6: true` for RDMA
-devices on GPU fabric shapes. When set, DRANET:
-
-1. Soft-fails the initial IPv6 address application (EACCES due to disabled IPv6)
-2. Enables IPv6 per-interface via `net.ipv6.conf.<ifname>.disable_ipv6=0`
-3. Re-applies the IPv6 address, populating the routable GID at index 3
+For NCCL to use the routable GID, the RDMA NICs in the pod must carry the
+RA-assigned IPv6 address (not just a link-local GID). Ensure your cluster /
+node configuration leaves IPv6 enabled on the RDMA interfaces inside pods.
 
 **NCCL configuration note:** Set `NCCL_IB_DATA_DIRECT=0` to prevent NCCL from
 selecting the Data Direct DMA interface (`mlx5_N_dma`) and instead use the
-standard IB verbs path, which correctly uses the GID configured by DRANET.
+standard IB verbs path, which correctly uses the routable GID.
 
 ## Files
 
 | File | Description |
 |---|---|
+| `deviceclass.yaml` | `dranet.net` `DeviceClass` matching all DRANET NIC devices (referenced by the templates) |
 | `resource-claim-template.yaml` | `ResourceClaimTemplate` objects: `1nic-aligned`, `1nic-unaligned`, `2nic-aligned`, `4nic-aligned`, `4gpu-8nic` |
 | `mpi-job.yaml` | `MPIJob` running `all_reduce_perf` across 2 workers (per-node benchmarks) |
 | `multinode-mpi-job.yaml` | `MPIJob` running `all_reduce_perf` across 16 workers with `4gpu-8nic` + ComputeDomain |
@@ -119,6 +112,9 @@ standard IB verbs path, which correctly uses the GID configured by DRANET.
 ```bash
 # Install MPI Operator (if not already installed)
 kubectl apply --server-side -k "https://github.com/kubeflow/mpi-operator/manifests/overlays/standalone?ref=v0.7.0"
+
+# Create the dranet.net DeviceClass (required by the ResourceClaimTemplates)
+kubectl apply -f deviceclass.yaml
 
 # Apply ResourceClaimTemplates
 kubectl apply -f resource-claim-template.yaml
@@ -187,7 +183,9 @@ by NCCL; expect lower bandwidth due to cross-NUMA memory traffic.
 ## Running the full test suite
 
 Each test requires deleting the previous MPIJob since the resource claims are
-immutable. Between tests, orphaned NICs may need PCI rebinding (see next section).
+immutable. When a worker pod is deleted, DRANET returns its NIC(s) to the host
+namespace and the device reappears in the node's ResourceSlice within one poll
+interval, so the next test can reallocate them.
 
 ```bash
 # --- Test 1: 1nic-aligned ---
@@ -206,58 +204,6 @@ kubectl delete mpijob nccl-test-dra
 kubectl apply -f mpi-job.yaml
 kubectl delete mpijob nccl-test-dra
 ```
-
-## Recovering orphaned RDMA NICs
-
-When a pod is deleted, DRANET may not return the RDMA NIC from the pod namespace
-to the host namespace. The NIC disappears from both the host and the ResourceSlice.
-This is a known DRANET bug. [This issue](https://github.com/kubernetes-sigs/dranet/issues/137) tracks the DRANET progress, while [this PR](https://github.com/containerd/nri/pull/286) addresses the upstream NRI changes.
-
-**Symptoms:** Workers stuck in `Pending` with `cannot allocate all claims`.
-
-**Check which NICs are missing:**
-
-```bash
-kubectl get resourceslice -o json | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-for rs in data['items']:
-    if rs['spec'].get('driver') != 'dra.net': continue
-    node = rs['spec']['nodeName']
-    for d in rs['spec'].get('devices', []):
-        attrs = d.get('attributes', {})
-        if attrs.get('dra.net/rdma', {}).get('bool') and \
-           not attrs.get('dra.net/virtual', {}).get('bool', True) and \
-           not attrs.get('dra.net/ifName', {}).get('string', ''):
-            pci = attrs.get('dra.net/pciAddress', {}).get('string', '?')
-            print(f'{node}: {d[\"name\"]} pci={pci}')
-"
-```
-
-**Recover via PCI rebind** (requires a privileged pod on each affected GPU node):
-
-```bash
-kubectl debug node/<node-ip> --image=<any-cached-image> -it -- bash
-# Inside the debug pod:
-chroot /host
-echo "0000:03:00.0" > /sys/bus/pci/drivers/mlx5_core/unbind && sleep 1
-echo "0000:03:00.0" > /sys/bus/pci/drivers/mlx5_core/bind
-```
-
-Common PCI addresses on BM.GPU.GB200-v3.4:
-
-| ifName | PCI Address | NUMA |
-|---|---|---|
-| rdma0 | 0000:03:00.0 | 0 |
-| rdma1 | 0000:03:00.1 | 0 |
-| rdma2 | 0002:03:00.0 | 0 |
-| rdma3 | 0002:03:00.1 | 0 |
-| rdma4 | 0010:03:00.0 | 1 |
-| rdma5 | 0010:03:00.1 | 1 |
-| rdma6 | 0012:03:00.0 | 1 |
-| rdma7 | 0012:03:00.1 | 1 |
-
-Wait ~15 seconds for DRANET to rescan, then verify the NIC reappears in the ResourceSlice.
 
 ## Benchmark Results
 
@@ -332,7 +278,7 @@ idiomatic DRA approach for multi-device allocation from a homogeneous pool.
 **~92–96% of theoretical at 2 nodes:**
 Peak single-NIC bandwidth is 400 Gb/s = 50 GB/s. The 1nic-aligned result
 (~46 GB/s) achieves ~92% of theoretical, demonstrating that DRANET's DRA-based
-NIC injection and IPv6 GID configuration adds negligible overhead.
+NIC injection adds negligible overhead.
 
 **Channel × QPS equivalence at 16 nodes (1-GPU mode):**
 At scale, total QP fanout governs throughput. `NCCL_MIN_NCHANNELS=8` with

--- a/examples/oci_oke_examples/BM.GPU.GB200-v3.4/deviceclass.yaml
+++ b/examples/oci_oke_examples/BM.GPU.GB200-v3.4/deviceclass.yaml
@@ -1,0 +1,11 @@
+# DeviceClass that matches all DRANET-managed network devices.
+# Required for DRA to resolve the `deviceClassName: dranet.net` references in
+# the ResourceClaimTemplates in this directory.
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: dranet.net
+spec:
+  selectors:
+    - cel:
+        expression: device.driver == "dra.net"

--- a/examples/oci_oke_examples/BM.GPU.H100.8/README.md
+++ b/examples/oci_oke_examples/BM.GPU.H100.8/README.md
@@ -13,7 +13,7 @@ Each node has:
 | Resource | Count | Detail |
 |---|---|---|
 | GPU | 8 x NVIDIA H100 | 80 GB HBM3, Hopper architecture, NVLink/NVSwitch all-to-all |
-| NIC | 16 x Mellanox ConnectX-7 (8 dual-port cards) | 400 Gb/s RoCEv2 per port |
+| NIC | 16 x Mellanox ConnectX-7 (8 dual-port cards) | RoCEv2, 3,200 Gbps RDMA cluster network per node |
 | NUMA nodes | 2 | 4 GPUs + 8 NICs per NUMA node |
 
 ### NIC layout
@@ -131,23 +131,9 @@ launcher=$(kubectl get pods \
 kubectl logs -f "${launcher}"
 ```
 
-## Recovering orphaned RDMA NICs
+## Device lifecycle
 
-When a pod is deleted, DRANET may not return the RDMA NIC from the pod namespace
-to the host namespace (see [#137](https://github.com/kubernetes-sigs/dranet/issues/137)).
-
-**Symptoms:** Workers stuck in `Pending` with `cannot allocate all claims`.
-
-**Recover via PCI rebind** (requires a privileged debug pod on each GPU node):
-
-```bash
-kubectl debug node/<node-name> --image=busybox -it -- sh
-chroot /host
-# Replace with the actual PCI address of the orphaned NIC
-echo "0000:0c:00.0" > /sys/bus/pci/drivers/mlx5_core/unbind
-sleep 2
-echo "0000:0c:00.0" > /sys/bus/pci/drivers/mlx5_core/bind
-```
-
-Wait ~15 seconds for DRANET to rescan, then verify the NIC reappears in the
-ResourceSlice.
+When a worker pod is deleted, DRANET returns its RDMA NIC(s) from the pod
+network namespace to the host and the device reappears in the node's
+ResourceSlice within one inventory poll interval — no manual intervention is
+required between runs.

--- a/examples/oci_oke_examples/README.md
+++ b/examples/oci_oke_examples/README.md
@@ -8,13 +8,12 @@ on Oracle Kubernetes Engine (OKE) with dranet.
 
 | Shape | Network | Example |
 |---|---|---|
-| [BM.GPU.H100.8](BM.GPU.H100.8/) | RoCEv2 (8x ConnectX-7, 100 Gb/s) | NUMA-aligned GPU + NIC allocation, NCCL all_reduce benchmark |
-| [BM.GPU.GB200-v3.4](BM.GPU.GB200-v3.4/) | RoCEv2 (8x ConnectX-8, 400 Gb/s) | NUMA-aligned GPU + NIC allocation, NCCL all_reduce benchmark, IPv6 GID |
+| [BM.GPU.H100.8](BM.GPU.H100.8/) | RoCEv2 (ConnectX-7, 3,200 Gbps RDMA/node) | NUMA-aligned GPU + NIC allocation, NCCL all_reduce benchmark |
+| [BM.GPU.GB200-v3.4](BM.GPU.GB200-v3.4/) | RoCEv2 (8x ConnectX-8, 400 Gb/s) | NUMA-aligned GPU + NIC allocation, NCCL all_reduce benchmark |
 | [BM.GPU.GB200-v3.4 Placement Group](BM.GPU.GB200-v3.4/placement-group/) | RoCEv2 | OKE topology-aware scheduling using hpcIslandId / networkBlockId / localBlockId |
 
 ## Key dranet Features Demonstrated
 
 - **NUMA alignment**: CEL selectors constrain NIC allocation to GPUs on the same NUMA node, enabling GDR
 - **OKE topology attributes**: `oke.dra.net/{hpcIslandId,networkBlockId,localBlockId,rackId,gpuMemoryFabricId}` exposed as DRA device attributes
-- **IPv6 GID support**: dranet enables per-interface IPv6 on RoCEv2 NICs in IPv4-only clusters, populating the routable GID at index 3 required by NCCL
 - **Device isolation**: NRI plugin injects only allocated `/dev/infiniband/uverbs*` devices without `privileged: true`


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

DRANET now returns RDMA NICs to the host namespace when a pod is deleted on OCI, so the manual PCI-rebind recovery steps are no longer needed. Remove the 'Recovering orphaned RDMA NICs' sections from the GB200-v3.4 and H100.8 READMEs and replace the H100.8 section with a short device-lifecycle note.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#111 
#### Special notes for your reviewer:

dranet works from a clean install on OCI now!

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Works fully from clean install on OCI OKE bare-metal clusters.
```