### PR TITLE
chore: add OWNERS for helm chart and OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  # -----------------------------------------------------------
+  # OWNERS_ALIASES for deployments/helm/dranet
+  # -----------------------------------------------------------
+  dranet-helm-approvers:
+    - fmuyassarov

--- a/deployments/helm/dranet/OWNERS
+++ b/deployments/helm/dranet/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - dranet-helm-approvers
+


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Add OWNERS file for deployments/helm/dranet/ so PRs touching only the Helm chart can be approved by its owners independently of the root OWNERS file.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```