### PR TITLE
Update DeviceIdentifiers.Name to use interfaceName

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -532,14 +532,19 @@ func (db *DB) getProviderAttributes(device *resourceapi.Device, instance cloudpr
 		return nil
 	}
 
-	id := cloudprovider.DeviceIdentifiers{
-		Name: device.Name,
+	id := cloudprovider.DeviceIdentifiers{}
+	if ifaceNameAttr, ok := device.Attributes[apis.AttrInterfaceName]; ok && ifaceNameAttr.StringValue != nil {
+		id.Name = *ifaceNameAttr.StringValue
 	}
 	if macAttr, ok := device.Attributes[apis.AttrMac]; ok && macAttr.StringValue != nil {
 		id.MAC = *macAttr.StringValue
 	}
 	if pciAttr, ok := device.Attributes[apis.AttrPCIAddress]; ok && pciAttr.StringValue != nil {
 		id.PCIAddress = *pciAttr.StringValue
+	}
+	if id.Name == "" && id.MAC == "" && id.PCIAddress == "" {
+		klog.Warningf("device %s has no identifiers, cannot get provider attributes.", device.Name)
+		return nil
 	}
 
 	return instance.GetDeviceAttributes(id)

--- a/pkg/inventory/db_test.go
+++ b/pkg/inventory/db_test.go
@@ -471,11 +471,13 @@ type mockCloudInstance struct {
 }
 
 func (m *mockCloudInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
-	// For testing, we primarily look up by MAC if present, similar to the GCE implementation for now
+	// Look up by MAC if present, otherwise fall back to the (interface) name.
 	if id.MAC != "" {
 		return m.deviceAttributes[id.MAC]
 	}
-	// We could extend this to look up by Name or PCIAddress if tests require it
+	if id.Name != "" {
+		return m.deviceAttributes[id.Name]
+	}
 	return nil
 }
 
@@ -499,6 +501,12 @@ func TestGetProviderAttributes(t *testing.T) {
 		{
 			name:     "nil device",
 			device:   nil,
+			instance: &mockCloudInstance{},
+			want:     nil,
+		},
+		{
+			name:     "device with no identifiers",
+			device:   &resourceapi.Device{},
 			instance: &mockCloudInstance{},
 			want:     nil,
 		},
@@ -538,6 +546,29 @@ func TestGetProviderAttributes(t *testing.T) {
 			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 				gce.AttrGCENetworkName: {StringValue: ptr.To("test-network")},
 				gce.AttrGCEMachineType: {StringValue: ptr.To("machine-type-a")},
+			},
+		},
+		{
+			// The interface name (from the ifName attribute) must reach
+			// GetDeviceAttributes, not the DRA device name. They differ when the
+			// interface name is not a DNS-1123 label (e.g. it has capital letters),
+			// so the device name is a normalized "net-<hash>".
+			name: "interface name is passed, not the normalized device name",
+			device: &resourceapi.Device{
+				Name: "net-mr2w23lzkjqws3bq", // normalized iface name
+				Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					apis.AttrInterfaceName: {StringValue: ptr.To("enP22s22f0np0")},
+				},
+			},
+			instance: &mockCloudInstance{
+				deviceAttributes: map[string]map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"enP22s22f0np0": {
+						gce.AttrGCENetworkName: {StringValue: ptr.To("test-network")},
+					},
+				},
+			},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				gce.AttrGCENetworkName: {StringValue: ptr.To("test-network")},
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
device.Name is normalized and coming from PCIAddress or netlink interface name. PCI address is already a part of DeviceIdentifiers, so there is no use in adding its normalized version.
For interfaceName, if the original string is already a valid DNS-1123 label, it's returned as is. Otherwise, it's encoded using Base32, prefixed with NormalizedPrefix, and returned. The means, e.g. if an interfaceName has a capital letter, DeviceIdentifiers.Name will be something like net-mr2w23lzkjqws3bq instead of an actual interface name.

Since device.Name in general is not a hardware identifier, replacing it with the actual ifaceName to avoid getting no useful IDs for non-PCI devices.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
I guess since we haven't had a release with providers yet, it is not a braking change?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```