### PR TITLE
inventory: cap pci device attribute length

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -868,7 +868,22 @@ func (db *DB) addPCIAttributes(devices []resourceapi.Device, pciInfo *ghw.PCIInf
 			devices[i].Attributes[apis.AttrPCIVendor] = resourceapi.DeviceAttribute{StringValue: &pciDev.Vendor.Name}
 		}
 		if _, hasAttr := devices[i].Attributes[apis.AttrPCIDevice]; !hasAttr && pciDev.Product != nil {
-			devices[i].Attributes[apis.AttrPCIDevice] = resourceapi.DeviceAttribute{StringValue: &pciDev.Product.Name}
+			productName := pciDev.Product.Name
+
+			if len(productName) > resourceapi.DeviceAttributeMaxValueLength {
+				klog.V(4).Infof(
+					"Truncating PCI device name %q from %d to %d bytes",
+					productName,
+					len(productName),
+					resourceapi.DeviceAttributeMaxValueLength,
+				)
+
+				productName = productName[:resourceapi.DeviceAttributeMaxValueLength]
+			}
+
+			devices[i].Attributes[apis.AttrPCIDevice] = resourceapi.DeviceAttribute{
+				StringValue: &productName,
+			}
 		}
 		if _, hasAttr := devices[i].Attributes[apis.AttrPCISubsystem]; !hasAttr && pciDev.Subsystem != nil {
 			devices[i].Attributes[apis.AttrPCISubsystem] = resourceapi.DeviceAttribute{StringValue: &pciDev.Subsystem.ID}

--- a/pkg/inventory/db_test.go
+++ b/pkg/inventory/db_test.go
@@ -642,6 +642,40 @@ func TestAddPCIAttributes(t *testing.T) {
 		}
 	})
 
+	t.Run("truncates long product name", func(t *testing.T) {
+		longName := strings.Repeat("a", resourceapi.DeviceAttributeMaxValueLength+10)
+		longPCIInfo := &ghw.PCIInfo{
+			Devices: []*ghw.PCIDevice{
+				{
+					Address: "0000:00:1f.0",
+					Class:   &pcidb.Class{ID: "02"},
+					Product: &pcidb.Product{Name: longName, ID: "0x1234"},
+				},
+			},
+		}
+		devices := []resourceapi.Device{
+			{
+				Name: "0000:00:1f.0",
+				Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					apis.AttrPCIAddress: {StringValue: ptr.To("0000:00:1f.0")},
+				},
+			},
+		}
+		db := &DB{}
+		result := db.addPCIAttributes(devices, longPCIInfo)
+
+		v, ok := result[0].Attributes[apis.AttrPCIDevice]
+		if !ok || v.StringValue == nil {
+			t.Fatalf("AttrPCIDevice not set, got: %v", v)
+		}
+		if len(*v.StringValue) != resourceapi.DeviceAttributeMaxValueLength {
+			t.Errorf("AttrPCIDevice length = %d, want %d", len(*v.StringValue), resourceapi.DeviceAttributeMaxValueLength)
+		}
+		if *v.StringValue != longName[:resourceapi.DeviceAttributeMaxValueLength] {
+			t.Errorf("AttrPCIDevice = %q, want prefix of long name", *v.StringValue)
+		}
+	})
+
 	t.Run("does not overwrite existing attributes", func(t *testing.T) {
 		devices := []resourceapi.Device{
 			{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug



#### What this PR does / why we need it:
DRANET publishes the PCI product name as the dra.net/pciDevice attribute. Some PCI device names obtained from pci.ids can exceed Kubernetes' device attribute string length limit (resourceapi.DeviceAttributeMaxValueLength). For example, Mellanox ConnectX-3 Pro VFs (15b3:1004) expose a 67-byte product name, causing the API server to reject the entire ResourceSlice with a validation error and preventing resources from being advertised on the affected node. This PR truncates PCI device names to the Kubernetes-defined maximum length before publishing them as the dra.net/pciDevice attribute, preventing ResourceSlice validation failures while preserving the existing attribute semantics.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This issue was observed on a ConnectX-3 Pro VF (`15b3:1004`) where the PCI device description is 67 bytes long. Kubernetes rejects the entire ResourceSlice when the attribute exceeds the device attribute length limit. This change mirrors existing handling in DRANET for other attributes that may exceed `resourceapi.DeviceAttributeMaxValueLength`.

#### Does this PR introduce a user-facing change?

```release-note
Prevent ResourceSlice creation failures caused by PCI device names that exceed Kubernetes device attribute length limits by truncating the published `dra.net/pciDevice` attribute value.
```