### PR TITLE
apis: reject routes and rules that mix IPv4 and IPv6 in validation

### DIFF
--- a/pkg/apis/validation.go
+++ b/pkg/apis/validation.go
@@ -202,16 +202,29 @@ func validateVRFConfig(cfg *VRFConfig, fieldPath string) (allErrors []error) {
 	return allErrors
 }
 
+// sameIPFamily reports whether a and b are both IPv4 or both IPv6.
+func sameIPFamily(a, b net.IP) bool {
+	return (a.To4() != nil) == (b.To4() != nil)
+}
+
 // validateRoutes validates a slice of RouteConfig.
 func validateRoutes(routes []RouteConfig, fieldPath string) (allErrors []error) {
 	for i, route := range routes {
 		currentFieldPath := fmt.Sprintf("%s[%d]", fieldPath, i)
 
+		// dstIP is retained so the gateway and source can be checked against the
+		// destination's IP family. The kernel (via netlink RouteAdd) rejects a
+		// route whose gateway or source is a different family than the destination,
+		// so validation rejects the mismatch here rather than letting it fail at
+		// apply time.
+		var dstIP net.IP
 		if route.Destination == "" {
 			allErrors = append(allErrors, fmt.Errorf("%s.destination: cannot be empty", currentFieldPath))
 		} else {
-			if _, _, err := net.ParseCIDR(route.Destination); err != nil {
+			if ip, _, err := net.ParseCIDR(route.Destination); err != nil {
 				allErrors = append(allErrors, fmt.Errorf("%s.destination: invalid CIDR format '%s' (host routes use /32 or /128)", currentFieldPath, route.Destination))
+			} else {
+				dstIP = ip
 			}
 		}
 
@@ -224,16 +237,22 @@ func validateRoutes(routes []RouteConfig, fieldPath string) (allErrors []error) 
 		}
 
 		if route.Gateway != "" {
-			if net.ParseIP(route.Gateway) == nil {
+			gwIP := net.ParseIP(route.Gateway)
+			if gwIP == nil {
 				allErrors = append(allErrors, fmt.Errorf("%s.gateway: invalid IP address format '%s'", currentFieldPath, route.Gateway))
+			} else if dstIP != nil && !sameIPFamily(dstIP, gwIP) {
+				allErrors = append(allErrors, fmt.Errorf("%s.gateway: '%s' must be the same IP family as destination '%s'", currentFieldPath, route.Gateway, route.Destination))
 			}
 		} else if !scopeIsLink { // Gateway is required if scope is Universe
 			allErrors = append(allErrors, fmt.Errorf("%s.gateway: must be specified for Universe scope routes", currentFieldPath))
 		}
 
 		if route.Source != "" {
-			if net.ParseIP(route.Source) == nil {
+			srcIP := net.ParseIP(route.Source)
+			if srcIP == nil {
 				allErrors = append(allErrors, fmt.Errorf("%s.source: invalid IP address format '%s'", currentFieldPath, route.Source))
+			} else if dstIP != nil && !sameIPFamily(dstIP, srcIP) {
+				allErrors = append(allErrors, fmt.Errorf("%s.source: '%s' must be the same IP family as destination '%s'", currentFieldPath, route.Source, route.Destination))
 			}
 		}
 
@@ -257,16 +276,28 @@ func validateRules(rules []RuleConfig, fieldPath string) (allErrors []error) {
 			allErrors = append(allErrors, fmt.Errorf("%s.table: must be a non-negative integer, got %d", currentFieldPath, rule.Table))
 		}
 
+		var srcIP, dstIP net.IP
 		if rule.Source != "" {
-			if _, _, err := net.ParseCIDR(rule.Source); err != nil {
+			if ip, _, err := net.ParseCIDR(rule.Source); err != nil {
 				allErrors = append(allErrors, fmt.Errorf("%s.source: invalid CIDR format '%s'", currentFieldPath, rule.Source))
+			} else {
+				srcIP = ip
 			}
 		}
 
 		if rule.Destination != "" {
-			if _, _, err := net.ParseCIDR(rule.Destination); err != nil {
+			if ip, _, err := net.ParseCIDR(rule.Destination); err != nil {
 				allErrors = append(allErrors, fmt.Errorf("%s.destination: invalid CIDR format '%s'", currentFieldPath, rule.Destination))
+			} else {
+				dstIP = ip
 			}
+		}
+
+		// The kernel (via netlink RuleAdd) rejects a rule whose source and
+		// destination are different IP families, so reject it here rather than
+		// letting it fail at apply time.
+		if srcIP != nil && dstIP != nil && !sameIPFamily(srcIP, dstIP) {
+			allErrors = append(allErrors, fmt.Errorf("%s: source '%s' and destination '%s' must be the same IP family", currentFieldPath, rule.Source, rule.Destination))
 		}
 	}
 	return allErrors

--- a/pkg/apis/validation_test.go
+++ b/pkg/apis/validation_test.go
@@ -433,6 +433,39 @@ func TestValidateRoutes(t *testing.T) {
 			expectErr: true,
 			errCount:  1,
 		},
+		{
+			name:      "valid IPv6 route with IPv6 gateway",
+			routes:    []RouteConfig{{Destination: "2001:db8:1::/64", Gateway: "2001:db8::1", Scope: scopeUniverse}},
+			fieldPath: "routes",
+			expectErr: false,
+		},
+		{
+			name:      "valid route with matching gateway and source",
+			routes:    []RouteConfig{{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Source: "192.168.1.2", Scope: scopeUniverse}},
+			fieldPath: "routes",
+			expectErr: false,
+		},
+		{
+			name:      "gateway family mismatch (IPv4 destination, IPv6 gateway)",
+			routes:    []RouteConfig{{Destination: "10.0.0.0/8", Gateway: "2001:db8::1", Scope: scopeUniverse}},
+			fieldPath: "routes",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "gateway family mismatch (IPv6 destination, IPv4 gateway)",
+			routes:    []RouteConfig{{Destination: "2001:db8::/64", Gateway: "192.168.1.1", Scope: scopeUniverse}},
+			fieldPath: "routes",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "source family mismatch (IPv4 destination, IPv6 source)",
+			routes:    []RouteConfig{{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Source: "2001:db8::2"}},
+			fieldPath: "routes",
+			expectErr: true,
+			errCount:  1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -505,6 +538,19 @@ func TestValidateRules(t *testing.T) {
 		{
 			name:      "invalid destination CIDR",
 			rules:     []RuleConfig{{Destination: "invalid-cidr"}},
+			fieldPath: "rules",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "valid rule with matching IPv6 source and destination",
+			rules:     []RuleConfig{{Source: "2001:db8::/64", Destination: "2001:db8:1::/64", Table: 100}},
+			fieldPath: "rules",
+			expectErr: false,
+		},
+		{
+			name:      "source and destination family mismatch",
+			rules:     []RuleConfig{{Source: "10.0.0.0/8", Destination: "2001:db8::/32", Table: 100}},
 			fieldPath: "rules",
 			expectErr: true,
 			errCount:  1,

--- a/pkg/apis/validation_test.go
+++ b/pkg/apis/validation_test.go
@@ -434,13 +434,13 @@ func TestValidateRoutes(t *testing.T) {
 			errCount:  1,
 		},
 		{
-			name:      "valid IPv6 route with IPv6 gateway",
+			name:      "valid IPv6 route with gateway matching the destination IP family",
 			routes:    []RouteConfig{{Destination: "2001:db8:1::/64", Gateway: "2001:db8::1", Scope: scopeUniverse}},
 			fieldPath: "routes",
 			expectErr: false,
 		},
 		{
-			name:      "valid route with matching gateway and source",
+			name:      "valid IPv4 route with gateway and source matching the destination IP family",
 			routes:    []RouteConfig{{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Source: "192.168.1.2", Scope: scopeUniverse}},
 			fieldPath: "routes",
 			expectErr: false,
@@ -543,7 +543,7 @@ func TestValidateRules(t *testing.T) {
 			errCount:  1,
 		},
 		{
-			name:      "valid rule with matching IPv6 source and destination",
+			name:      "valid IPv6 rule with matching source and destination IP family",
 			rules:     []RuleConfig{{Source: "2001:db8::/64", Destination: "2001:db8:1::/64", Table: 100}},
 			fieldPath: "rules",
 			expectErr: false,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`validateRoutes` checks the gateway and source with `net.ParseIP` (which accepts any family regardless of the destination), and `validateRules` checks source and destination independently. Neither checks that the IP families are consistent, but the apply path (netlink `RouteAdd` / `RuleAdd`) rejects a family mismatch unconditionally. So a route with an IPv4 destination and an IPv6 gateway, or a rule whose source and destination are different families, passes validation and then fails at Prepare time with no hint that the family is the cause.

This checks IP-family consistency in `validateRoutes` (gateway and source vs destination) and `validateRules` (source vs destination), so validation rejects what the kernel would reject. It follows the same "make validation match the apply path" direction as #247, which tightened route destinations.

Verified with a differential harness (apply each config against a real interface in a netns): the three mismatch cases below passed `ValidateConfig` and failed netlink before this change, and are rejected by validation after it. Unit tests cover both the rejected mismatches and the valid same-family cases.

#### Which issue(s) this PR is related to

Fixes #253

#### Special notes for reviewers

`sameIPFamily` uses `To4()`, matching how `netlink` determines family (an IPv4-mapped IPv6 address is treated as IPv4 by both), so validation and apply stay in agreement. The route destination stays CIDR-only per #247; the change only retains the parsed destination IP to compare families.

#### Release note

```release-note
Route and rule network configs that mix IPv4 and IPv6 (e.g. an IPv4 destination with an IPv6 gateway) are now rejected during validation instead of failing later when the configuration is applied.
```
