### PR TITLE
cloudbuild: migrate gcloud to registry.k8s.io registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_32
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
+- name: registry.k8s.io/releng/gcb-docker-gcloud:v20260806
   entrypoint: make
   env:
   - REGISTRY=gcr.io/k8s-staging-networking


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Migrate to the `registry.k8s.io/releng/gcb-docker-gcloud` as part of the general move mentioned here https://github.com/kubernetes/k8s.io/issues/9599

xref: https://github.com/kubernetes/k8s.io/issues/9599 and https://github.com/kubernetes/release/pull/4481

The image has now been moved and more info can be found [here](https://github.com/kubernetes/test-infra/tree/master/images/gcb-docker-gcloud)

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Latest slack thread on this move: https://kubernetes.slack.com/archives/CCK68P2Q2/p1786028781579649

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```