### PR TITLE
go.mod: bump insomniacslk/dhcp past the nclient4 ReadFrom panic fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/containerd/nri v0.12.1
 	github.com/google/cel-go v0.31.0
 	github.com/google/go-cmp v0.7.0
-	github.com/insomniacslk/dhcp v0.0.0-20250417080101-5f8cf70e8c5f
+	github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82
 	github.com/jaypipes/ghw v0.25.0
 	github.com/jaypipes/pcidb v1.1.1
 	github.com/mdlayher/genetlink v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 h1:/jC7qQFrv8
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714/go.mod h1:2Goc3h8EklBH5mspfHFxBnEoURQCGzQQH1ga9Myjvis=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/insomniacslk/dhcp v0.0.0-20250417080101-5f8cf70e8c5f h1:dd33oobuIv9PcBVqvbEiCXEbNTomOHyj3WFuC5YiPRU=
-github.com/insomniacslk/dhcp v0.0.0-20250417080101-5f8cf70e8c5f/go.mod h1:zhFlBeJssZ1YBCMZ5Lzu1pX4vhftDvU10WUVb1uXKtM=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82 h1:y5aU8Uvl7eyM5WNgdQvRxbMJb+zo7pD+S72/Yo4pvnQ=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82/go.mod h1:qfvBmyDNp+/liLEYWRvqny/PEz9hGe2Dz833eXILSmo=
 github.com/jaypipes/ghw v0.25.0 h1:+7HlAHtQSrCOafYC6oRjqxuCzDZXBr2dFgVlYRRafrs=
 github.com/jaypipes/ghw v0.25.0/go.mod h1:Qk3UjdH8Xu/OiVyb/eDJqnDsUc+awHU75y23ErZU33s=
 github.com/jaypipes/pcidb v1.1.1 h1:QmPhpsbmmnCwZmHeYAATxEaoRuiMAJusKYkUncMC0ro=


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The DHCP client in `pkg/driver` (`getDHCP` in `dhcp.go`) uses `nclient4.New`, so it reads replies through `BroadcastRawUDPConn.ReadFrom`. Before insomniacslk/dhcp#583 that function could compute a negative DHCP length from a malformed frame whose IPv4 payload was shorter than a UDP header, and panic on a bad slice index. dranet was pinned to a build from April 2025, before the fix.

This moves the pin to the merge commit. Only `go.mod`/`go.sum` change, and `go build ./...` and `go vet ./...` pass. I wrote #583 upstream, so happy to answer anything about it.

In dranet the panic would land while `NodePrepareResources` is getting a DHCP lease for a claimed device, before any routes are applied. There's no CVE for it and I haven't tried to reproduce a crash inside dranet, so I kept this to the bump.

#### Which issue(s) this PR is related to:

None; it picks up insomniacslk/dhcp#583.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

