### PR TITLE
Add PCI mocking capability to exercise PCI in E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,18 @@ build-dranet:
 build-dranetctl:
 	go build -v -o "$(OUT_DIR)/dranetctl" ./cmd/dranetctl
 
+build-test-tools: build-mockpci
+
+build-mockpci:
+	go build -v -o "$(OUT_DIR)/mockpci" ./cmd/mockpci
+
 clean:
 	rm -rf "$(OUT_DIR)/"
 
 test:
 	CGO_ENABLED=1 go test -v -race -count 1 ./...
 
-e2e-test:
+e2e-test: build-test-tools
 	bats --verbose-run tests/
 
 # code linters

--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -68,6 +68,7 @@ var (
 	profileProvider   string
 	webhookURL        string
 	featureGates      string
+	sysfsRoot         string
 
 	kubeletRootDir string
 
@@ -89,6 +90,7 @@ func init() {
 	flag.StringVar(&webhookURL, "webhook-url", "", "URL for the webhook provider (required if using webhook for either provider)")
 	flag.StringVar(&kubeletRootDir, "kubelet-root-dir", "/var/lib/kubelet", "The kubelet data directory (its --root-dir). The driver's registration socket lives under <dir>/plugins_registry and its dra.sock under <dir>/plugins/<driver-name>. Set this to match the kubelet --root-dir on clusters that relocate it.")
 	flag.StringVar(&featureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
+	flag.StringVar(&sysfsRoot, "dranet-experimental-sysfs-root", "/sys", "The path to the sysfs root directory. Set to a custom path during testing or device simulation.")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: dranet [options]\n\n")
@@ -197,7 +199,13 @@ func main() {
 		klog.Fatalf("failed to setup providers: %v", err)
 	}
 
+	// DRANET_EXPERIMENTAL_SYSFS_ROOT The path to the sysfs root directory. Set to a custom path during testing or device simulation.
+	if envRoot := os.Getenv("DRANET_EXPERIMENTAL_SYSFS_ROOT"); envRoot != "" && sysfsRoot == "/sys" {
+		sysfsRoot = envRoot
+	}
+
 	optsDb := []inventory.Option{
+		inventory.WithSysfsRoot(sysfsRoot),
 		inventory.WithRateLimiter(rate.NewLimiter(rate.Every(minPollInterval), pollBurst)),
 		inventory.WithMaxPollInterval(maxPollInterval),
 		inventory.WithMoveIBInterfaces(moveIBInterfaces),

--- a/cmd/mockpci/main.go
+++ b/cmd/mockpci/main.go
@@ -1,0 +1,120 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/dranet/pkg/mockpci"
+)
+
+var (
+	devCfg mockpci.DeviceConfig
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "mockpci",
+	Short: "mockpci manages synthetic in-kernel and PCIe network devices for testing",
+}
+
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add and configure a mocked PCIe network device",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := mockpci.Create(devCfg); err != nil {
+			return fmt.Errorf("failed creating mock PCI device: %w", err)
+		}
+		fmt.Printf("Successfully created mock PCI device %s at %s\n", devCfg.Name, devCfg.PCIAddress)
+		return nil
+	},
+}
+
+var delCmd = &cobra.Command{
+	Use:   "del [name or BDF]",
+	Short: "Delete a mocked PCIe network device",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := mockpci.Delete(args[0]); err != nil {
+			return fmt.Errorf("failed deleting mock PCI device %s: %w", args[0], err)
+		}
+		fmt.Printf("Successfully deleted mock PCI device %s\n", args[0])
+		return nil
+	},
+}
+
+var cleanupCmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Clean up all mocked PCIe devices and unmount sysfs tmpfs layers",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := mockpci.Cleanup(); err != nil {
+			return fmt.Errorf("failed during cleanup: %w", err)
+		}
+		fmt.Println("Successfully cleaned up all mock PCI devices and unmounted sysfs layers")
+		return nil
+	},
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all active mocked PCIe devices",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		devs, err := mockpci.List()
+		if err != nil {
+			return err
+		}
+		data, err := json.MarshalIndent(devs, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	},
+}
+
+func init() {
+	addCmd.Flags().StringVarP(&devCfg.Name, "name", "n", "", "Interface name (e.g. mlx0)")
+	addCmd.Flags().StringVar(&devCfg.PCIAddress, "pci-address", "", "PCI BDF address (e.g. 0000:00:10.0)")
+	addCmd.Flags().StringVarP(&devCfg.VendorID, "vendor", "v", "0x15b3", "PCI Vendor ID in hex")
+	addCmd.Flags().StringVarP(&devCfg.DeviceID, "device", "d", "0x101b", "PCI Device ID in hex")
+	addCmd.Flags().StringVar(&devCfg.Class, "class", "0x020000", "PCI Class in hex")
+	addCmd.Flags().StringVar(&devCfg.Driver, "driver", "mlx5_core", "PCI kernel driver name")
+	addCmd.Flags().IntVar(&devCfg.NUMANode, "numa-node", 0, "NUMA node ID")
+	addCmd.Flags().StringVar(&devCfg.MAC, "mac", "", "Hardware MAC address")
+	addCmd.Flags().IntVar(&devCfg.MTU, "mtu", 1500, "Interface MTU")
+	addCmd.Flags().StringVar(&devCfg.RDMADevice, "rdma-device", "", "RDMA device name (e.g. mlx5_0 or rxe0)")
+	addCmd.Flags().IntVar(&devCfg.SRIOVTotalVFs, "sriov-total-vfs", 0, "SR-IOV total VFs supported (for PF)")
+	addCmd.Flags().IntVar(&devCfg.SRIOVNumVFs, "sriov-num-vfs", 0, "SR-IOV active VFs (for PF)")
+	addCmd.Flags().StringVar(&devCfg.PhysFn, "physfn", "", "BDF of Physical Function (if this device is a VF)")
+
+	if err := addCmd.MarkFlagRequired("name"); err != nil {
+		panic(err)
+	}
+	if err := addCmd.MarkFlagRequired("pci-address"); err != nil {
+		panic(err)
+	}
+
+	rootCmd.AddCommand(addCmd, delCmd, cleanupCmd, listCmd)
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -105,9 +105,18 @@ type DB struct {
 	// deviceAttributeMachineModifiers is used to redirect the upstream
 	// topology helpers to a synthetic sysfs in unit tests.
 	deviceAttributeMachineModifiers []deviceattribute.MachineModifier
+
+	sysfsRoot string
 }
 
 type Option func(*DB)
+
+func WithSysfsRoot(root string) Option {
+	return func(db *DB) {
+		db.sysfsRoot = root
+		SetSysfsRoot(root)
+	}
+}
 
 func WithRateLimiter(limiter *rate.Limiter) Option {
 	return func(db *DB) {
@@ -150,7 +159,7 @@ func WithProfileProvider(profProv cloudprovider.ProfileProvider) Option {
 
 func New(opts ...Option) *DB {
 	db := &DB{
-
+		sysfsRoot:         sysfsRoot,
 		deviceStore:       map[string]resourceapi.Device{},
 		deviceConfigStore: map[string]*apis.NetworkConfig{},
 		rateLimiter:       rate.NewLimiter(rate.Every(defaultMinPollInterval), defaultPollBurst),
@@ -212,9 +221,18 @@ func (db *DB) Run(ctx context.Context) error {
 // It discovers PCI, network, and RDMA devices, adds cloud attributes,
 // filters out default interfaces, and updates the device store.
 func (db *DB) scan() []resourceapi.Device {
-	pciInfo, err := ghw.PCI(
-		ghw.WithDisableTools(),
-	)
+	var pciInfo *ghw.PCIInfo
+	var err error
+	if chroot := ghwChroot(); chroot != "" {
+		pciInfo, err = ghw.PCI(
+			ghw.WithDisableTools(),
+			ghw.WithChroot(chroot),
+		)
+	} else {
+		pciInfo, err = ghw.PCI(
+			ghw.WithDisableTools(),
+		)
+	}
 	if err != nil {
 		klog.Errorf("Could not get PCI devices: %v", err)
 	}

--- a/pkg/inventory/sysfs.go
+++ b/pkg/inventory/sysfs.go
@@ -30,35 +30,99 @@ import (
 )
 
 const (
+	defaultSysfsRoot         = "/sys"
+	defaultSysnetPath        = "/sys/class/net/"
+	defaultSysdevPath        = "/sys/devices"
+	defaultSysInfinibandPath = "/sys/class/infiniband/"
+)
+
+var (
+	sysfsRoot = defaultSysfsRoot
+
 	// https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-net
-	sysnetPath = "/sys/class/net/"
+	sysnetPath = defaultSysnetPath
+
 	// Each of the entries in this directory is a symbolic link
 	// representing one of the real or virtual networking devices
 	// that are visible in the network namespace of the process
 	// that is accessing the directory.  Each of these symbolic
 	// links refers to entries in the /sys/devices directory.
 	// https://man7.org/linux/man-pages/man5/sysfs.5.html
-	sysdevPath = "/sys/devices"
+	sysdevPath = defaultSysdevPath
+
+	sysInfinibandPath = defaultSysInfinibandPath
 )
+
+// SetSysfsRoot configures the base path for sysfs discovery.
+func SetSysfsRoot(root string) {
+	if root == "" {
+		root = defaultSysfsRoot
+	}
+	sysfsRoot = root
+	sysnetPath = filepath.Join(root, "class", "net")
+	sysdevPath = filepath.Join(root, "devices")
+	sysInfinibandPath = filepath.Join(root, "class", "infiniband")
+}
+
+// SysfsRoot returns the configured sysfs root path.
+func SysfsRoot() string {
+	return sysfsRoot
+}
 
 // pciAddressRegex is used to identify a PCI address within a string.
 // It matches patterns like "0000:00:04.0" or "00:04.0".
 var pciAddressRegex = regexp.MustCompile(`^(?:([0-9a-fA-F]{4}):)?([0-9a-fA-F]{2}):([0-9a-fA-F]{2})\.([0-9a-fA-F])$`)
 
-func realpath(ifName string, syspath string) string {
+// isCustomSysfsRoot returns true if a custom non-default sysfs root is configured
+// (e.g. during testing or device simulation).
+func isCustomSysfsRoot() bool {
+	clean := filepath.Clean(sysfsRoot)
+	return clean != "" && clean != "." && clean != defaultSysfsRoot && clean != "/"
+}
+
+// ghwChroot returns the chroot path for ghw discovery, or an empty string if using the default host sysfs.
+func ghwChroot() string {
+	if !isCustomSysfsRoot() {
+		return ""
+	}
+	clean := filepath.Clean(sysfsRoot)
+	return strings.TrimSuffix(clean, "/sys")
+}
+
+func resolveLinkTarget(linkPath, target string) string {
+	if filepath.IsAbs(target) {
+		return target
+	}
+	return filepath.Join(filepath.Dir(linkPath), target)
+}
+
+// readNetSysfsLink reads a network interface symlink from the configured syspath.
+// When a custom sysfs root is configured (e.g. in tests), if the interface is not
+// found in the custom path, it falls back to the real host /sys/class/net so real
+// host and pod interfaces (like veth pairs) remain fully discoverable.
+func readNetSysfsLink(ifName, syspath string) (string, error) {
 	linkPath := filepath.Join(syspath, ifName)
 	dst, err := os.Readlink(linkPath)
+	if err == nil {
+		return resolveLinkTarget(linkPath, dst), nil
+	}
+
+	if isCustomSysfsRoot() {
+		realLinkPath := filepath.Join(defaultSysnetPath, ifName)
+		if dstReal, errReal := os.Readlink(realLinkPath); errReal == nil {
+			return resolveLinkTarget(realLinkPath, dstReal), nil
+		}
+	}
+
+	return "", err
+}
+
+func realpath(ifName string, syspath string) string {
+	target, err := readNetSysfsLink(ifName, syspath)
 	if err != nil {
-		klog.Error(err, "unexpected error trying reading link", "link", linkPath)
+		klog.Error(err, "unexpected error trying reading link", "link", filepath.Join(syspath, ifName))
 	}
-	var dstAbs string
-	if filepath.IsAbs(dst) {
-		dstAbs = dst
-	} else {
-		// Symlink targets are relative to the directory containing the link.
-		dstAbs = filepath.Join(filepath.Dir(linkPath), dst)
-	}
-	return dstAbs
+	return target
 }
 
 // $ realpath /sys/class/net/cilium_host
@@ -66,7 +130,13 @@ func realpath(ifName string, syspath string) string {
 func isVirtual(name string, syspath string) bool {
 	sysfsPath := realpath(name, syspath)
 	prefix := filepath.Join(sysdevPath, "virtual")
-	return strings.HasPrefix(sysfsPath, prefix)
+	if strings.HasPrefix(sysfsPath, prefix) {
+		return true
+	}
+	if isCustomSysfsRoot() && strings.HasPrefix(sysfsPath, filepath.Join(defaultSysdevPath, "virtual")) {
+		return true
+	}
+	return false
 }
 
 func sriovTotalVFs(name string) int {
@@ -272,8 +342,6 @@ func pciAddressForNetInterface(ifName string) (*pciAddress, error) {
 	}
 	return address, nil
 }
-
-const sysInfinibandPath = "/sys/class/infiniband/"
 
 // pciAddressForRDMADevice resolves the PCI address for an RDMA device by
 // following the sysfs device symlink. For example, /sys/class/infiniband/erdma_0/device

--- a/pkg/inventory/sysfs_test.go
+++ b/pkg/inventory/sysfs_test.go
@@ -462,3 +462,51 @@ func TestPCIAddressForRDMADevice(t *testing.T) {
 		}
 	})
 }
+
+func TestSysfsRootAndLinkFallback(t *testing.T) {
+	origRoot := SysfsRoot()
+	defer SetSysfsRoot(origRoot)
+
+	// 1. Default root
+	SetSysfsRoot("/sys")
+	if isCustomSysfsRoot() {
+		t.Errorf("isCustomSysfsRoot() = true for /sys, want false")
+	}
+	if chroot := ghwChroot(); chroot != "" {
+		t.Errorf("ghwChroot() = %q, want empty string", chroot)
+	}
+
+	// 2. Custom root
+	SetSysfsRoot("/var/run/dranet/sysfs/sys")
+	if !isCustomSysfsRoot() {
+		t.Errorf("isCustomSysfsRoot() = false for custom root, want true")
+	}
+	if chroot := ghwChroot(); chroot != "/var/run/dranet/sysfs" {
+		t.Errorf("ghwChroot() = %q, want %q", chroot, "/var/run/dranet/sysfs")
+	}
+
+	// 3. Create mock link under custom sysfs and test resolution
+	tempDir := t.TempDir()
+	customSys := filepath.Join(tempDir, "custom-sys")
+	SetSysfsRoot(customSys)
+
+	mockNetDir := filepath.Join(customSys, "class", "net")
+	if err := os.MkdirAll(mockNetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	targetDevice := filepath.Join(customSys, "devices", "pci0000:00", "0000:00:10.0", "net", "mlx0")
+	if err := os.MkdirAll(targetDevice, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(targetDevice, filepath.Join(mockNetDir, "mlx0")); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := readNetSysfsLink("mlx0", mockNetDir)
+	if err != nil {
+		t.Fatalf("readNetSysfsLink(mlx0) failed: %v", err)
+	}
+	if resolved != targetDevice {
+		t.Errorf("readNetSysfsLink(mlx0) = %q, want %q", resolved, targetDevice)
+	}
+}

--- a/pkg/mockpci/mockpci.go
+++ b/pkg/mockpci/mockpci.go
@@ -1,0 +1,465 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockpci
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	defaultMockPCIRoot = "/var/run/dranet/mock-pci"
+	stateFileName      = "state.json"
+	sysBusPCIDevices   = "/sys/bus/pci/devices"
+	sysClassNet        = "/sys/class/net"
+	savedPCIBusDir     = "/var/run/dranet/pci-bus-save"
+	savedNetDir        = "/var/run/dranet/net-save"
+)
+
+// DeviceConfig represents a synthetic PCI network device configuration.
+type DeviceConfig struct {
+	Name          string `json:"name"`
+	PCIAddress    string `json:"pciAddress"`
+	VendorID      string `json:"vendorId"`
+	DeviceID      string `json:"deviceId"`
+	Class         string `json:"class"`
+	Driver        string `json:"driver"`
+	NUMANode      int    `json:"numaNode"`
+	MAC           string `json:"mac,omitempty"`
+	MTU           int    `json:"mtu,omitempty"`
+	RDMADevice    string `json:"rdmaDevice,omitempty"`
+	SRIOVTotalVFs int    `json:"sriovTotalVFs,omitempty"`
+	SRIOVNumVFs   int    `json:"sriovNumVFs,omitempty"`
+	PhysFn        string `json:"physFn,omitempty"`
+}
+
+// ApplyDefaults populates default values for missing configuration fields.
+func ApplyDefaults(cfg *DeviceConfig) {
+	if cfg.VendorID == "" {
+		cfg.VendorID = "0x15b3"
+	}
+	if cfg.DeviceID == "" {
+		cfg.DeviceID = "0x101b"
+	}
+	if cfg.Class == "" {
+		cfg.Class = "0x020000"
+	}
+	if cfg.Driver == "" {
+		cfg.Driver = "mlx5_core"
+	}
+	if cfg.MTU == 0 {
+		cfg.MTU = 1500
+	}
+}
+
+// GenerateModalias creates a standard Linux kernel modalias string for a PCI device.
+func GenerateModalias(vendorID, deviceID, class string) string {
+	if vendorID == "" {
+		vendorID = "0x15b3"
+	}
+	if deviceID == "" {
+		deviceID = "0x101b"
+	}
+	if class == "" {
+		class = "0x020000"
+	}
+	vInt, _ := strconv.ParseUint(strings.TrimPrefix(vendorID, "0x"), 16, 64)
+	dInt, _ := strconv.ParseUint(strings.TrimPrefix(deviceID, "0x"), 16, 64)
+	cInt, _ := strconv.ParseUint(strings.TrimPrefix(class, "0x"), 16, 64)
+
+	baseClass := (cInt >> 16) & 0xff
+	subClass := (cInt >> 8) & 0xff
+	progIface := cInt & 0xff
+
+	return fmt.Sprintf("pci:v%08Xd%08Xsv%08Xsd00000001bc%02Xsc%02Xi%02X\n", vInt, dInt, vInt, baseClass, subClass, progIface)
+}
+
+func ensureSymlink(target, link string) error {
+	if err := os.Remove(link); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed removing existing link %s: %w", link, err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		return fmt.Errorf("failed creating symlink %s -> %s: %w", link, target, err)
+	}
+	return nil
+}
+
+// PopulateMockPCIDir creates the mock sysfs tree structure for a PCIe device.
+func PopulateMockPCIDir(cfg DeviceConfig, rootDir string) error {
+	ApplyDefaults(&cfg)
+	mockPCIDir := filepath.Join(rootDir, cfg.PCIAddress)
+	mockNetDir := filepath.Join(mockPCIDir, "net", cfg.Name)
+	if err := os.MkdirAll(mockNetDir, 0755); err != nil {
+		return fmt.Errorf("failed creating mock directory %s: %w", mockNetDir, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(mockPCIDir, "vendor"), []byte(cfg.VendorID+"\n"), 0644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(mockPCIDir, "device"), []byte(cfg.DeviceID+"\n"), 0644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(mockPCIDir, "subsystem_vendor"), []byte(cfg.VendorID+"\n"), 0644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(mockPCIDir, "subsystem_device"), []byte("0x0001\n"), 0644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(mockPCIDir, "class"), []byte(cfg.Class+"\n"), 0644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(mockPCIDir, "numa_node"), []byte(strconv.Itoa(cfg.NUMANode)+"\n"), 0644); err != nil {
+		return err
+	}
+
+	modalias := GenerateModalias(cfg.VendorID, cfg.DeviceID, cfg.Class)
+	if err := os.WriteFile(filepath.Join(mockPCIDir, "modalias"), []byte(modalias), 0644); err != nil {
+		return err
+	}
+
+	// Driver symlink
+	driverDir := filepath.Join(rootDir, "drivers", cfg.Driver)
+	if err := os.MkdirAll(driverDir, 0755); err != nil {
+		return fmt.Errorf("failed creating driver directory %s: %w", driverDir, err)
+	}
+	if err := ensureSymlink(driverDir, filepath.Join(mockPCIDir, "driver")); err != nil {
+		return err
+	}
+
+	// SR-IOV attributes if present
+	if cfg.SRIOVTotalVFs > 0 {
+		if err := os.WriteFile(filepath.Join(mockPCIDir, "sriov_totalvfs"), []byte(strconv.Itoa(cfg.SRIOVTotalVFs)+"\n"), 0644); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(mockPCIDir, "sriov_numvfs"), []byte(strconv.Itoa(cfg.SRIOVNumVFs)+"\n"), 0644); err != nil {
+			return err
+		}
+	}
+	if cfg.PhysFn != "" {
+		if err := ensureSymlink(filepath.Join(rootDir, cfg.PhysFn), filepath.Join(mockPCIDir, "physfn")); err != nil {
+			return err
+		}
+	}
+
+	// Net device link inside PCI directory
+	if err := ensureSymlink(mockPCIDir, filepath.Join(mockNetDir, "device")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// State stores active mocked PCI devices.
+type State struct {
+	Devices map[string]DeviceConfig `json:"devices"`
+}
+
+func loadState() (*State, error) {
+	statePath := filepath.Join(defaultMockPCIRoot, stateFileName)
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &State{Devices: make(map[string]DeviceConfig)}, nil
+		}
+		return nil, err
+	}
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	if state.Devices == nil {
+		state.Devices = make(map[string]DeviceConfig)
+	}
+	return &state, nil
+}
+
+func saveState(state *State) error {
+	if err := os.MkdirAll(defaultMockPCIRoot, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(defaultMockPCIRoot, stateFileName), data, 0644)
+}
+
+func isMountPoint(path string) bool {
+	data, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return false
+	}
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == path {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureTmpfsMount(target, backupDir string) error {
+	if isMountPoint(target) {
+		return nil
+	}
+
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(target)
+	if err == nil {
+		for _, entry := range entries {
+			src := filepath.Join(target, entry.Name())
+			linkDst, err := filepath.EvalSymlinks(src)
+			if err == nil {
+				if err := ensureSymlink(linkDst, filepath.Join(backupDir, entry.Name())); err != nil {
+					return fmt.Errorf("failed backing up symlink %s: %w", entry.Name(), err)
+				}
+			}
+		}
+	}
+
+	if err := unix.Mount("tmpfs", target, "tmpfs", 0, ""); err != nil {
+		return fmt.Errorf("failed mounting tmpfs over %s: %w", target, err)
+	}
+
+	backupEntries, err := os.ReadDir(backupDir)
+	if err == nil {
+		for _, entry := range backupEntries {
+			dst, err := os.Readlink(filepath.Join(backupDir, entry.Name()))
+			if err == nil {
+				if err := ensureSymlink(dst, filepath.Join(target, entry.Name())); err != nil {
+					return fmt.Errorf("failed restoring symlink %s: %w", entry.Name(), err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// Create sets up an in-kernel dummy network interface and links it into a mocked sysfs PCI hierarchy.
+func Create(cfg DeviceConfig) error {
+	if cfg.Name == "" {
+		return fmt.Errorf("device name is required")
+	}
+	if cfg.PCIAddress == "" {
+		return fmt.Errorf("pciAddress is required")
+	}
+	ApplyDefaults(&cfg)
+
+	// 1. Create in-kernel dummy network interface via Netlink
+	link, err := netlink.LinkByName(cfg.Name)
+	if err != nil {
+		dummy := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: cfg.Name,
+				MTU:  cfg.MTU,
+			},
+		}
+		if cfg.MAC != "" {
+			hwAddr, err := net.ParseMAC(cfg.MAC)
+			if err == nil {
+				dummy.LinkAttrs.HardwareAddr = hwAddr
+			}
+		}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("failed to add dummy interface %s: %w", cfg.Name, err)
+		}
+		link, err = netlink.LinkByName(cfg.Name)
+		if err != nil {
+			return fmt.Errorf("failed to get newly created interface %s: %w", cfg.Name, err)
+		}
+	}
+
+	// 2. Attach Soft-RoCE (rdma_rxe) if requested
+	if cfg.RDMADevice != "" {
+		_ = exec.Command("modprobe", "rdma_rxe").Run()
+		if out, err := exec.Command("rdma", "link", "add", cfg.RDMADevice, "type", "rxe", "netdev", cfg.Name).CombinedOutput(); err != nil {
+			return fmt.Errorf("failed adding rdma link %s: %s: %w", cfg.RDMADevice, strings.TrimSpace(string(out)), err)
+		}
+	}
+
+	// 3. Populate mock PCI directory
+	if err := PopulateMockPCIDir(cfg, defaultMockPCIRoot); err != nil {
+		return err
+	}
+	mockPCIDir := filepath.Join(defaultMockPCIRoot, cfg.PCIAddress)
+	mockNetDir := filepath.Join(mockPCIDir, "net", cfg.Name)
+
+	// 4. Mount tmpfs over /sys/bus/pci/devices and /sys/class/net
+	if err := ensureTmpfsMount(sysBusPCIDevices, savedPCIBusDir); err != nil {
+		return err
+	}
+	if err := ensureTmpfsMount(sysClassNet, savedNetDir); err != nil {
+		return err
+	}
+
+	// 5. Link into sysfs
+	if err := ensureSymlink(mockPCIDir, filepath.Join(sysBusPCIDevices, cfg.PCIAddress)); err != nil {
+		return err
+	}
+	if err := ensureSymlink(mockNetDir, filepath.Join(sysClassNet, cfg.Name)); err != nil {
+		return err
+	}
+
+	// 6. Trigger Netlink notification so dranet immediately scans the interface
+	if err := netlink.LinkSetDown(link); err != nil {
+		return fmt.Errorf("failed setting link %s down: %w", cfg.Name, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("failed setting link %s up: %w", cfg.Name, err)
+	}
+
+	// Save state
+	state, err := loadState()
+	if err != nil {
+		return fmt.Errorf("failed loading state: %w", err)
+	}
+	state.Devices[cfg.Name] = cfg
+	return saveState(state)
+}
+
+// Delete removes a single mocked device.
+func Delete(nameOrBDF string) error {
+	state, err := loadState()
+	if err != nil {
+		return err
+	}
+
+	var targetCfg *DeviceConfig
+	for name, dev := range state.Devices {
+		if name == nameOrBDF || dev.PCIAddress == nameOrBDF {
+			targetCfg = &dev
+			delete(state.Devices, name)
+			break
+		}
+	}
+
+	if targetCfg != nil {
+		// Remove RDMA link if attached
+		if targetCfg.RDMADevice != "" {
+			_ = exec.Command("rdma", "link", "del", targetCfg.RDMADevice).Run()
+		}
+
+		// Delete dummy interface
+		if link, err := netlink.LinkByName(targetCfg.Name); err == nil {
+			if err := netlink.LinkDel(link); err != nil {
+				return fmt.Errorf("failed deleting link %s: %w", targetCfg.Name, err)
+			}
+		}
+
+		// Remove sysfs links
+		if err := os.Remove(filepath.Join(sysBusPCIDevices, targetCfg.PCIAddress)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed removing %s from %s: %w", targetCfg.PCIAddress, sysBusPCIDevices, err)
+		}
+		if err := os.Remove(filepath.Join(sysClassNet, targetCfg.Name)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed removing %s from %s: %w", targetCfg.Name, sysClassNet, err)
+		}
+		if err := os.RemoveAll(filepath.Join(defaultMockPCIRoot, targetCfg.PCIAddress)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed removing mock PCI directory %s: %w", targetCfg.PCIAddress, err)
+		}
+	}
+
+	return saveState(state)
+}
+
+// Cleanup unmounts tmpfs layers and purges all mocked devices.
+func Cleanup() error {
+	var errs []error
+	state, err := loadState()
+	if err == nil {
+		for _, dev := range state.Devices {
+			if dev.RDMADevice != "" {
+				_ = exec.Command("rdma", "link", "del", dev.RDMADevice).Run()
+			}
+			if link, err := netlink.LinkByName(dev.Name); err == nil {
+				if err := netlink.LinkDel(link); err != nil {
+					errs = append(errs, fmt.Errorf("failed deleting link %s: %w", dev.Name, err))
+				}
+			}
+		}
+	}
+
+	// Clean up any other rdma links
+	out, err := exec.Command("rdma", "link", "show").Output()
+	if err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			parts := strings.Split(line, ":")
+			if len(parts) >= 2 {
+				rdmaDev := strings.TrimSpace(parts[1])
+				if rdmaDev != "" {
+					_ = exec.Command("rdma", "link", "del", rdmaDev).Run()
+				}
+			}
+		}
+	}
+
+	if isMountPoint(sysBusPCIDevices) {
+		if err := unix.Unmount(sysBusPCIDevices, unix.MNT_DETACH); err != nil {
+			errs = append(errs, fmt.Errorf("failed unmounting %s: %w", sysBusPCIDevices, err))
+		}
+	}
+	if isMountPoint(sysClassNet) {
+		if err := unix.Unmount(sysClassNet, unix.MNT_DETACH); err != nil {
+			errs = append(errs, fmt.Errorf("failed unmounting %s: %w", sysClassNet, err))
+		}
+	}
+
+	if err := os.RemoveAll(defaultMockPCIRoot); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("failed removing %s: %w", defaultMockPCIRoot, err))
+	}
+	if err := os.RemoveAll(savedPCIBusDir); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("failed removing %s: %w", savedPCIBusDir, err))
+	}
+	if err := os.RemoveAll(savedNetDir); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("failed removing %s: %w", savedNetDir, err))
+	}
+
+	if len(errs) > 0 {
+		var errMsgs []string
+		for _, e := range errs {
+			errMsgs = append(errMsgs, e.Error())
+		}
+		return fmt.Errorf("cleanup encountered errors:\n%s", strings.Join(errMsgs, "\n"))
+	}
+	return nil
+}
+
+// List returns all registered mock devices.
+func List() ([]DeviceConfig, error) {
+	state, err := loadState()
+	if err != nil {
+		return nil, err
+	}
+	devices := make([]DeviceConfig, 0, len(state.Devices))
+	for _, d := range state.Devices {
+		devices = append(devices, d)
+	}
+	return devices, nil
+}

--- a/pkg/mockpci/mockpci.go
+++ b/pkg/mockpci/mockpci.go
@@ -27,16 +27,13 @@ import (
 	"strings"
 
 	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 )
 
 var (
-	defaultMockPCIRoot = "/var/run/dranet/mock-pci"
-	stateFileName      = "state.json"
-	sysBusPCIDevices   = "/sys/bus/pci/devices"
-	sysClassNet        = "/sys/class/net"
-	savedPCIBusDir     = "/var/run/dranet/pci-bus-save"
-	savedNetDir        = "/var/run/dranet/net-save"
+	defaultMockSysfsRoot = "/var/run/dranet/sysfs"
+	stateFileName        = "state.json"
 )
 
 // DeviceConfig represents a synthetic PCI network device configuration.
@@ -76,7 +73,7 @@ func ApplyDefaults(cfg *DeviceConfig) {
 }
 
 // GenerateModalias creates a standard Linux kernel modalias string for a PCI device.
-func GenerateModalias(vendorID, deviceID, class string) string {
+func GenerateModalias(vendorID, deviceID, class string) (string, error) {
 	if vendorID == "" {
 		vendorID = "0x15b3"
 	}
@@ -86,15 +83,24 @@ func GenerateModalias(vendorID, deviceID, class string) string {
 	if class == "" {
 		class = "0x020000"
 	}
-	vInt, _ := strconv.ParseUint(strings.TrimPrefix(vendorID, "0x"), 16, 64)
-	dInt, _ := strconv.ParseUint(strings.TrimPrefix(deviceID, "0x"), 16, 64)
-	cInt, _ := strconv.ParseUint(strings.TrimPrefix(class, "0x"), 16, 64)
+	vInt, err := strconv.ParseUint(strings.TrimPrefix(vendorID, "0x"), 16, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid hex vendorID %q: %w", vendorID, err)
+	}
+	dInt, err := strconv.ParseUint(strings.TrimPrefix(deviceID, "0x"), 16, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid hex deviceID %q: %w", deviceID, err)
+	}
+	cInt, err := strconv.ParseUint(strings.TrimPrefix(class, "0x"), 16, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid hex class %q: %w", class, err)
+	}
 
 	baseClass := (cInt >> 16) & 0xff
 	subClass := (cInt >> 8) & 0xff
 	progIface := cInt & 0xff
 
-	return fmt.Sprintf("pci:v%08Xd%08Xsv%08Xsd00000001bc%02Xsc%02Xi%02X\n", vInt, dInt, vInt, baseClass, subClass, progIface)
+	return fmt.Sprintf("pci:v%08Xd%08Xsv%08Xsd00000001bc%02Xsc%02Xi%02X\n", vInt, dInt, vInt, baseClass, subClass, progIface), nil
 }
 
 func ensureSymlink(target, link string) error {
@@ -107,13 +113,26 @@ func ensureSymlink(target, link string) error {
 	return nil
 }
 
-// PopulateMockPCIDir creates the mock sysfs tree structure for a PCIe device.
+// PopulateMockPCIDir creates the mock sysfs tree structure for a PCIe device inside a shadow sysfs root.
 func PopulateMockPCIDir(cfg DeviceConfig, rootDir string) error {
 	ApplyDefaults(&cfg)
-	mockPCIDir := filepath.Join(rootDir, cfg.PCIAddress)
+
+	sysRoot := filepath.Join(rootDir, "sys")
+	busPCIDevices := filepath.Join(sysRoot, "bus", "pci", "devices")
+	busPCIDrivers := filepath.Join(sysRoot, "bus", "pci", "drivers")
+	classNet := filepath.Join(sysRoot, "class", "net")
+	devicesDir := filepath.Join(sysRoot, "devices", "pci0000:00")
+	mockPCIDir := filepath.Join(devicesDir, cfg.PCIAddress)
 	mockNetDir := filepath.Join(mockPCIDir, "net", cfg.Name)
+
 	if err := os.MkdirAll(mockNetDir, 0755); err != nil {
 		return fmt.Errorf("failed creating mock directory %s: %w", mockNetDir, err)
+	}
+	if err := os.MkdirAll(busPCIDevices, 0755); err != nil {
+		return fmt.Errorf("failed creating %s: %w", busPCIDevices, err)
+	}
+	if err := os.MkdirAll(classNet, 0755); err != nil {
+		return fmt.Errorf("failed creating %s: %w", classNet, err)
 	}
 
 	if err := os.WriteFile(filepath.Join(mockPCIDir, "vendor"), []byte(cfg.VendorID+"\n"), 0644); err != nil {
@@ -135,13 +154,16 @@ func PopulateMockPCIDir(cfg DeviceConfig, rootDir string) error {
 		return err
 	}
 
-	modalias := GenerateModalias(cfg.VendorID, cfg.DeviceID, cfg.Class)
+	modalias, err := GenerateModalias(cfg.VendorID, cfg.DeviceID, cfg.Class)
+	if err != nil {
+		return err
+	}
 	if err := os.WriteFile(filepath.Join(mockPCIDir, "modalias"), []byte(modalias), 0644); err != nil {
 		return err
 	}
 
 	// Driver symlink
-	driverDir := filepath.Join(rootDir, "drivers", cfg.Driver)
+	driverDir := filepath.Join(busPCIDrivers, cfg.Driver)
 	if err := os.MkdirAll(driverDir, 0755); err != nil {
 		return fmt.Errorf("failed creating driver directory %s: %w", driverDir, err)
 	}
@@ -159,14 +181,37 @@ func PopulateMockPCIDir(cfg DeviceConfig, rootDir string) error {
 		}
 	}
 	if cfg.PhysFn != "" {
-		if err := ensureSymlink(filepath.Join(rootDir, cfg.PhysFn), filepath.Join(mockPCIDir, "physfn")); err != nil {
+		if err := ensureSymlink(filepath.Join(devicesDir, cfg.PhysFn), filepath.Join(mockPCIDir, "physfn")); err != nil {
 			return err
 		}
 	}
 
-	// Net device link inside PCI directory
+	// Net device link inside PCI directory: mockPCIDir/net/<dev>/device -> mockPCIDir
 	if err := ensureSymlink(mockPCIDir, filepath.Join(mockNetDir, "device")); err != nil {
 		return err
+	}
+
+	// Symlink in bus/pci/devices/<PCIAddress> -> mockPCIDir
+	if err := ensureSymlink(mockPCIDir, filepath.Join(busPCIDevices, cfg.PCIAddress)); err != nil {
+		return err
+	}
+
+	// Symlink in class/net/<Name> -> mockNetDir
+	if err := ensureSymlink(mockNetDir, filepath.Join(classNet, cfg.Name)); err != nil {
+		return err
+	}
+
+	// Mirror existing real host PCI devices into shadow bus/pci/devices if present
+	if realEntries, err := os.ReadDir("/sys/bus/pci/devices"); err == nil {
+		for _, entry := range realEntries {
+			if entry.Name() != cfg.PCIAddress {
+				target := filepath.Join("/sys/bus/pci/devices", entry.Name())
+				link := filepath.Join(busPCIDevices, entry.Name())
+				if err := ensureSymlink(target, link); err != nil {
+					return fmt.Errorf("failed mirroring host PCI device %s: %w", entry.Name(), err)
+				}
+			}
+		}
 	}
 
 	return nil
@@ -178,7 +223,7 @@ type State struct {
 }
 
 func loadState() (*State, error) {
-	statePath := filepath.Join(defaultMockPCIRoot, stateFileName)
+	statePath := filepath.Join(defaultMockSysfsRoot, stateFileName)
 	data, err := os.ReadFile(statePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -197,73 +242,17 @@ func loadState() (*State, error) {
 }
 
 func saveState(state *State) error {
-	if err := os.MkdirAll(defaultMockPCIRoot, 0755); err != nil {
+	if err := os.MkdirAll(defaultMockSysfsRoot, 0755); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(defaultMockPCIRoot, stateFileName), data, 0644)
+	return os.WriteFile(filepath.Join(defaultMockSysfsRoot, stateFileName), data, 0644)
 }
 
-func isMountPoint(path string) bool {
-	data, err := os.ReadFile("/proc/mounts")
-	if err != nil {
-		return false
-	}
-	lines := strings.Split(string(data), "\n")
-	for _, line := range lines {
-		fields := strings.Fields(line)
-		if len(fields) >= 2 && fields[1] == path {
-			return true
-		}
-	}
-	return false
-}
-
-func ensureTmpfsMount(target, backupDir string) error {
-	if isMountPoint(target) {
-		return nil
-	}
-
-	if err := os.MkdirAll(backupDir, 0755); err != nil {
-		return err
-	}
-
-	entries, err := os.ReadDir(target)
-	if err == nil {
-		for _, entry := range entries {
-			src := filepath.Join(target, entry.Name())
-			linkDst, err := filepath.EvalSymlinks(src)
-			if err == nil {
-				if err := ensureSymlink(linkDst, filepath.Join(backupDir, entry.Name())); err != nil {
-					return fmt.Errorf("failed backing up symlink %s: %w", entry.Name(), err)
-				}
-			}
-		}
-	}
-
-	if err := unix.Mount("tmpfs", target, "tmpfs", 0, ""); err != nil {
-		return fmt.Errorf("failed mounting tmpfs over %s: %w", target, err)
-	}
-
-	backupEntries, err := os.ReadDir(backupDir)
-	if err == nil {
-		for _, entry := range backupEntries {
-			dst, err := os.Readlink(filepath.Join(backupDir, entry.Name()))
-			if err == nil {
-				if err := ensureSymlink(dst, filepath.Join(target, entry.Name())); err != nil {
-					return fmt.Errorf("failed restoring symlink %s: %w", entry.Name(), err)
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-// Create sets up an in-kernel dummy network interface and links it into a mocked sysfs PCI hierarchy.
+// Create sets up an in-kernel dummy network interface and registers it in the shadow sysfs hierarchy.
 func Create(cfg DeviceConfig) error {
 	if cfg.Name == "" {
 		return fmt.Errorf("device name is required")
@@ -274,7 +263,7 @@ func Create(cfg DeviceConfig) error {
 	ApplyDefaults(&cfg)
 
 	// 1. Create in-kernel dummy network interface via Netlink
-	link, err := netlink.LinkByName(cfg.Name)
+	link, err := nlwrap.LinkByName(cfg.Name)
 	if err != nil {
 		dummy := &netlink.Dummy{
 			LinkAttrs: netlink.LinkAttrs{
@@ -285,13 +274,13 @@ func Create(cfg DeviceConfig) error {
 		if cfg.MAC != "" {
 			hwAddr, err := net.ParseMAC(cfg.MAC)
 			if err == nil {
-				dummy.LinkAttrs.HardwareAddr = hwAddr
+				dummy.HardwareAddr = hwAddr
 			}
 		}
 		if err := netlink.LinkAdd(dummy); err != nil {
 			return fmt.Errorf("failed to add dummy interface %s: %w", cfg.Name, err)
 		}
-		link, err = netlink.LinkByName(cfg.Name)
+		link, err = nlwrap.LinkByName(cfg.Name)
 		if err != nil {
 			return fmt.Errorf("failed to get newly created interface %s: %w", cfg.Name, err)
 		}
@@ -299,36 +288,21 @@ func Create(cfg DeviceConfig) error {
 
 	// 2. Attach Soft-RoCE (rdma_rxe) if requested
 	if cfg.RDMADevice != "" {
-		_ = exec.Command("modprobe", "rdma_rxe").Run()
+		// modprobe may fail if running without CAP_SYS_MODULE, but the module may already be loaded in the kernel.
+		if out, err := exec.Command("modprobe", "rdma_rxe").CombinedOutput(); err != nil {
+			klog.V(4).Infof("modprobe rdma_rxe notice: %s (%v)", strings.TrimSpace(string(out)), err)
+		}
 		if out, err := exec.Command("rdma", "link", "add", cfg.RDMADevice, "type", "rxe", "netdev", cfg.Name).CombinedOutput(); err != nil {
 			return fmt.Errorf("failed adding rdma link %s: %s: %w", cfg.RDMADevice, strings.TrimSpace(string(out)), err)
 		}
 	}
 
-	// 3. Populate mock PCI directory
-	if err := PopulateMockPCIDir(cfg, defaultMockPCIRoot); err != nil {
-		return err
-	}
-	mockPCIDir := filepath.Join(defaultMockPCIRoot, cfg.PCIAddress)
-	mockNetDir := filepath.Join(mockPCIDir, "net", cfg.Name)
-
-	// 4. Mount tmpfs over /sys/bus/pci/devices and /sys/class/net
-	if err := ensureTmpfsMount(sysBusPCIDevices, savedPCIBusDir); err != nil {
-		return err
-	}
-	if err := ensureTmpfsMount(sysClassNet, savedNetDir); err != nil {
+	// 3. Populate shadow sysfs directory
+	if err := PopulateMockPCIDir(cfg, defaultMockSysfsRoot); err != nil {
 		return err
 	}
 
-	// 5. Link into sysfs
-	if err := ensureSymlink(mockPCIDir, filepath.Join(sysBusPCIDevices, cfg.PCIAddress)); err != nil {
-		return err
-	}
-	if err := ensureSymlink(mockNetDir, filepath.Join(sysClassNet, cfg.Name)); err != nil {
-		return err
-	}
-
-	// 6. Trigger Netlink notification so dranet immediately scans the interface
+	// 4. Trigger Netlink notification so dranet immediately scans the interface
 	if err := netlink.LinkSetDown(link); err != nil {
 		return fmt.Errorf("failed setting link %s down: %w", cfg.Name, err)
 	}
@@ -364,41 +338,50 @@ func Delete(nameOrBDF string) error {
 	if targetCfg != nil {
 		// Remove RDMA link if attached
 		if targetCfg.RDMADevice != "" {
-			_ = exec.Command("rdma", "link", "del", targetCfg.RDMADevice).Run()
+			if out, err := exec.Command("rdma", "link", "del", targetCfg.RDMADevice).CombinedOutput(); err != nil {
+				return fmt.Errorf("failed deleting rdma link %s: %s: %w", targetCfg.RDMADevice, strings.TrimSpace(string(out)), err)
+			}
 		}
 
 		// Delete dummy interface
-		if link, err := netlink.LinkByName(targetCfg.Name); err == nil {
+		if link, err := nlwrap.LinkByName(targetCfg.Name); err == nil {
 			if err := netlink.LinkDel(link); err != nil {
 				return fmt.Errorf("failed deleting link %s: %w", targetCfg.Name, err)
 			}
 		}
 
-		// Remove sysfs links
-		if err := os.Remove(filepath.Join(sysBusPCIDevices, targetCfg.PCIAddress)); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed removing %s from %s: %w", targetCfg.PCIAddress, sysBusPCIDevices, err)
+		// Remove shadow sysfs links and device directory
+		sysRoot := filepath.Join(defaultMockSysfsRoot, "sys")
+		busPCILink := filepath.Join(sysRoot, "bus", "pci", "devices", targetCfg.PCIAddress)
+		classNetLink := filepath.Join(sysRoot, "class", "net", targetCfg.Name)
+		deviceDir := filepath.Join(sysRoot, "devices", "pci0000:00", targetCfg.PCIAddress)
+
+		if err := os.Remove(busPCILink); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed removing %s: %w", busPCILink, err)
 		}
-		if err := os.Remove(filepath.Join(sysClassNet, targetCfg.Name)); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed removing %s from %s: %w", targetCfg.Name, sysClassNet, err)
+		if err := os.Remove(classNetLink); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed removing %s: %w", classNetLink, err)
 		}
-		if err := os.RemoveAll(filepath.Join(defaultMockPCIRoot, targetCfg.PCIAddress)); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed removing mock PCI directory %s: %w", targetCfg.PCIAddress, err)
+		if err := os.RemoveAll(deviceDir); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed removing %s: %w", deviceDir, err)
 		}
 	}
 
 	return saveState(state)
 }
 
-// Cleanup unmounts tmpfs layers and purges all mocked devices.
+// Cleanup purges all mocked devices and removes the shadow sysfs hierarchy.
 func Cleanup() error {
 	var errs []error
 	state, err := loadState()
 	if err == nil {
 		for _, dev := range state.Devices {
 			if dev.RDMADevice != "" {
-				_ = exec.Command("rdma", "link", "del", dev.RDMADevice).Run()
+				if out, err := exec.Command("rdma", "link", "del", dev.RDMADevice).CombinedOutput(); err != nil {
+					errs = append(errs, fmt.Errorf("failed deleting rdma link %s: %s: %w", dev.RDMADevice, strings.TrimSpace(string(out)), err))
+				}
 			}
-			if link, err := netlink.LinkByName(dev.Name); err == nil {
+			if link, err := nlwrap.LinkByName(dev.Name); err == nil {
 				if err := netlink.LinkDel(link); err != nil {
 					errs = append(errs, fmt.Errorf("failed deleting link %s: %w", dev.Name, err))
 				}
@@ -414,31 +397,16 @@ func Cleanup() error {
 			if len(parts) >= 2 {
 				rdmaDev := strings.TrimSpace(parts[1])
 				if rdmaDev != "" {
-					_ = exec.Command("rdma", "link", "del", rdmaDev).Run()
+					if out, err := exec.Command("rdma", "link", "del", rdmaDev).CombinedOutput(); err != nil {
+						errs = append(errs, fmt.Errorf("failed deleting rdma link %s: %s: %w", rdmaDev, strings.TrimSpace(string(out)), err))
+					}
 				}
 			}
 		}
 	}
 
-	if isMountPoint(sysBusPCIDevices) {
-		if err := unix.Unmount(sysBusPCIDevices, unix.MNT_DETACH); err != nil {
-			errs = append(errs, fmt.Errorf("failed unmounting %s: %w", sysBusPCIDevices, err))
-		}
-	}
-	if isMountPoint(sysClassNet) {
-		if err := unix.Unmount(sysClassNet, unix.MNT_DETACH); err != nil {
-			errs = append(errs, fmt.Errorf("failed unmounting %s: %w", sysClassNet, err))
-		}
-	}
-
-	if err := os.RemoveAll(defaultMockPCIRoot); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Errorf("failed removing %s: %w", defaultMockPCIRoot, err))
-	}
-	if err := os.RemoveAll(savedPCIBusDir); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Errorf("failed removing %s: %w", savedPCIBusDir, err))
-	}
-	if err := os.RemoveAll(savedNetDir); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Errorf("failed removing %s: %w", savedNetDir, err))
+	if err := os.RemoveAll(defaultMockSysfsRoot); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("failed removing %s: %w", defaultMockSysfsRoot, err))
 	}
 
 	if len(errs) > 0 {

--- a/pkg/mockpci/mockpci_test.go
+++ b/pkg/mockpci/mockpci_test.go
@@ -90,11 +90,12 @@ func TestApplyDefaults(t *testing.T) {
 
 func TestGenerateModalias(t *testing.T) {
 	tests := []struct {
-		name     string
-		vendor   string
-		device   string
-		class    string
-		expected string
+		name      string
+		vendor    string
+		device    string
+		class     string
+		expected  string
+		expectErr bool
 	}{
 		{
 			name:     "default mellanox connectx",
@@ -131,11 +132,41 @@ func TestGenerateModalias(t *testing.T) {
 			class:    "",
 			expected: "pci:v000015B3d0000101Bsv000015B3sd00000001bc02sc00i00\n",
 		},
+		{
+			name:      "invalid vendorID hex returns error",
+			vendor:    "0xZZZZ",
+			device:    "0x101b",
+			class:     "0x020000",
+			expectErr: true,
+		},
+		{
+			name:      "invalid deviceID hex returns error",
+			vendor:    "0x15b3",
+			device:    "invalid",
+			class:     "0x020000",
+			expectErr: true,
+		},
+		{
+			name:      "invalid class hex returns error",
+			vendor:    "0x15b3",
+			device:    "0x101b",
+			class:     "0xGGGG",
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := GenerateModalias(tt.vendor, tt.device, tt.class)
+			actual, err := GenerateModalias(tt.vendor, tt.device, tt.class)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error for %s, got nil", tt.name)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if actual != tt.expected {
 				t.Errorf("GenerateModalias(%q, %q, %q) = %q, want %q", tt.vendor, tt.device, tt.class, actual, tt.expected)
 			}
@@ -168,7 +199,8 @@ func TestPopulateMockPCIDir(t *testing.T) {
 		t.Fatalf("PopulateMockPCIDir failed: %v", err)
 	}
 
-	mockPCIDir := filepath.Join(tempDir, cfg.PCIAddress)
+	sysRoot := filepath.Join(tempDir, "sys")
+	mockPCIDir := filepath.Join(sysRoot, "devices", "pci0000:00", cfg.PCIAddress)
 
 	// Check files created
 	checkFileContent := func(filename, expected string) {
@@ -198,7 +230,7 @@ func TestPopulateMockPCIDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read driver symlink: %v", err)
 	}
-	expectedDriverDest := filepath.Join(tempDir, "drivers", "mlx5_core")
+	expectedDriverDest := filepath.Join(sysRoot, "bus", "pci", "drivers", "mlx5_core")
 	if driverLink != expectedDriverDest {
 		t.Errorf("driver link = %q, want %q", driverLink, expectedDriverDest)
 	}
@@ -217,18 +249,37 @@ func TestPopulateMockPCIDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read physfn symlink: %v", err)
 	}
-	expectedPhysfn := filepath.Join(tempDir, "0000:00:08.0")
+	expectedPhysfn := filepath.Join(sysRoot, "devices", "pci0000:00", "0000:00:08.0")
 	if physfnLink != expectedPhysfn {
 		t.Errorf("physfn link = %q, want %q", physfnLink, expectedPhysfn)
+	}
+
+	// Check bus/pci/devices symlink
+	busPCILink, err := os.Readlink(filepath.Join(sysRoot, "bus", "pci", "devices", cfg.PCIAddress))
+	if err != nil {
+		t.Fatalf("failed to read bus/pci/devices symlink: %v", err)
+	}
+	if busPCILink != mockPCIDir {
+		t.Errorf("bus/pci/devices link = %q, want %q", busPCILink, mockPCIDir)
+	}
+
+	// Check class/net symlink
+	classNetLink, err := os.Readlink(filepath.Join(sysRoot, "class", "net", cfg.Name))
+	if err != nil {
+		t.Fatalf("failed to read class/net symlink: %v", err)
+	}
+	expectedNetDir := filepath.Join(mockPCIDir, "net", cfg.Name)
+	if classNetLink != expectedNetDir {
+		t.Errorf("class/net link = %q, want %q", classNetLink, expectedNetDir)
 	}
 }
 
 func TestStateLoadSave(t *testing.T) {
-	origRoot := defaultMockPCIRoot
+	origRoot := defaultMockSysfsRoot
 	tempDir := t.TempDir()
-	defaultMockPCIRoot = tempDir
+	defaultMockSysfsRoot = tempDir
 	defer func() {
-		defaultMockPCIRoot = origRoot
+		defaultMockSysfsRoot = origRoot
 	}()
 
 	// 1. Initial load from non-existent state file should return empty map

--- a/pkg/mockpci/mockpci_test.go
+++ b/pkg/mockpci/mockpci_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockpci
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplyDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    DeviceConfig
+		expected DeviceConfig
+	}{
+		{
+			name:  "all empty fields get defaults",
+			input: DeviceConfig{Name: "test0", PCIAddress: "0000:00:10.0"},
+			expected: DeviceConfig{
+				Name:       "test0",
+				PCIAddress: "0000:00:10.0",
+				VendorID:   "0x15b3",
+				DeviceID:   "0x101b",
+				Class:      "0x020000",
+				Driver:     "mlx5_core",
+				MTU:        1500,
+			},
+		},
+		{
+			name: "custom fields preserved",
+			input: DeviceConfig{
+				Name:       "custom0",
+				PCIAddress: "0000:01:00.0",
+				VendorID:   "0x8086",
+				DeviceID:   "0x1592",
+				Class:      "0x020001",
+				Driver:     "ice",
+				MTU:        9000,
+			},
+			expected: DeviceConfig{
+				Name:       "custom0",
+				PCIAddress: "0000:01:00.0",
+				VendorID:   "0x8086",
+				DeviceID:   "0x1592",
+				Class:      "0x020001",
+				Driver:     "ice",
+				MTU:        9000,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.input
+			ApplyDefaults(&cfg)
+			if cfg.VendorID != tt.expected.VendorID {
+				t.Errorf("VendorID = %q, want %q", cfg.VendorID, tt.expected.VendorID)
+			}
+			if cfg.DeviceID != tt.expected.DeviceID {
+				t.Errorf("DeviceID = %q, want %q", cfg.DeviceID, tt.expected.DeviceID)
+			}
+			if cfg.Class != tt.expected.Class {
+				t.Errorf("Class = %q, want %q", cfg.Class, tt.expected.Class)
+			}
+			if cfg.Driver != tt.expected.Driver {
+				t.Errorf("Driver = %q, want %q", cfg.Driver, tt.expected.Driver)
+			}
+			if cfg.MTU != tt.expected.MTU {
+				t.Errorf("MTU = %d, want %d", cfg.MTU, tt.expected.MTU)
+			}
+		})
+	}
+}
+
+func TestGenerateModalias(t *testing.T) {
+	tests := []struct {
+		name     string
+		vendor   string
+		device   string
+		class    string
+		expected string
+	}{
+		{
+			name:     "default mellanox connectx",
+			vendor:   "0x15b3",
+			device:   "0x101b",
+			class:    "0x020000",
+			expected: "pci:v000015B3d0000101Bsv000015B3sd00000001bc02sc00i00\n",
+		},
+		{
+			name:     "intel e810",
+			vendor:   "0x8086",
+			device:   "0x1592",
+			class:    "0x020000",
+			expected: "pci:v00008086d00001592sv00008086sd00000001bc02sc00i00\n",
+		},
+		{
+			name:     "class with subclass and prog interface",
+			vendor:   "0x10de",
+			device:   "0x1eb8",
+			class:    "0x030201",
+			expected: "pci:v000010DEd00001EB8sv000010DEsd00000001bc03sc02i01\n",
+		},
+		{
+			name:     "without 0x prefix",
+			vendor:   "15b3",
+			device:   "101b",
+			class:    "020000",
+			expected: "pci:v000015B3d0000101Bsv000015B3sd00000001bc02sc00i00\n",
+		},
+		{
+			name:     "empty fields fallback to defaults",
+			vendor:   "",
+			device:   "",
+			class:    "",
+			expected: "pci:v000015B3d0000101Bsv000015B3sd00000001bc02sc00i00\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := GenerateModalias(tt.vendor, tt.device, tt.class)
+			if actual != tt.expected {
+				t.Errorf("GenerateModalias(%q, %q, %q) = %q, want %q", tt.vendor, tt.device, tt.class, actual, tt.expected)
+			}
+			// Kernel modalias without newline must be 53 chars
+			trimmed := strings.TrimRight(actual, "\n")
+			if len(trimmed) != 53 {
+				t.Errorf("modalias length = %d, expected 53", len(trimmed))
+			}
+		})
+	}
+}
+
+func TestPopulateMockPCIDir(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg := DeviceConfig{
+		Name:          "mlx0",
+		PCIAddress:    "0000:00:10.0",
+		VendorID:      "0x15b3",
+		DeviceID:      "0x101b",
+		Class:         "0x020000",
+		Driver:        "mlx5_core",
+		NUMANode:      1,
+		SRIOVTotalVFs: 8,
+		SRIOVNumVFs:   4,
+		PhysFn:        "0000:00:08.0",
+	}
+
+	if err := PopulateMockPCIDir(cfg, tempDir); err != nil {
+		t.Fatalf("PopulateMockPCIDir failed: %v", err)
+	}
+
+	mockPCIDir := filepath.Join(tempDir, cfg.PCIAddress)
+
+	// Check files created
+	checkFileContent := func(filename, expected string) {
+		t.Helper()
+		content, err := os.ReadFile(filepath.Join(mockPCIDir, filename))
+		if err != nil {
+			t.Errorf("failed to read %s: %v", filename, err)
+			return
+		}
+		if string(content) != expected {
+			t.Errorf("%s content = %q, want %q", filename, string(content), expected)
+		}
+	}
+
+	checkFileContent("vendor", "0x15b3\n")
+	checkFileContent("device", "0x101b\n")
+	checkFileContent("subsystem_vendor", "0x15b3\n")
+	checkFileContent("subsystem_device", "0x0001\n")
+	checkFileContent("class", "0x020000\n")
+	checkFileContent("numa_node", "1\n")
+	checkFileContent("sriov_totalvfs", "8\n")
+	checkFileContent("sriov_numvfs", "4\n")
+	checkFileContent("modalias", "pci:v000015B3d0000101Bsv000015B3sd00000001bc02sc00i00\n")
+
+	// Check driver symlink
+	driverLink, err := os.Readlink(filepath.Join(mockPCIDir, "driver"))
+	if err != nil {
+		t.Fatalf("failed to read driver symlink: %v", err)
+	}
+	expectedDriverDest := filepath.Join(tempDir, "drivers", "mlx5_core")
+	if driverLink != expectedDriverDest {
+		t.Errorf("driver link = %q, want %q", driverLink, expectedDriverDest)
+	}
+
+	// Check net device symlink
+	netDevLink, err := os.Readlink(filepath.Join(mockPCIDir, "net", "mlx0", "device"))
+	if err != nil {
+		t.Fatalf("failed to read net device symlink: %v", err)
+	}
+	if netDevLink != mockPCIDir {
+		t.Errorf("net device link = %q, want %q", netDevLink, mockPCIDir)
+	}
+
+	// Check physfn symlink
+	physfnLink, err := os.Readlink(filepath.Join(mockPCIDir, "physfn"))
+	if err != nil {
+		t.Fatalf("failed to read physfn symlink: %v", err)
+	}
+	expectedPhysfn := filepath.Join(tempDir, "0000:00:08.0")
+	if physfnLink != expectedPhysfn {
+		t.Errorf("physfn link = %q, want %q", physfnLink, expectedPhysfn)
+	}
+}
+
+func TestStateLoadSave(t *testing.T) {
+	origRoot := defaultMockPCIRoot
+	tempDir := t.TempDir()
+	defaultMockPCIRoot = tempDir
+	defer func() {
+		defaultMockPCIRoot = origRoot
+	}()
+
+	// 1. Initial load from non-existent state file should return empty map
+	state, err := loadState()
+	if err != nil {
+		t.Fatalf("loadState on non-existent file failed: %v", err)
+	}
+	if len(state.Devices) != 0 {
+		t.Errorf("expected empty devices map, got %d items", len(state.Devices))
+	}
+
+	// 2. Save state
+	testCfg := DeviceConfig{
+		Name:       "mlx0",
+		PCIAddress: "0000:00:10.0",
+		VendorID:   "0x15b3",
+		DeviceID:   "0x101b",
+	}
+	state.Devices[testCfg.Name] = testCfg
+	if err := saveState(state); err != nil {
+		t.Fatalf("saveState failed: %v", err)
+	}
+
+	// 3. Reload state
+	reloaded, err := loadState()
+	if err != nil {
+		t.Fatalf("reloaded loadState failed: %v", err)
+	}
+	if len(reloaded.Devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(reloaded.Devices))
+	}
+	dev, ok := reloaded.Devices["mlx0"]
+	if !ok {
+		t.Fatalf("expected mlx0 in reloaded devices")
+	}
+	if dev.PCIAddress != "0000:00:10.0" || dev.VendorID != "0x15b3" {
+		t.Errorf("device data mismatch: %+v", dev)
+	}
+
+	// 4. Test List()
+	list, err := List()
+	if err != nil {
+		t.Fatalf("List() failed: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "mlx0" {
+		t.Errorf("unexpected List() result: %+v", list)
+	}
+
+	// 5. Corrupt state file returns unmarshal error
+	stateFile := filepath.Join(tempDir, stateFileName)
+	if err := os.WriteFile(stateFile, []byte("invalid json content"), 0644); err != nil {
+		t.Fatalf("failed to write corrupted state: %v", err)
+	}
+	if _, err := loadState(); err == nil {
+		t.Errorf("expected error loading corrupted state file, got nil")
+	}
+}
+
+func TestValidation(t *testing.T) {
+	if err := Create(DeviceConfig{PCIAddress: "0000:00:10.0"}); err == nil || !strings.Contains(err.Error(), "device name is required") {
+		t.Errorf("expected device name error, got: %v", err)
+	}
+
+	if err := Create(DeviceConfig{Name: "eth0"}); err == nil || !strings.Contains(err.Error(), "pciAddress is required") {
+		t.Errorf("expected pciAddress error, got: %v", err)
+	}
+}
+
+func TestEnsureSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	target1 := filepath.Join(tempDir, "target1")
+	target2 := filepath.Join(tempDir, "target2")
+	link := filepath.Join(tempDir, "symlink")
+
+	if err := os.WriteFile(target1, []byte("one"), 0644); err != nil {
+		t.Fatalf("failed to create target1: %v", err)
+	}
+	if err := os.WriteFile(target2, []byte("two"), 0644); err != nil {
+		t.Fatalf("failed to create target2: %v", err)
+	}
+
+	// 1. Initial symlink creation
+	if err := ensureSymlink(target1, link); err != nil {
+		t.Fatalf("ensureSymlink(target1, link) failed: %v", err)
+	}
+	dest, err := os.Readlink(link)
+	if err != nil || dest != target1 {
+		t.Errorf("link points to %q, want %q", dest, target1)
+	}
+
+	// 2. Overwrite existing symlink cleanly
+	if err := ensureSymlink(target2, link); err != nil {
+		t.Fatalf("ensureSymlink(target2, link) overwrite failed: %v", err)
+	}
+	dest, err = os.Readlink(link)
+	if err != nil || dest != target2 {
+		t.Errorf("overwritten link points to %q, want %q", dest, target2)
+	}
+}

--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -13,6 +13,7 @@ teardown() {
   cleanup_dummy_interfaces
   cleanup_veth_interfaces
   cleanup_bpf_programs
+  cleanup_mock_pci_devices
   # The driver is rate limited to updates with interval of atleast 5 seconds. So
   # we need to sleep for an equivalent amount of time to ensure state from a
   # previous test is cleared up and old (non-existent) devices have been removed
@@ -79,6 +80,20 @@ cleanup_veth_interfaces() {
 
 cleanup_bpf_programs() {
   docker exec "$CLUSTER_NAME"-worker2 bash -c "rm -rf /sys/fs/bpf/* || true"
+}
+
+cleanup_mock_pci_devices() {
+  for node in "$CLUSTER_NAME"-worker "$CLUSTER_NAME"-worker2; do
+    docker cp "$BATS_TEST_DIRNAME"/../bin/mockpci "${node}":/usr/local/bin/mockpci 2>/dev/null || true
+    docker exec "$node" mockpci cleanup 2>/dev/null || true
+  done
+}
+
+setup_mock_pci_device() {
+  local node="$1"
+  shift
+  docker cp "$BATS_TEST_DIRNAME"/../bin/mockpci "${node}":/usr/local/bin/mockpci
+  docker exec "$node" mockpci add "$@"
 }
 
 # ---- SETUP HELPERS ----
@@ -757,3 +772,95 @@ EOF
   kubectl patch daemonset dranet -n kube-system --type='json' -p="[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $ORIGINAL_ARGS}]"
   kubectl rollout status -n kube-system daemonset/dranet --timeout=90s
 }
+
+@test "mockpci: PCIe device discovery with Mellanox vendor, NUMA node, and RDMA attributes in ResourceSlice" {
+  local NODE_NAME="$CLUSTER_NAME"-worker
+  local IFACE_NAME="mlx0"
+  local PCI_BDF="0000:00:10.0"
+  local DEV_NAME="pci-0000-00-10-0"
+  local RDMA_DEV="rxe0"
+
+  setup_mock_pci_device "$NODE_NAME" \
+    --name "$IFACE_NAME" \
+    --pci-address "$PCI_BDF" \
+    --vendor "0x15b3" \
+    --device "0x101b" \
+    --driver "mlx5_core" \
+    --numa-node 0 \
+    --rdma-device "$RDMA_DEV"
+
+  # 1. Wait for ResourceSlice to publish the mock PCI device with Mellanox vendor
+  for attempt in {1..6}; do
+    run kubectl get resourceslices --field-selector spec.nodeName="$NODE_NAME" \
+      -o jsonpath="{.items[0].spec.devices[?(@.name=='$DEV_NAME')].attributes.dra\.net\/pciVendor.string}"
+    if [ "$status" -eq 0 ] && [[ "$output" == *"Mellanox"* ]]; then
+      break
+    fi
+    sleep 2
+  done
+
+  assert_success
+  assert_output --partial "Mellanox"
+
+  # 2. Check PCI Address
+  run kubectl get resourceslices --field-selector spec.nodeName="$NODE_NAME" \
+    -o jsonpath="{.items[0].spec.devices[?(@.name=='$DEV_NAME')].attributes.dra\.net\/pciAddress.string}"
+  assert_success
+  assert_output "$PCI_BDF"
+
+  # 3. Check PCI Device Product name resolved via pcidb
+  run kubectl get resourceslices --field-selector spec.nodeName="$NODE_NAME" \
+    -o jsonpath="{.items[0].spec.devices[?(@.name=='$DEV_NAME')].attributes.dra\.net\/pciDevice.string}"
+  assert_success
+  assert_output --partial "ConnectX-6"
+
+  # 4. Check in-kernel RDMA capability and RDMA device name
+  run kubectl get resourceslices --field-selector spec.nodeName="$NODE_NAME" \
+    -o jsonpath="{.items[0].spec.devices[?(@.name=='$DEV_NAME')].attributes.dra\.net\/rdma.bool}"
+  assert_success
+  assert_output "true"
+
+  run kubectl get resourceslices --field-selector spec.nodeName="$NODE_NAME" \
+    -o jsonpath="{.items[0].spec.devices[?(@.name=='$DEV_NAME')].attributes.dra\.net\/rdmaDevice.string}"
+  assert_success
+  assert_output "$RDMA_DEV"
+
+  # 5. Check Interface name
+  run kubectl get resourceslices --field-selector spec.nodeName="$NODE_NAME" \
+    -o jsonpath="{.items[0].spec.devices[?(@.name=='$DEV_NAME')].attributes.dra\.net\/ifName.string}"
+  assert_success
+  assert_output "$IFACE_NAME"
+}
+
+@test "mockpci: PCIe device allocation and container network attachment via ResourceClaim" {
+  local NODE_NAME="$CLUSTER_NAME"-worker
+  local IFACE_NAME="mlx0"
+  local PCI_BDF="0000:00:10.0"
+  local RDMA_DEV="rxe0"
+
+  setup_mock_pci_device "$NODE_NAME" \
+    --name "$IFACE_NAME" \
+    --pci-address "$PCI_BDF" \
+    --vendor "0x15b3" \
+    --device "0x101b" \
+    --driver "mlx5_core" \
+    --numa-node 0 \
+    --rdma-device "$RDMA_DEV"
+
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/deviceclass.yaml
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/resourceclaim_mock_pci.yaml
+  wait_for_ready_pods app=pod-mock-pci 30s
+
+  run kubectl exec pod-mock-pci -- ip addr show mockpci0
+  assert_success
+  assert_output --partial "169.254.169.50"
+
+  run kubectl get resourceclaims mock-pci-interface-static-ip -o=jsonpath='{.status.devices[0].networkData.ips[*]}'
+  assert_success
+  assert_output --partial "169.254.169.50"
+}
+
+
+
+
+

--- a/tests/manifests/resourceclaim_mock_pci.yaml
+++ b/tests/manifests/resourceclaim_mock_pci.yaml
@@ -1,0 +1,49 @@
+# Copyright The Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: mock-pci-interface-static-ip
+spec:
+  devices:
+    requests:
+    - name: req-mock-pci
+      exactly:
+        deviceClassName: dra.net
+        selectors:
+          - cel:
+              expression: has(device.attributes["dra.net"].pciAddress) && device.attributes["dra.net"].pciAddress == "0000:00:10.0" && has(device.attributes["dra.net"].pciVendor) && device.attributes["dra.net"].pciVendor == "Mellanox Technologies"
+    config:
+    - opaque:
+        driver: dra.net
+        parameters:
+          interface:
+            name: "mockpci0"
+            addresses:
+            - "169.254.169.50/24"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-mock-pci
+  labels:
+    app: pod-mock-pci
+spec:
+  containers:
+  - name: ctr1
+    image: registry.k8s.io/e2e-test-images/agnhost:2.54
+  resourceClaims:
+  - name: mockpcidev1
+    resourceClaimName: mock-pci-interface-static-ip

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -8,6 +8,9 @@ function setup_suite {
   export CLUSTER_NAME="dranet-test-cluster"
   export IMAGE_NAME="registry.k8s.io/networking/dranet"
 
+  # Build test helper binaries
+  make -C "$BATS_TEST_DIRNAME"/.. build-mockpci
+
   # Build the image
   docker build -t "$IMAGE_NAME":test -f Dockerfile "$BATS_TEST_DIRNAME"/.. --load
 
@@ -34,14 +37,14 @@ function setup_suite {
 
   kind load docker-image "$IMAGE_NAME":test --name "$CLUSTER_NAME"
 
-  # Creating BPF and cgroup mounts on the Kind nodes.
+  # Creating BPF mounts on the Kind nodes.
   NODES=$(kind get nodes --name ${CLUSTER_NAME})
   for node in $NODES; do
     docker exec "$node" mount -t bpf bpffs /sys/fs/bpf
     docker exec "$node" mount --make-shared /sys/fs/bpf
   done
 
-  _install=$(sed -e s#"$IMAGE_NAME".*#"$IMAGE_NAME":test# -e 's/--v=4/--v=4\n        - --filter=/' < "$BATS_TEST_DIRNAME"/../install.yaml)
+  _install=$(sed -e s#"$IMAGE_NAME".*#"$IMAGE_NAME":test# -e 's/--v=4/--v=4\n        - --dranet-experimental-sysfs-root=\/var\/run\/dranet\/sysfs\/sys\n        - --filter=/' < "$BATS_TEST_DIRNAME"/../install.yaml)
   printf '%s' "${_install}" | kubectl apply -f -
   kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=dranet
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds PCI support for testing for network devices in E2E tests.

#### Which issue(s) this PR is related to:
Fixes #68
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:


If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add test support for PCI devices
```