### PR TITLE
apis: deduplicate merged routes by destination and table

### DIFF
--- a/pkg/apis/config_merge.go
+++ b/pkg/apis/config_merge.go
@@ -49,7 +49,9 @@ func MergeNetworkConfig(user, cloud *NetworkConfig) *NetworkConfig {
 	// For addresses, we just unique them.
 	merged.Interface.Addresses = deduplicateStrings(merged.Interface.Addresses)
 
-	// For Routes, deduplicate by destination (user wins, which were appended last, so we iterate backwards).
+	// For Routes, deduplicate by destination and table (user wins, which were appended last, so we
+	// iterate backwards). Routes to the same destination in different tables are distinct entries
+	// (policy routing) and are all kept.
 	merged.Routes = deduplicateRoutes(merged.Routes)
 	merged.Neighbors = deduplicateNeighbors(merged.Neighbors)
 
@@ -70,12 +72,18 @@ func deduplicateStrings(s []string) []string {
 }
 
 func deduplicateRoutes(routes []RouteConfig) []RouteConfig {
-	seen := make(map[string]bool)
+	// A route is identified by its destination and table: the same destination in
+	// different tables is a distinct route (policy routing) and must be kept.
+	type routeKey struct {
+		destination string
+		table       int
+	}
+	seen := make(map[routeKey]bool)
 	var res []RouteConfig
 	for i := len(routes) - 1; i >= 0; i-- {
-		dest := routes[i].Destination
-		if !seen[dest] {
-			seen[dest] = true
+		key := routeKey{destination: routes[i].Destination, table: routes[i].Table}
+		if !seen[key] {
+			seen[key] = true
 			res = append([]RouteConfig{routes[i]}, res...)
 		}
 	}

--- a/pkg/apis/config_merge_test.go
+++ b/pkg/apis/config_merge_test.go
@@ -131,7 +131,7 @@ func TestMergeNetworkConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "same destination in different tables is kept (policy routing)",
+			name: "same destination in different tables is kept across user and cloud (policy routing)",
 			user: &NetworkConfig{
 				Routes: []RouteConfig{
 					{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Table: 100},
@@ -141,11 +141,15 @@ func TestMergeNetworkConfig(t *testing.T) {
 			cloud: &NetworkConfig{
 				Routes: []RouteConfig{
 					{Destination: "0.0.0.0/0", Gateway: "192.168.1.254"},
+					// Same destination as the user routes but a distinct table:
+					// this cloud route must be preserved, not deduplicated away.
+					{Destination: "10.0.0.0/8", Gateway: "192.168.1.254", Table: 300},
 				},
 			},
 			want: &NetworkConfig{
 				Routes: []RouteConfig{
 					{Destination: "0.0.0.0/0", Gateway: "192.168.1.254"},
+					{Destination: "10.0.0.0/8", Gateway: "192.168.1.254", Table: 300},
 					{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Table: 100},
 					{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Table: 200},
 				},

--- a/pkg/apis/config_merge_test.go
+++ b/pkg/apis/config_merge_test.go
@@ -130,6 +130,45 @@ func TestMergeNetworkConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "same destination in different tables is kept (policy routing)",
+			user: &NetworkConfig{
+				Routes: []RouteConfig{
+					{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Table: 100},
+					{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Table: 200},
+				},
+			},
+			cloud: &NetworkConfig{
+				Routes: []RouteConfig{
+					{Destination: "0.0.0.0/0", Gateway: "192.168.1.254"},
+				},
+			},
+			want: &NetworkConfig{
+				Routes: []RouteConfig{
+					{Destination: "0.0.0.0/0", Gateway: "192.168.1.254"},
+					{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Table: 100},
+					{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Table: 200},
+				},
+			},
+		},
+		{
+			name: "same destination and table resolves to user (override preserved)",
+			user: &NetworkConfig{
+				Routes: []RouteConfig{
+					{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Table: 100},
+				},
+			},
+			cloud: &NetworkConfig{
+				Routes: []RouteConfig{
+					{Destination: "10.0.0.0/8", Gateway: "192.168.1.254", Table: 100},
+				},
+			},
+			want: &NetworkConfig{
+				Routes: []RouteConfig{
+					{Destination: "10.0.0.0/8", Gateway: "192.168.1.1", Table: 100},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`MergeNetworkConfig` deduplicated the merged routes by destination only, so a config with the same destination in two routing tables (policy routing) lost one route after being merged with a cloud provider config. `deduplicateRoutes` keyed the `seen` set on `route.Destination` alone, ignoring `Table`.

This keys the deduplication on destination and table, so routes to the same destination in different tables are all kept, while a route that collides on both destination and table still resolves in favor of the user config (the existing "user wins" behavior).

Only the cloud/webhook merge path is affected; the user-only path returns early without deduplication.

#### Which issue(s) this PR is related to

Fixes #255

#### Special notes for reviewers

Neighbors are left unchanged: a neighbor maps an IP to a single MAC, so deduplicating by destination is correct there. Tests cover both the multi-table case (all kept) and the same-destination-and-table case (user still wins).

#### Release note

```release-note
Merging a network config with a cloud provider config no longer drops routes that share a destination but use different routing tables.
```
