### PR TITLE
Require CIDR for route Destination in validation

### DIFF
--- a/pkg/apis/validation.go
+++ b/pkg/apis/validation.go
@@ -211,7 +211,7 @@ func validateRoutes(routes []RouteConfig, fieldPath string) (allErrors []error) 
 			allErrors = append(allErrors, fmt.Errorf("%s.destination: cannot be empty", currentFieldPath))
 		} else {
 			if _, _, err := net.ParseCIDR(route.Destination); err != nil {
-				allErrors = append(allErrors, fmt.Errorf("%s.destination: invalid CIDR format '%s'", currentFieldPath, route.Destination))
+				allErrors = append(allErrors, fmt.Errorf("%s.destination: invalid CIDR format '%s' (host routes use /32 or /128)", currentFieldPath, route.Destination))
 			}
 		}
 

--- a/pkg/apis/validation.go
+++ b/pkg/apis/validation.go
@@ -211,9 +211,7 @@ func validateRoutes(routes []RouteConfig, fieldPath string) (allErrors []error) 
 			allErrors = append(allErrors, fmt.Errorf("%s.destination: cannot be empty", currentFieldPath))
 		} else {
 			if _, _, err := net.ParseCIDR(route.Destination); err != nil {
-				if net.ParseIP(route.Destination) == nil {
-					allErrors = append(allErrors, fmt.Errorf("%s.destination: invalid IP or CIDR format '%s'", currentFieldPath, route.Destination))
-				}
+				allErrors = append(allErrors, fmt.Errorf("%s.destination: invalid CIDR format '%s'", currentFieldPath, route.Destination))
 			}
 		}
 

--- a/pkg/apis/validation_test.go
+++ b/pkg/apis/validation_test.go
@@ -108,7 +108,7 @@ func TestValidateConfig(t *testing.T) {
 			raw:         newRawExtension(t, invalidRouteConf),
 			expectErr:   true,
 			expectedCfg: &invalidRouteConf,
-			errContains: []string{"routes[0].destination: invalid CIDR format 'invalid-cidr'"},
+			errContains: []string{"routes[0].destination: invalid CIDR format 'invalid-cidr' (host routes use /32 or /128)"},
 		},
 		{
 			name:        "config with rule validation error",

--- a/pkg/apis/validation_test.go
+++ b/pkg/apis/validation_test.go
@@ -108,7 +108,7 @@ func TestValidateConfig(t *testing.T) {
 			raw:         newRawExtension(t, invalidRouteConf),
 			expectErr:   true,
 			expectedCfg: &invalidRouteConf,
-			errContains: []string{"routes[0].destination: invalid IP or CIDR format 'invalid-cidr'"},
+			errContains: []string{"routes[0].destination: invalid CIDR format 'invalid-cidr'"},
 		},
 		{
 			name:        "config with rule validation error",
@@ -374,6 +374,26 @@ func TestValidateRoutes(t *testing.T) {
 		{
 			name:      "invalid destination CIDR",
 			routes:    []RouteConfig{{Destination: "10.0.0/24", Gateway: "192.168.1.1"}},
+			fieldPath: "routes",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "valid host route as /32",
+			routes:    []RouteConfig{{Destination: "192.168.1.1/32", Gateway: "192.168.1.254", Scope: scopeUniverse}},
+			fieldPath: "routes",
+			expectErr: false,
+		},
+		{
+			name:      "bare IPv4 destination rejected",
+			routes:    []RouteConfig{{Destination: "192.168.1.1", Gateway: "192.168.1.254"}},
+			fieldPath: "routes",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "bare IPv6 destination rejected",
+			routes:    []RouteConfig{{Destination: "2001:db8::1", Scope: scopeLink}},
 			fieldPath: "routes",
 			expectErr: true,
 			errCount:  1,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A route Destination that is a bare IP (like `192.168.1.1` or `::1`) passes `validateRoutes` today but then silently fails to apply, because `applyRoutingConfig` parses the Destination with `net.ParseCIDR` while validation falls back to `net.ParseIP`. So the config is reported valid and then errors out at Prepare time.

Since `RouteConfig.Destination` is documented as CIDR format (and the examples all use CIDRs, including host routes as `/32` and `/128`), this tightens validation to require a CIDR so it matches what the apply path actually accepts. It also lines routes up with the rest of the package: `validateRules` already requires CIDR for `rule.Destination` with no bare-IP fallback.

Per review, the error message now points the user at the fix: an unparseable Destination reports `invalid CIDR format '...' (host routes use /32 or /128)`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

If you would rather support bare IPs as host routes instead, I am happy to flip it the other way and fix the apply path rather than validation, just let me know. I added table cases to `TestValidateRoutes` that fail before and pass after, and `GOOS=linux go test ./pkg/apis` passes.

#### Does this PR introduce a user-facing change?

```release-note
A network route `Destination` that is a bare IP address is now rejected during validation with a clear error. Use CIDR notation, including `/32` for a single IPv4 host or `/128` for a single IPv6 host.
```
