### PR TITLE
driver: sort a copy of the routes instead of the shared slice

### DIFF
--- a/pkg/driver/netnamespace.go
+++ b/pkg/driver/netnamespace.go
@@ -63,13 +63,16 @@ func applyRoutingConfig(containerNsPAth string, ifName string, routeConfig []api
 	// # ip route show dev eth0
 	//   10.0.5.0/24 via 10.0.5.1 proto dhcp src 10.0.5.8
 	//   10.0.5.1 proto dhcp scope link src 10.0.5.8
-	slices.SortFunc(routeConfig, func(a, b apis.RouteConfig) int {
-		// Routes with scope RT_SCOPE_LINK (253) should come before RT_SCOPE_UNIVERSE (0)
+	// Sort a clone: routeConfig aliases the pod's stored slice, so sorting it in
+	// place would reorder the stored routes and race with their readers.
+	sortedRoutes := slices.Clone(routeConfig)
+	slices.SortFunc(sortedRoutes, func(a, b apis.RouteConfig) int {
+		// Routes with scope RT_SCOPE_LINK (253) should come before RT_SCOPE_UNIVERSE (0).
 		// A higher scope value means it's processed earlier.
 		return int(b.Scope) - int(a.Scope)
 	})
 
-	for _, route := range routeConfig {
+	for _, route := range sortedRoutes {
 		table := route.Table
 		// If VRF is enabled (vrfTable > 0), all routes for this interface
 		// must go into the VRF table to be reachable via the VRF device.

--- a/pkg/driver/netnamespace_test.go
+++ b/pkg/driver/netnamespace_test.go
@@ -17,9 +17,126 @@ limitations under the License.
 package driver
 
 import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path"
+	"runtime"
 	"testing"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"sigs.k8s.io/dranet/internal/nlwrap"
+	"sigs.k8s.io/dranet/pkg/apis"
 )
 
 func Test_applyRoutingConfig(t *testing.T) {
-	// TODO: see hostdevice_test.go and ethtool_test.go
+	if os.Getuid() != 0 {
+		t.Skip("Test requires root privileges.")
+	}
+
+	// NewNamed moves the calling thread into the new namespace, so pin the
+	// goroutine and put the thread back where we found it afterwards.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	origns, err := netns.Get()
+	if err != nil {
+		t.Fatalf("unexpected error trying to get namespace: %v", err)
+	}
+	defer origns.Close()
+
+	rndString := make([]byte, 4)
+	if _, err := rand.Read(rndString); err != nil {
+		t.Fatalf("fail to generate random name: %v", err)
+	}
+	nsName := fmt.Sprintf("ns%x", rndString)
+	containerNsPath := path.Join("/run/netns", nsName)
+	testNS, err := netns.NewNamed(nsName)
+	if err != nil {
+		t.Fatalf("Failed to create network namespace: %v", err)
+	}
+	defer netns.DeleteNamed(nsName)
+	defer testNS.Close()
+
+	// Switch back to the original namespace
+	if err := netns.Set(origns); err != nil {
+		t.Fatalf("failed to restore original network namespace: %v", err)
+	}
+
+	nhNs, err := nlwrap.NewHandleAt(testNS)
+	if err != nil {
+		t.Fatalf("fail to open netlink handle: %v", err)
+	}
+	defer nhNs.Close()
+
+	// A /32 address keeps the gateway off-link, so the universe route installs
+	// only after the link route to it: that makes the scope ordering observable.
+	ifaceName := "dummy0"
+	la := netlink.NewLinkAttrs()
+	la.Name = ifaceName
+	la.Namespace = netlink.NsFd(int(testNS))
+	link := &netlink.Dummy{
+		LinkAttrs: la,
+	}
+	if err := nhNs.LinkAdd(link); err != nil {
+		t.Fatalf("Failed to add dummy link %s in ns %s: %v", ifaceName, nsName, err)
+	}
+	if err := nhNs.LinkSetUp(link); err != nil {
+		t.Fatalf("Failed to set up dummy link %s in ns %s: %v", ifaceName, nsName, err)
+	}
+	addr, err := netlink.ParseAddr("10.10.0.1/32")
+	if err != nil {
+		t.Fatalf("failed to parse address: %v", err)
+	}
+	if err := nhNs.AddrAdd(link, addr); err != nil {
+		t.Fatalf("failed to add address to %s: %v", ifaceName, err)
+	}
+
+	// Universe route first: without applyRoutingConfig sorting by scope, its
+	// gateway is unreachable when it is added and the route fails to install.
+	routes := []apis.RouteConfig{
+		{Destination: "192.168.99.0/24", Gateway: "10.10.0.254", Scope: 0},
+		{Destination: "10.10.0.254/32", Scope: 253},
+	}
+	if err := applyRoutingConfig(containerNsPath, ifaceName, routes, 0); err != nil {
+		t.Fatalf("applyRoutingConfig failed: %v", err)
+	}
+
+	// applyRoutingConfig sorts a copy, so the shared input keeps its order.
+	if routes[0].Destination != "192.168.99.0/24" || routes[1].Destination != "10.10.0.254/32" {
+		t.Errorf("applyRoutingConfig reordered its input slice: %+v", routes)
+	}
+
+	nsLink, err := nhNs.LinkByName(ifaceName)
+	if err != nil {
+		t.Fatalf("Failed to get %s after applying routes: %v", ifaceName, err)
+	}
+	got, err := nhNs.RouteList(nsLink, netlink.FAMILY_V4)
+	if err != nil {
+		t.Fatalf("failed to list routes: %v", err)
+	}
+	for _, want := range routes {
+		found := false
+		for _, r := range got {
+			if r.Dst == nil || r.Dst.String() != want.Destination {
+				continue
+			}
+			found = true
+			gotGw := ""
+			if r.Gw != nil {
+				gotGw = r.Gw.String()
+			}
+			if gotGw != want.Gateway {
+				t.Errorf("route %s gateway = %q, want %q", want.Destination, gotGw, want.Gateway)
+			}
+			if uint8(r.Scope) != want.Scope {
+				t.Errorf("route %s scope = %d, want %d", want.Destination, r.Scope, want.Scope)
+			}
+			break
+		}
+		if !found {
+			t.Errorf("route %s not found in namespace", want.Destination)
+		}
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

While reading the route setup I noticed that `applyRoutingConfig` sorts its `routeConfig` argument in place. That slice isn't a private copy: it comes from the pod config store, and `GetPodConfig` returns the `PodConfig` by value, so the `Routes` slice header is copied while its backing array still points at the stored config. Sorting it in place reorders the routes the store keeps for that pod, and because the sort runs after the store's read lock has been released, it can also race with another goroutine reading the same pod's config.

The order the routes are applied in still matters (link-local routes have to go in before the universe routes that depend on them), so I kept the sort but now sort a clone of the slice instead of the one shared with the store, leaving the caller's slice untouched. The routes are only reordered and never modified, so a shallow `slices.Clone` is enough here.

#### Which issue(s) this PR is related to:

None filed; this is a small follow-up to the route work in #254 and #256.

#### Special notes for your reviewer:

`Test_applyRoutingConfig` exercises the full path in a temporary network namespace: the interface uses a /32 address so the gateway is not on-link, and the universe route only installs once the link-local route to the gateway has been added, so the test fails if the scope ordering is dropped. It also checks that the input slice keeps its original order, which catches an in-place sort of the shared config.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
