### PR TITLE
Download bpftool to a file before extracting in e2e tests

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -57,6 +57,26 @@ jobs:
           # Clean
           sudo rm -rf "${TMP_DIR}"
 
+      - name: Fetch bpftool
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Authenticated download: anonymous release fetches from shared
+          # runner addresses are unreliable and have failed the bpf tests.
+          # The release CDN can still return errors, so retry a few times.
+          for attempt in 1 2 3; do
+            if gh release download v7.5.0 -R libbpf/bpftool -p 'bpftool-v7.5.0-amd64.tar.gz' -O "$RUNNER_TEMP/bpftool.tgz" --clobber; then
+              break
+            fi
+            if [ "$attempt" = "3" ]; then
+              echo "bpftool download failed after 3 attempts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          tar -xzf "$RUNNER_TEMP/bpftool.tgz" -C tests
+          chmod +x tests/bpftool
+
       - name: Setup Bats and bats libs
         id: setup-bats
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ go.work
 
 /bin
 .vscode
+tests/bpftool

--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -91,10 +91,26 @@ setup_bpf_device() {
   docker exec "$CLUSTER_NAME"-worker2 bash -c "ip link set up dev dummy0"
 }
 
+# ensure_bpftool puts a bpftool binary at $BATS_TEST_DIRNAME/bpftool.
+# CI downloads it authenticated before the tests run, because anonymous
+# release downloads from shared runner addresses are unreliable. The
+# download here covers local runs.
+ensure_bpftool() {
+  if [[ -x "$BATS_TEST_DIRNAME/bpftool" ]]; then
+    return
+  fi
+  local tmp
+  tmp=$(mktemp -d)
+  curl -fL --connect-timeout 5 --retry 5 --retry-all-errors -o "$tmp/bpftool.tgz" https://github.com/libbpf/bpftool/releases/download/v7.5.0/bpftool-v7.5.0-amd64.tar.gz
+  tar -xzf "$tmp/bpftool.tgz" -C "$BATS_TEST_DIRNAME"
+  chmod +x "$BATS_TEST_DIRNAME/bpftool"
+  rm -rf "$tmp"
+}
+
 setup_tcx_filter() {
   docker cp "$BATS_TEST_DIRNAME"/dummy_bpf_tcx.o "$CLUSTER_NAME"-worker2:/dummy_bpf_tcx.o
-  docker exec "$CLUSTER_NAME"-worker2 bash -c "curl --connect-timeout 5 --retry 3 -L https://github.com/libbpf/bpftool/releases/download/v7.5.0/bpftool-v7.5.0-amd64.tar.gz | tar -xz"
-  docker exec "$CLUSTER_NAME"-worker2 bash -c "chmod +x bpftool"
+  ensure_bpftool
+  docker cp "$BATS_TEST_DIRNAME"/bpftool "$CLUSTER_NAME"-worker2:/bpftool
   docker exec "$CLUSTER_NAME"-worker2 bash -c "./bpftool prog load dummy_bpf_tcx.o /sys/fs/bpf/dummy_prog_tcx"
   docker exec "$CLUSTER_NAME"-worker2 bash -c "./bpftool net attach tcx_ingress pinned /sys/fs/bpf/dummy_prog_tcx dev dummy0"
   # We update the interface to trigger a DRANET driver notification, which
@@ -332,10 +348,11 @@ wait_for_ready_pods() {
   kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/resourceclaim_disable_ebpf.yaml
   kubectl wait --for=condition=ready pod/pod-ebpf --timeout=120s
 
-  run kubectl exec pod-ebpf -- ash -c "curl --connect-timeout 5 --retry 3 -L https://github.com/libbpf/bpftool/releases/download/v7.5.0/bpftool-v7.5.0-amd64.tar.gz | tar -xz && chmod +x bpftool"
+  ensure_bpftool
+  run kubectl cp "$BATS_TEST_DIRNAME"/bpftool pod-ebpf:/bpftool
   assert_success
 
-  run kubectl exec pod-ebpf -- ash -c "./bpftool net show dev dummy0"
+  run kubectl exec pod-ebpf -- ash -c "chmod +x /bpftool && /bpftool net show dev dummy0"
   assert_success
   refute_output --partial "tcx/ingress handle_ingress prog_id"
   refute_output --partial "dummy_bpf.o:[classifier]"


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
The e2e tests downloaded bpftool anonymously inside the cluster in two places: on the kind node and in the test pod. These downloads fail when the GitHub release CDN returns errors to shared runner addresses, which failed the bpf tests (for example [this run](https://github.com/kubernetes-sigs/dranet/actions/runs/31631649160/job/94231624860)). An earlier version of this PR kept the in-cluster downloads and added retries, and CI [failed the same way](https://github.com/kubernetes-sigs/dranet/actions/runs/31634819312/job/94242344393).

This version removes the in-cluster downloads. The bats workflow downloads bpftool once on the runner with an authenticated `gh release download`, with retries and `--clobber`. The tests copy the binary into the kind node with `docker cp` and into the test pod with `kubectl cp`. Local runs without a token keep a curl fallback. Verified green on a fork run of the bats workflow.

#### Which issue(s) this PR is related to:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```