### PR TITLE
feat: publish rdmaDevice for netdev-linked RoCE/IB VFs

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -483,15 +483,13 @@ func (db *DB) addRDMAAttributes(devices []resourceapi.Device) []resourceapi.Devi
 	for i := range devices {
 		isRDMA := false
 		if ifName := devices[i].Attributes[apis.AttrInterfaceName].StringValue; ifName != nil && *ifName != "" {
-			// Try rdmamap library first
-			isRDMA = rdmamap.IsRDmaDeviceForNetdevice(*ifName)
-
-			// Fallback to sysfs check if rdmamap fails. This is particularly
-			// needed for InfiniBand interfaces where rdmamap has a bug comparing
-			// against node GUID instead of port GUID:
-			// https://github.com/Mellanox/rdmamap/issues/15
-			if !isRDMA {
-				isRDMA = isRdmaDeviceInSysfs(*ifName)
+			// Netdev-linked device (RoCE or IPoIB): if AttrRDMADevice was already
+			// set, trust it; otherwise resolve and publish the kernel RDMA link name.
+			if rdmaDevAttr, ok := devices[i].Attributes[apis.AttrRDMADevice]; ok && rdmaDevAttr.StringValue != nil && *rdmaDevAttr.StringValue != "" {
+				isRDMA = true
+			} else if rdmaDevName, err := GetRdmaDevice(*ifName); err == nil && rdmaDevName != "" {
+				isRDMA = true
+				devices[i].Attributes[apis.AttrRDMADevice] = resourceapi.DeviceAttribute{StringValue: ptr.To(rdmaDevName)}
 			}
 		} else if pciAddr := devices[i].Attributes[apis.AttrPCIAddress].StringValue; pciAddr != nil && *pciAddr != "" {
 			// IB-only device: has RDMA capability but no netdev interface.

--- a/pkg/inventory/db_test.go
+++ b/pkg/inventory/db_test.go
@@ -676,4 +676,51 @@ func TestAddRDMAAttributesStandalone(t *testing.T) {
 			t.Errorf("AttrRDMADevice = %v, want erdma_0 (should not be overwritten)", v)
 		}
 	})
+
+	t.Run("netdev-linked device uses existing AttrRDMADevice without lookup", func(t *testing.T) {
+		// A value already resolved elsewhere must be preserved: add*Attributes
+		// only fills missing attributes.
+		ifName := "dranettest1"
+		devices := []resourceapi.Device{
+			{
+				Name: ifName,
+				Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					apis.AttrInterfaceName: {StringValue: ptr.To(ifName)},
+					apis.AttrRDMADevice:    {StringValue: ptr.To("bnxt_re12")},
+				},
+			},
+		}
+		db := &DB{}
+		result := db.addRDMAAttributes(devices)
+
+		if v, ok := result[0].Attributes[apis.AttrRDMA]; !ok || v.BoolValue == nil || !*v.BoolValue {
+			t.Errorf("AttrRDMA = %v, want true", v)
+		}
+		if v, ok := result[0].Attributes[apis.AttrRDMADevice]; !ok || v.StringValue == nil || *v.StringValue != "bnxt_re12" {
+			t.Errorf("AttrRDMADevice = %v, want bnxt_re12 (should not be overwritten)", v)
+		}
+	})
+
+	t.Run("netdev without RDMA device is rdma=false", func(t *testing.T) {
+		// A name that will not resolve via rdmamap or sysfs.
+		ifName := "dranet-nonexistent-iface"
+		devices := []resourceapi.Device{
+			{
+				Name: ifName,
+				Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					apis.AttrInterfaceName: {StringValue: ptr.To(ifName)},
+					apis.AttrPCIAddress:    {StringValue: ptr.To("0000:1c:00.0")},
+				},
+			},
+		}
+		db := &DB{}
+		result := db.addRDMAAttributes(devices)
+
+		if v, ok := result[0].Attributes[apis.AttrRDMA]; !ok || v.BoolValue == nil || *v.BoolValue {
+			t.Errorf("AttrRDMA = %v, want false", v)
+		}
+		if _, ok := result[0].Attributes[apis.AttrRDMADevice]; ok {
+			t.Errorf("AttrRDMADevice should not be set for a non-RDMA netdev")
+		}
+	})
 }

--- a/pkg/inventory/sysfs.go
+++ b/pkg/inventory/sysfs.go
@@ -185,27 +185,6 @@ func getRdmaDeviceFromSysfs(basePath, ifName string) (string, error) {
 	return "", fmt.Errorf("no RDMA device found for %s", ifName)
 }
 
-// isRdmaDeviceInSysfs checks if a network interface has RDMA capability by
-// examining the sysfs infiniband directory. This serves as a workaround for
-// cases where the rdmamap library fails to detect RDMA devices, particularly
-// for InfiniBand interfaces where the library incorrectly compares against the
-// node GUID instead of the port GUID.
-//
-// The function checks /sys/class/net/{ifname}/device/infiniband/ for any RDMA
-// device entries. If the directory exists and contains at least one entry, the
-// interface is considered RDMA-capable.
-func isRdmaDeviceInSysfs(ifName string) bool {
-	// Check if the infiniband directory exists under the device
-	rdmaName, err := getRdmaDeviceFromSysfs(sysnetPath, ifName)
-	if err != nil {
-		klog.V(4).Infof("No RDMA device found for interface %s via sysfs: %v", ifName, err)
-		return false
-	}
-
-	klog.V(4).Infof("Interface %s is RDMA-capable with device %s", ifName, rdmaName)
-	return true
-}
-
 // pciAddress BDF Notation
 // [domain:]bus:device.function
 // https://wiki.xenproject.org/wiki/Bus:Device.Function_(BDF)_Notation


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

RDMA-capable SR-IOV VFs with an active netdev (e.g. Broadcom `bnxt_re*`
backing RoCE VFs) were advertised on the ResourceSlice with `dra.net/rdma=true`
but **without** `dra.net/rdmaDevice` — only the IB-only / netdev-absent PCI
branch set that attribute. As a result the kernel RDMA link name was not
discoverable from the inventory for the most common RoCE case.

This PR publishes `dra.net/rdmaDevice` (the kernel RDMA link name, e.g.
`bnxt_re12`, `mlx5_0`) for netdev-linked RoCE/IB devices too.

Per review feedback, the resolution stays in `addRDMAAttributes`: its `netdev`
branch trusts an existing `rdmaDevice` value (same pattern as the PCI branch),
otherwise resolves the kernel RDMA link name via `GetRdmaDevice(ifName)` and
fills the attribute. The `rdma=true/false` bool is derived from a successful
resolution, which consolidates RDMA detection into a single path and removes
the now-unused `isRdmaDeviceInSysfs` helper (its sysfs fallback already lives
in `GetRdmaDevice`).

Adds unit coverage for the netdev-linked attribute path (preserve an existing
value, and the non-RDMA case). Sysfs resolution itself is already covered by
`TestGetRdmaDeviceFromSysfs`.

> **Note:** an earlier revision of this PR also added an opt-in
> `--inject-rdma-env` flag that injected `UCX_NET_DEVICES` into containers. That
> has been dropped per review — env injection is application-specific (NCCL uses
> `NCCL_IB_HCA_NAME`, etc.), doesn't scale to every RDMA library, and can be
> silently overridden at runtime. Publishing `rdmaDevice` on the ResourceSlice
> lets applications set whatever env their stack needs.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Broadcom/Mellanox RoCE SR-IOV VFs with an active netdev now publish the `dra.net/rdmaDevice` attribute (the kernel RDMA link name, e.g. `bnxt_re12`) on their ResourceSlice, previously set only for IB-only devices.
```