### PR TITLE
Update Helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,5 +131,3 @@ kind-image: image-build
 
 # The main release target, which pushes all images and helm charts.
 release: image-push helm-push
-
-

--- a/deployments/helm/dranet/README.md
+++ b/deployments/helm/dranet/README.md
@@ -25,20 +25,37 @@ The following table lists the configurable parameters and their default values:
 | `podLabels` | Labels to add to pods | `{}` |
 | `logVerbosity` | Log verbosity level | `4` |
 | `metricsPort` | Port for the metrics/healthz server and readiness probe | binary default: `9177` |
-| `metricsPath` | HTTP path for the readiness probe | `/healthz` |
+| `metricsPath` | HTTP path for the startup and readiness probes | `/healthz` |
 | `tolerations` | Pod tolerations | `[{operator: Exists, effect: NoSchedule}]` |
 | `resources.requests.cpu` | CPU resource request | `100m` |
 | `resources.requests.memory` | Memory resource request | `50Mi` |
 | `resources.limits.cpu` | CPU resource limit | `""` (not set) |
 | `resources.limits.memory` | Memory resource limit | `""` (not set) |
+| `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
 | `args.filter` | CEL expression to filter network interface attributes | see binary default |
+| `args.dbPath` | Persistent bbolt database path; set to `""` to use in-memory state | binary default: `/var/run/dranet/dranet.db` |
 | `args.inventoryMinPollInterval` | Minimum interval between two consecutive inventory polls | binary default: `2s` |
 | `args.inventoryMaxPollInterval` | Maximum interval between two consecutive inventory polls | binary default: `1m` |
 | `args.inventoryPollBurst` | Number of inventory polls that can be run in a burst | binary default: `5` |
 | `args.moveIBInterfaces` | If true, InfiniBand (IPoIB) interfaces are moved into the pod network namespace | binary default: `true` |
-| `args.cloudProviderHint` | Hint for the cloud provider plugin (`GCE`, `AZURE`, `OKE`, `NONE`); auto-detected if unset | binary default: `""` |
+| `args.cloudProviderHint` | Hint for the cloud provider plugin (`GCE`, `AZURE`, `OKE`, `AWS`, `ALIBABA`, `webhook`, `NONE`); auto-detected if unset | binary default: `""` |
+| `args.profileProvider` | Provider for user profile configuration (`cloud`, `webhook`, `none`) | binary default: `cloud` |
+| `args.webhookURL` | HTTP, HTTPS, or Unix socket URL; required when either provider uses `webhook` | binary default: `""` |
+| `args.featureGates` | Comma-separated feature gate settings in `key=value` format | binary default: `""` |
 
 > **Note:** All `args.*` fields are optional. When omitted, the flag is not passed to the binary and the binary's built-in default applies.
+
+The chart mounts `/var/run/dranet` from the host so the default database survives
+DRANET pod replacement. Custom database paths must be placed under that directory
+to remain persistent. Set `args.dbPath` to an empty string to use in-memory state.
+
+When upgrading from a chart that does not mount `/var/run/dranet`, the existing
+container-local database cannot be copied into the new host path. Before the first
+upgrade that enables this mount, stop workloads that use DRANET-managed devices.
+After the upgrade, restart those workloads.
+
+When `args.profileProvider` or `args.cloudProviderHint` is `webhook`, set
+`args.webhookURL` to the webhook endpoint.
 
 Parameters can be set at install time using `--set` or a custom values file:
 

--- a/deployments/helm/dranet/templates/daemonset.yaml
+++ b/deployments/helm/dranet/templates/daemonset.yaml
@@ -57,6 +57,9 @@ spec:
             {{- if .Values.args.filter }}
             - {{ print "--filter=" .Values.args.filter | quote }}
             {{- end }}
+            {{- if (hasKey .Values.args "dbPath") }}
+            - {{ printf "--db-path=%s" .Values.args.dbPath | quote }}
+            {{- end }}
             {{- if .Values.args.inventoryMinPollInterval }}
             - --inventory-min-poll-interval={{ .Values.args.inventoryMinPollInterval }}
             {{- end }}
@@ -71,6 +74,15 @@ spec:
             {{- end }}
             {{- if .Values.args.cloudProviderHint }}
             - --cloud-provider-hint={{ .Values.args.cloudProviderHint }}
+            {{- end }}
+            {{- if (hasKey .Values.args "profileProvider") }}
+            - {{ printf "--profile-provider=%s" .Values.args.profileProvider | quote }}
+            {{- end }}
+            {{- if (hasKey .Values.args "webhookURL") }}
+            - {{ printf "--webhook-url=%s" .Values.args.webhookURL | quote }}
+            {{- end }}
+            {{- if (hasKey .Values.args "featureGates") }}
+            - {{ printf "--feature-gates=%s" .Values.args.featureGates | quote }}
             {{- end }}
             - --kubelet-root-dir={{ .Values.kubeletRootDir }}
           env:
@@ -113,6 +125,8 @@ spec:
             - name: bpf-programs
               mountPath: /sys/fs/bpf
               mountPropagation: HostToContainer
+            - name: dranet-run
+              mountPath: /var/run/dranet
       volumes:
         - name: device-plugin
           hostPath:
@@ -132,3 +146,7 @@ spec:
         - name: bpf-programs
           hostPath:
             path: /sys/fs/bpf
+        - name: dranet-run
+          hostPath:
+            path: /var/run/dranet
+            type: DirectoryOrCreate

--- a/deployments/helm/dranet/templates/serviceaccount.yaml
+++ b/deployments/helm/dranet/templates/serviceaccount.yaml
@@ -3,5 +3,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "dranet.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "dranet.labels" . | nindent 4 }}

--- a/deployments/helm/dranet/values.schema.json
+++ b/deployments/helm/dranet/values.schema.json
@@ -67,6 +67,20 @@
           "type": "string",
           "description": "CEL expression to filter network interface attributes"
         },
+        "dbPath": {
+          "type": "string",
+          "description": "Persistent bbolt database path under /var/run/dranet; set to an empty string to use in-memory state",
+          "allOf": [
+            {
+              "pattern": "^$|^/var/run/dranet/.+"
+            },
+            {
+              "not": {
+                "pattern": "(^|/)\\.\\.?(/|$)"
+              }
+            }
+          ]
+        },
         "inventoryMinPollInterval": {
           "type": "string",
           "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
@@ -86,10 +100,61 @@
         },
         "cloudProviderHint": {
           "type": "string",
-          "enum": ["GCE", "AZURE", "OKE", "AWS", "ALIBABA", "NONE"],
+          "enum": ["GCE", "AZURE", "OKE", "AWS", "ALIBABA", "webhook", "NONE"],
           "description": "Hint for the cloud provider plugin; auto-detected if unset"
+        },
+        "profileProvider": {
+          "type": "string",
+          "enum": ["cloud", "webhook", "none"],
+          "description": "Provider for user profile configuration"
+        },
+        "webhookURL": {
+          "type": "string",
+          "description": "HTTP, HTTPS, or Unix socket URL for cloud and profile webhook providers"
+        },
+        "featureGates": {
+          "type": "string",
+          "description": "Comma-separated feature gate settings in key=value format"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "cloudProviderHint": {
+                "const": "webhook"
+              }
+            },
+            "required": ["cloudProviderHint"]
+          },
+          "then": {
+            "properties": {
+              "webhookURL": {
+                "minLength": 1
+              }
+            },
+            "required": ["webhookURL"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "profileProvider": {
+                "const": "webhook"
+              }
+            },
+            "required": ["profileProvider"]
+          },
+          "then": {
+            "properties": {
+              "webhookURL": {
+                "minLength": 1
+              }
+            },
+            "required": ["webhookURL"]
+          }
+        }
+      ]
     },
     "nodeSelector": {
       "type": "object"
@@ -119,7 +184,10 @@
       "additionalProperties": false,
       "properties": {
         "annotations": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     }

--- a/deployments/helm/dranet/values.yaml
+++ b/deployments/helm/dranet/values.yaml
@@ -19,14 +19,18 @@ logVerbosity: 4
 metricsPort: ~
 metricsPath: /healthz
 
-# dranet daemon arguments — omit any field to use the binary's built-in default
+# DRANET daemon arguments. Omit a field to use the binary's built-in default.
 args: {}
 #  filter: '!("dra.net/type" in attributes) || attributes["dra.net/type"].StringValue  != "veth"'
+#  dbPath: "/var/run/dranet/dranet.db"
 #  inventoryMinPollInterval: "2s"
 #  inventoryMaxPollInterval: "1m"
 #  inventoryPollBurst: 5
 #  moveIBInterfaces: true
 #  cloudProviderHint: ""
+#  profileProvider: "cloud"
+#  webhookURL: ""
+#  featureGates: ""
 
 # kubeletRootDir is the kubelet data directory (its --root-dir). The driver's
 # registration socket lives under <kubeletRootDir>/plugins_registry (which the


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`install.yaml` mounts `/var/run/dranet` from the host. The Helm chart did not include this mount.

The Dranet binary stores its bbolt database at `/var/run/dranet/dranet.db` by default. Without the host mount, the database stays in the container file system. Kubernetes removes this database when it replaces the Dranet pod.

Dranet stores prepared pod device configuration in this database. The NRI hooks need this configuration after a Dranet restart.

This PR mounts the host `/var/run/dranet` directory in the Dranet container. The host path uses `DirectoryOrCreate`. The database now survives Dranet pod replacement.

This PR also:

- Adds Helm values for `dbPath`, `profileProvider`, `webhookURL`, and `featureGates`.
- Adds `webhook` as a cloud provider hint.
- Lets users add service account annotations.
- Validates webhook settings and database paths.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

All new argument values are optional. If users omit a value, the Dranet binary uses its built in default.

Set `args.dbPath` to an empty string to disable database persistence. If users set a custom database path, they must place it under `/var/run/dranet`.

An older chart stores the database in the container file system. Dranet cannot move this database to the new host mount during an upgrade.

Before the first upgrade, stop pods that use Dranet managed devices. Wait for the pods to terminate. Then upgrade the Helm release.

#### Does this PR introduce a user-facing change?

```release-note
Updated the Helm chart to preserve pod device configuration across pod replacements. Action required: before you upgrade from a chart that does not mount `/var/run/dranet`, stop pods that use devices managed by Dranet.
```