### PR TITLE
feat: make kubelet registrar and plugins directories configurable

### DIFF
--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -67,6 +67,8 @@ var (
 	profileProvider   string
 	webhookURL        string
 
+	kubeletRootDir string
+
 	ready atomic.Bool
 )
 
@@ -83,6 +85,7 @@ func init() {
 	flag.StringVar(&cloudProviderHint, "cloud-provider-hint", "", "Hint for the cloud provider that will be used to select the appropriate provider plugin. Supported values: (AWS, GCE, AZURE, OKE, ALIBABA, webhook, NONE). If left unset, the cloud provider is auto-detected.")
 	flag.StringVar(&profileProvider, "profile-provider", "cloud", "Provides user intent (cloud, webhook, none). 'cloud' falls back to the cloud-provider's native implementation.")
 	flag.StringVar(&webhookURL, "webhook-url", "", "URL for the webhook provider (required if using webhook for either provider)")
+	flag.StringVar(&kubeletRootDir, "kubelet-root-dir", "/var/lib/kubelet", "The kubelet data directory (its --root-dir). The driver's registration socket lives under <dir>/plugins_registry and its dra.sock under <dir>/plugins/<driver-name>. Set this to match the kubelet --root-dir on clusters that relocate it.")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: dranet [options]\n\n")
@@ -157,6 +160,8 @@ func main() {
 	if dbPath != "" {
 		opts = append(opts, driver.WithDBPath(dbPath))
 	}
+
+	opts = append(opts, driver.WithKubeletRootDir(kubeletRootDir))
 
 	if celExpression != "" {
 		env, err := cel.NewEnv(

--- a/deployments/helm/dranet/templates/daemonset.yaml
+++ b/deployments/helm/dranet/templates/daemonset.yaml
@@ -72,6 +72,7 @@ spec:
             {{- if .Values.args.cloudProviderHint }}
             - --cloud-provider-hint={{ .Values.args.cloudProviderHint }}
             {{- end }}
+            - --kubelet-root-dir={{ .Values.kubeletRootDir }}
           env:
             - name: NODE_NAME
               valueFrom:
@@ -98,9 +99,9 @@ spec:
               port: {{ .Values.metricsPort | default 9177 }}
           volumeMounts:
             - name: device-plugin
-              mountPath: /var/lib/kubelet/plugins
+              mountPath: {{ .Values.kubeletRootDir }}/plugins
             - name: plugin-registry
-              mountPath: /var/lib/kubelet/plugins_registry
+              mountPath: {{ .Values.kubeletRootDir }}/plugins_registry
             - name: nri-plugin
               mountPath: /var/run/nri
             - name: netns
@@ -115,10 +116,10 @@ spec:
       volumes:
         - name: device-plugin
           hostPath:
-            path: /var/lib/kubelet/plugins
+            path: {{ .Values.kubeletRootDir }}/plugins
         - name: plugin-registry
           hostPath:
-            path: /var/lib/kubelet/plugins_registry
+            path: {{ .Values.kubeletRootDir }}/plugins_registry
         - name: nri-plugin
           hostPath:
             path: /var/run/nri

--- a/deployments/helm/dranet/values.schema.json
+++ b/deployments/helm/dranet/values.schema.json
@@ -55,6 +55,10 @@
       "type": "integer",
       "minimum": 0
     },
+    "kubeletRootDir": {
+      "type": "string",
+      "description": "Kubelet data directory (its --root-dir); the driver's plugin and registration sockets live under it"
+    },
     "args": {
       "type": "object",
       "additionalProperties": false,

--- a/deployments/helm/dranet/values.yaml
+++ b/deployments/helm/dranet/values.yaml
@@ -28,6 +28,14 @@ args: {}
 #  moveIBInterfaces: true
 #  cloudProviderHint: ""
 
+# kubeletRootDir is the kubelet data directory (its --root-dir). The driver's
+# registration socket lives under <kubeletRootDir>/plugins_registry (which the
+# kubelet watches) and its dra.sock under <kubeletRootDir>/plugins. The same path
+# is used for the hostPath and the mountPath so it is identical inside and outside
+# the container, as the kubeletplugin library requires. Set this to match the
+# kubelet --root-dir on clusters that relocate it; the default suits a standard kubelet.
+kubeletRootDir: /var/lib/kubelet
+
 nodeSelector: {}
 
 affinity: {}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -46,10 +46,6 @@ import (
 )
 
 const (
-	kubeletPluginPath = "/var/lib/kubelet/plugins"
-)
-
-const (
 	// maxAttempts indicates the number of times the driver will try to recover itself before failing
 	maxAttempts = 5
 )
@@ -96,6 +92,16 @@ func WithDBPath(path string) Option {
 	}
 }
 
+// WithKubeletRootDir sets the kubelet data directory (its --root-dir). The
+// driver's registration socket lives under <dir>/plugins_registry and its
+// dra.sock under <dir>/plugins. Set this when the kubelet runs with a
+// non-default --root-dir.
+func WithKubeletRootDir(dir string) Option {
+	return func(o *NetworkDriver) {
+		o.kubeletRootDir = dir
+	}
+}
+
 type NetworkDriver struct {
 	draPlugin     pluginHelper
 	driverName    string
@@ -112,6 +118,10 @@ type NetworkDriver struct {
 	rdmaSharedMode bool
 	podConfigStore *PodConfigStore
 	dbPath         string // path for persistent bbolt database; empty means in-memory
+
+	// kubeletRootDir is the kubelet data directory (its --root-dir). Set when the
+	// kubelet runs with a non-default --root-dir.
+	kubeletRootDir string
 
 	clock clock.WithTicker // Injectable clock for testing
 }
@@ -165,16 +175,22 @@ func Start(ctx context.Context, driverName string, kubeClient kubernetes.Interfa
 	}
 	plugin.podConfigStore = store
 
-	driverPluginPath := filepath.Join(kubeletPluginPath, driverName)
+	driverPluginPath := filepath.Join(plugin.kubeletRootDir, "plugins", driverName)
 	err = os.MkdirAll(driverPluginPath, 0750)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin path %s: %v", driverPluginPath, err)
 	}
 
+	// Derive the registration and plugin data directories from the kubelet root
+	// dir so they are correct when the kubelet uses a non-default --root-dir. At
+	// the default this matches the kubeletplugin defaults, so existing deployments
+	// are unaffected.
 	kubeletOpts := []kubeletplugin.Option{
 		kubeletplugin.DriverName(driverName),
 		kubeletplugin.NodeName(nodeName),
 		kubeletplugin.KubeClient(kubeClient),
+		kubeletplugin.RegistrarDirectoryPath(filepath.Join(plugin.kubeletRootDir, "plugins_registry")),
+		kubeletplugin.PluginDataDirectoryPath(driverPluginPath),
 	}
 	d, err := kubeletplugin.Start(ctx, plugin, kubeletOpts...)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

On a node whose kubelet runs with a non-default `--root-dir`, `dranet` crash-loops and never registers: the kubelet plugin-watcher only watches `<root-dir>/plugins_registry`, but the driver creates its registrar socket under the hardcoded `/var/lib/kubelet/plugins_registry` (the `kubeletplugin` default), so registration times out with `context deadline exceeded`.

This adds a single `--kubelet-root-dir` flag (default `/var/lib/kubelet`) and a matching `kubeletRootDir` Helm value. The driver derives its registration directory (`<root>/plugins_registry`) and plugin data directory (`<root>/plugins/<driver>`) from it and passes them to the `kubeletplugin` `RegistrarDirectoryPath` / `PluginDataDirectoryPath` options. The chart uses the same value for the flag and for the plugin `hostPath` and `mountPath`, so the path is identical inside and outside the container, which the `kubeletplugin` options require: "This path must be the same inside and outside of the driver's container." At the default, rendered output and behavior are unchanged.

Verified on a live cluster (kubelet `--root-dir=/mnt/fast/k8s/kubelet`, v1.36.1): without the flag the DaemonSet CrashLoops with `context deadline exceeded`; with `--kubelet-root-dir=/mnt/fast/k8s/kubelet` the driver registers within a few seconds and publishes its `dra.net` ResourceSlice, with the registration socket under `<root>/plugins_registry` and `dra.sock` under `<root>/plugins/dra.net`. `go build ./...`, `CGO_ENABLED=1 go test -race` on the touched packages, `golangci-lint run` (v2.9.0), and `helm lint --strict` all pass; `helm template` at the default renders the current `/var/lib/kubelet` paths unchanged.

#### Which issue(s) this PR fixes

Fixes #250

#### Special notes for your reviewer

Per your suggestion this is a single `--kubelet-root-dir` flag rather than two separate directory flags, matching the Helm value and the kubelet's own `--root-dir`. The static `install.yaml` variants still target the default layout; I am happy to regenerate them to match if you would like.

```release-note
dranet: add a `--kubelet-root-dir` flag and a `kubeletRootDir` Helm value so the driver can run on clusters where the kubelet uses a non-default `--root-dir`.
```
