### PR TITLE
helm: allow global values in chart schema

### DIFF
--- a/deployments/helm/dranet/values.schema.json
+++ b/deployments/helm/dranet/values.schema.json
@@ -107,6 +107,9 @@
         }
       }
     },
+    "global": {
+      "type": "object"
+    },
     "serviceAccount": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When dranet is used as a subchart, Helm automatically passes the parent chart's
`global` values into it. The chart schema had `additionalProperties: false` without
declaring `global`, causing schema validation to fail for any parent chart that
uses `global` values.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
`global` is a Helm-reserved key automatically propagated to all subcharts. No
functional change — schema validation only.

#### Does this PR introduce a user-facing change?
```release-note
Fixed Helm chart schema validation failure when dranet is used as a subchart and
the parent chart defines `global` values.
```
