### PR TITLE
Add extraVolumes and extraVolumeMounts to the Helm chart

### DIFF
--- a/deployments/helm/dranet/README.md
+++ b/deployments/helm/dranet/README.md
@@ -32,6 +32,8 @@ The following table lists the configurable parameters and their default values:
 | `resources.limits.cpu` | CPU resource limit | `""` (not set) |
 | `resources.limits.memory` | Memory resource limit | `""` (not set) |
 | `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
+| `extraVolumes` | Extra volumes, added after the built-in volumes | `[]` |
+| `extraVolumeMounts` | Extra volume mounts for the dranet container, added after the built-in mounts | `[]` |
 | `args.filter` | CEL expression to filter network interface attributes | see binary default |
 | `args.dbPath` | Persistent bbolt database path; set to `""` to use in-memory state | binary default: `/var/run/dranet/dranet.db` |
 | `args.inventoryMinPollInterval` | Minimum interval between two consecutive inventory polls | binary default: `2s` |
@@ -56,6 +58,23 @@ After the upgrade, restart those workloads.
 
 When `args.profileProvider` or `args.cloudProviderHint` is `webhook`, set
 `args.webhookURL` to the webhook endpoint.
+
+`extraVolumes` and `extraVolumeMounts` add entries after the built-in volumes
+and container mounts. The chart does not change the entries. Do not reuse the
+built-in volume names. Example, a host configuration directory mounted
+read-only:
+
+```yaml
+extraVolumes:
+  - name: host-config
+    hostPath:
+      path: /etc/host-config
+      type: DirectoryOrCreate
+extraVolumeMounts:
+  - name: host-config
+    mountPath: /etc/host-config
+    readOnly: true
+```
 
 Parameters can be set at install time using `--set` or a custom values file:
 

--- a/deployments/helm/dranet/templates/daemonset.yaml
+++ b/deployments/helm/dranet/templates/daemonset.yaml
@@ -127,6 +127,9 @@ spec:
               mountPropagation: HostToContainer
             - name: dranet-run
               mountPath: /var/run/dranet
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: device-plugin
           hostPath:
@@ -150,3 +153,6 @@ spec:
           hostPath:
             path: /var/run/dranet
             type: DirectoryOrCreate
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/deployments/helm/dranet/values.schema.json
+++ b/deployments/helm/dranet/values.schema.json
@@ -156,6 +156,36 @@
         }
       ]
     },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mountPath": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["name", "mountPath"]
+      }
+    },
     "nodeSelector": {
       "type": "object"
     },

--- a/deployments/helm/dranet/values.yaml
+++ b/deployments/helm/dranet/values.yaml
@@ -40,6 +40,19 @@ args: {}
 # kubelet --root-dir on clusters that relocate it; the default suits a standard kubelet.
 kubeletRootDir: /var/lib/kubelet
 
+# Extra volumes and volume mounts for the dranet container.
+# The chart adds them after the built-in ones without changes.
+# Do not reuse the built-in volume names.
+extraVolumes: []
+#  - name: host-config
+#    hostPath:
+#      path: /etc/host-config
+#      type: DirectoryOrCreate
+extraVolumeMounts: []
+#  - name: host-config
+#    mountPath: /etc/host-config
+#    readOnly: true
+
 nodeSelector: {}
 
 affinity: {}

--- a/install.yaml
+++ b/install.yaml
@@ -155,6 +155,11 @@ spec:
           mountPropagation: HostToContainer
         - name: dranet-run
           mountPath: /var/run/dranet
+        # Additional host mounts go here. Example, a host configuration
+        # directory mounted read-only (pair with the volume below):
+        # - name: host-config
+        #   mountPath: /etc/host-config
+        #   readOnly: true
       volumes:
       - name: device-plugin
         hostPath:
@@ -178,4 +183,10 @@ spec:
         hostPath:
           path: /var/run/dranet
           type: DirectoryOrCreate
+      # Additional host volumes go here. Example, a host configuration
+      # directory (pair with the mount above):
+      # - name: host-config
+      #   hostPath:
+      #     path: /etc/host-config
+      #     type: DirectoryOrCreate
 ---


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds `extraVolumes` and `extraVolumeMounts` values to the Helm chart. Some deployments need host files mounted into the driver, for example a cloud provider agent configuration directory. The chart adds the entries after the built-in volumes without changes. The values schema requires `name` and `mountPath`. The Helm CI workflow renders the new path and checks the output. `install.yaml` gets a commented example.

#### Which issue(s) this PR is related to:
None

#### Does this PR introduce a user-facing change?
```release-note
Add `extraVolumes` and `extraVolumeMounts` values to the Helm chart for mounting extra host paths.
```