### PR TITLE
Add CoreWeave CKS cloud provider support

### DIFF
--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -192,11 +192,16 @@ func main() {
 		}
 		opts = append(opts, driver.WithFilter(prg))
 	}
-	providerDependencies := discovery.Dependencies{
-		Nodes:    clientset.CoreV1().Nodes(),
-		NodeName: nodeName,
+	providerOpts := providerOptions{
+		cloudProviderHint: cloudProviderHint,
+		profileProvider:   profileProvider,
+		webhookURL:        webhookURL,
+		dependencies: discovery.Dependencies{
+			NodeClient: clientset.CoreV1().Nodes(),
+			NodeName:   nodeName,
+		},
 	}
-	cloudInst, profProv, err := setupProviders(ctx, cloudProviderHint, profileProvider, webhookURL, providerDependencies)
+	cloudInst, profProv, err := setupProviders(ctx, providerOpts)
 	if err != nil {
 		klog.Fatalf("failed to setup providers: %v", err)
 	}
@@ -253,28 +258,35 @@ func printVersion() {
 	klog.Infof("dranet go %s build: %s time: %s", info.GoVersion, vcsRevision, vcsTime)
 }
 
-func setupProviders(ctx context.Context, cloudProviderHint string, profileProvider string, webhookURL string, dependencies discovery.Dependencies) (cloudprovider.CloudInstance, cloudprovider.ProfileProvider, error) {
+type providerOptions struct {
+	cloudProviderHint string
+	profileProvider   string
+	webhookURL        string
+	dependencies      discovery.Dependencies
+}
+
+func setupProviders(ctx context.Context, opts providerOptions) (cloudprovider.CloudInstance, cloudprovider.ProfileProvider, error) {
 	var cloudInst cloudprovider.CloudInstance
 	var profProv cloudprovider.ProfileProvider
 	var err error
 
 	var hint discovery.CloudProviderHint
 	// Auto-discover cloud provider if not explicitly set
-	if cloudProviderHint == "" {
-		hint = discovery.DiscoverCloudProviderWithDependencies(ctx, webhookURL, dependencies)
+	if opts.cloudProviderHint == "" {
+		hint = discovery.DiscoverCloudProviderWithDependencies(ctx, opts.webhookURL, opts.dependencies)
 	} else {
-		hint = discovery.CloudProviderHint(cloudProviderHint)
+		hint = discovery.CloudProviderHint(opts.cloudProviderHint)
 	}
 
 	// Setup the Underlay (Hardware Discovery / Cloud Instance Info)
-	cloudInst, err = discovery.GetInstancePropertiesWithDependencies(ctx, hint, webhookURL, dependencies)
+	cloudInst, err = discovery.GetInstancePropertiesWithDependencies(ctx, hint, opts.webhookURL, opts.dependencies)
 	if err != nil {
 		klog.Infof("failed to initialize cloud provider %q: %v", hint, err)
 		cloudInst = nil
 	}
 
 	// Setup the Overlay (Profile Provider / User Intent)
-	switch profileProvider {
+	switch opts.profileProvider {
 	case "cloud":
 		if p, ok := cloudInst.(cloudprovider.ProfileProvider); ok {
 			profProv = p
@@ -282,27 +294,27 @@ func setupProviders(ctx context.Context, cloudProviderHint string, profileProvid
 			profProv = nil
 		}
 	case "webhook":
-		if webhookURL == "" {
+		if opts.webhookURL == "" {
 			return nil, nil, fmt.Errorf("--webhook-url is required when using the webhook profile provider")
 		}
 		var wh *webhook.WebhookProvider
 		if existing, ok := cloudInst.(*webhook.WebhookProvider); ok {
 			wh = existing
 		} else {
-			wh, err = webhook.NewWebhookProvider(ctx, webhookURL)
+			wh, err = webhook.NewWebhookProvider(ctx, opts.webhookURL)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to initialize webhook profile provider: %v", err)
 			}
 		}
 
 		if !wh.HasProfileProvider() {
-			return nil, nil, fmt.Errorf("webhook at %q does not support ProfileProvider capability", webhookURL)
+			return nil, nil, fmt.Errorf("webhook at %q does not support ProfileProvider capability", opts.webhookURL)
 		}
 		profProv = wh
 	case "none":
 		profProv = nil
 	default:
-		return nil, nil, fmt.Errorf("unsupported profile provider: %s", profileProvider)
+		return nil, nil, fmt.Errorf("unsupported profile provider: %s", opts.profileProvider)
 	}
 
 	return cloudInst, profProv, nil

--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -84,7 +84,7 @@ func init() {
 	flag.DurationVar(&maxPollInterval, "inventory-max-poll-interval", 1*time.Minute, "The maximum interval between two consecutive polls of the inventory.")
 	flag.IntVar(&pollBurst, "inventory-poll-burst", 5, "The number of polls that can be run in a burst.")
 	flag.BoolVar(&moveIBInterfaces, "move-ib-interfaces", true, "If true, InfiniBand (IPoIB) network interfaces associated with PCI devices are moved into pod network namespace. If false, moving IB network interfaces are skipped and the underlying device is exposed as an IB-only RDMA device.")
-	flag.StringVar(&cloudProviderHint, "cloud-provider-hint", "", "Hint for the cloud provider that will be used to select the appropriate provider plugin. Supported values: (AWS, GCE, AZURE, OKE, ALIBABA, webhook, NONE). If left unset, the cloud provider is auto-detected.")
+	flag.StringVar(&cloudProviderHint, "cloud-provider-hint", "", "Hint for the cloud provider that will be used to select the appropriate provider plugin. Supported values: (AWS, GCE, AZURE, OKE, ALIBABA, CKS, webhook, NONE). If left unset, the cloud provider is auto-detected.")
 	flag.StringVar(&profileProvider, "profile-provider", "cloud", "Provides user intent (cloud, webhook, none). 'cloud' falls back to the cloud-provider's native implementation.")
 	flag.StringVar(&webhookURL, "webhook-url", "", "URL for the webhook provider (required if using webhook for either provider)")
 	flag.StringVar(&kubeletRootDir, "kubelet-root-dir", "/var/lib/kubelet", "The kubelet data directory (its --root-dir). The driver's registration socket lives under <dir>/plugins_registry and its dra.sock under <dir>/plugins/<driver-name>. Set this to match the kubelet --root-dir on clusters that relocate it.")
@@ -192,7 +192,11 @@ func main() {
 		}
 		opts = append(opts, driver.WithFilter(prg))
 	}
-	cloudInst, profProv, err := setupProviders(ctx, cloudProviderHint, profileProvider, webhookURL)
+	providerDependencies := discovery.Dependencies{
+		Nodes:    clientset.CoreV1().Nodes(),
+		NodeName: nodeName,
+	}
+	cloudInst, profProv, err := setupProviders(ctx, cloudProviderHint, profileProvider, webhookURL, providerDependencies)
 	if err != nil {
 		klog.Fatalf("failed to setup providers: %v", err)
 	}
@@ -249,7 +253,7 @@ func printVersion() {
 	klog.Infof("dranet go %s build: %s time: %s", info.GoVersion, vcsRevision, vcsTime)
 }
 
-func setupProviders(ctx context.Context, cloudProviderHint string, profileProvider string, webhookURL string) (cloudprovider.CloudInstance, cloudprovider.ProfileProvider, error) {
+func setupProviders(ctx context.Context, cloudProviderHint string, profileProvider string, webhookURL string, dependencies discovery.Dependencies) (cloudprovider.CloudInstance, cloudprovider.ProfileProvider, error) {
 	var cloudInst cloudprovider.CloudInstance
 	var profProv cloudprovider.ProfileProvider
 	var err error
@@ -257,13 +261,13 @@ func setupProviders(ctx context.Context, cloudProviderHint string, profileProvid
 	var hint discovery.CloudProviderHint
 	// Auto-discover cloud provider if not explicitly set
 	if cloudProviderHint == "" {
-		hint = discovery.DiscoverCloudProvider(ctx, webhookURL)
+		hint = discovery.DiscoverCloudProviderWithDependencies(ctx, webhookURL, dependencies)
 	} else {
 		hint = discovery.CloudProviderHint(cloudProviderHint)
 	}
 
 	// Setup the Underlay (Hardware Discovery / Cloud Instance Info)
-	cloudInst, err = discovery.GetInstanceProperties(ctx, hint, webhookURL)
+	cloudInst, err = discovery.GetInstancePropertiesWithDependencies(ctx, hint, webhookURL, dependencies)
 	if err != nil {
 		klog.Infof("failed to initialize cloud provider %q: %v", hint, err)
 		cloudInst = nil

--- a/cmd/dranet/app.go
+++ b/cmd/dranet/app.go
@@ -273,13 +273,13 @@ func setupProviders(ctx context.Context, opts providerOptions) (cloudprovider.Cl
 	var hint discovery.CloudProviderHint
 	// Auto-discover cloud provider if not explicitly set
 	if opts.cloudProviderHint == "" {
-		hint = discovery.DiscoverCloudProviderWithDependencies(ctx, opts.webhookURL, opts.dependencies)
+		hint = discovery.DiscoverCloudProvider(ctx, opts.webhookURL, opts.dependencies)
 	} else {
 		hint = discovery.CloudProviderHint(opts.cloudProviderHint)
 	}
 
 	// Setup the Underlay (Hardware Discovery / Cloud Instance Info)
-	cloudInst, err = discovery.GetInstancePropertiesWithDependencies(ctx, hint, opts.webhookURL, opts.dependencies)
+	cloudInst, err = discovery.GetInstanceProperties(ctx, hint, opts.webhookURL, opts.dependencies)
 	if err != nil {
 		klog.Infof("failed to initialize cloud provider %q: %v", hint, err)
 		cloudInst = nil

--- a/cmd/dranet/app_test.go
+++ b/cmd/dranet/app_test.go
@@ -158,7 +158,11 @@ func TestSetupProviders(t *testing.T) {
 				endpoint = srv.URL
 			}
 
-			cloudInst, profProv, err := setupProviders(ctx, tt.cloudProviderHint, tt.profileProvider, endpoint, discovery.Dependencies{})
+			cloudInst, profProv, err := setupProviders(ctx, providerOptions{
+				cloudProviderHint: tt.cloudProviderHint,
+				profileProvider:   tt.profileProvider,
+				webhookURL:        endpoint,
+			})
 
 			if (err != nil) != tt.expectErr {
 				t.Errorf("expected error: %v, got: %v", tt.expectErr, err)
@@ -184,11 +188,15 @@ func TestSetupProvidersCKS(t *testing.T) {
 		},
 	}}
 	dependencies := discovery.Dependencies{
-		Nodes:    fake.NewSimpleClientset(node).CoreV1().Nodes(),
-		NodeName: node.Name,
+		NodeClient: fake.NewSimpleClientset(node).CoreV1().Nodes(),
+		NodeName:   node.Name,
 	}
 
-	cloudInstance, profileProvider, err := setupProviders(context.Background(), "CKS", "cloud", "", dependencies)
+	cloudInstance, profileProvider, err := setupProviders(context.Background(), providerOptions{
+		cloudProviderHint: "CKS",
+		profileProvider:   "cloud",
+		dependencies:      dependencies,
+	})
 	if err != nil {
 		t.Fatalf("setupProviders() error = %v", err)
 	}

--- a/cmd/dranet/app_test.go
+++ b/cmd/dranet/app_test.go
@@ -23,6 +23,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/dranet/pkg/cloudprovider/coreweave"
+	"sigs.k8s.io/dranet/pkg/cloudprovider/discovery"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/webhook"
 )
 
@@ -153,7 +158,7 @@ func TestSetupProviders(t *testing.T) {
 				endpoint = srv.URL
 			}
 
-			cloudInst, profProv, err := setupProviders(ctx, tt.cloudProviderHint, tt.profileProvider, endpoint)
+			cloudInst, profProv, err := setupProviders(ctx, tt.cloudProviderHint, tt.profileProvider, endpoint, discovery.Dependencies{})
 
 			if (err != nil) != tt.expectErr {
 				t.Errorf("expected error: %v, got: %v", tt.expectErr, err)
@@ -167,5 +172,30 @@ func TestSetupProviders(t *testing.T) {
 				t.Errorf("expected profProv: %v, got: %v", tt.expectProfProv, profProv != nil)
 			}
 		})
+	}
+}
+
+func TestSetupProvidersCKS(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "cks-node",
+		Labels: map[string]string{
+			coreweave.LabelCKSCluster:   "use15",
+			coreweave.LabelFabricFlavor: "infiniband",
+		},
+	}}
+	dependencies := discovery.Dependencies{
+		Nodes:    fake.NewSimpleClientset(node).CoreV1().Nodes(),
+		NodeName: node.Name,
+	}
+
+	cloudInstance, profileProvider, err := setupProviders(context.Background(), "CKS", "cloud", "", dependencies)
+	if err != nil {
+		t.Fatalf("setupProviders() error = %v", err)
+	}
+	if _, ok := cloudInstance.(*coreweave.Instance); !ok {
+		t.Fatalf("setupProviders() cloud instance = %T, want *coreweave.Instance", cloudInstance)
+	}
+	if profileProvider != nil {
+		t.Fatalf("setupProviders() profile provider = %T, want nil", profileProvider)
 	}
 }

--- a/deployments/helm/dranet/README.md
+++ b/deployments/helm/dranet/README.md
@@ -40,7 +40,7 @@ The following table lists the configurable parameters and their default values:
 | `args.inventoryMaxPollInterval` | Maximum interval between two consecutive inventory polls | binary default: `1m` |
 | `args.inventoryPollBurst` | Number of inventory polls that can be run in a burst | binary default: `5` |
 | `args.moveIBInterfaces` | If true, InfiniBand (IPoIB) interfaces are moved into the pod network namespace | binary default: `true` |
-| `args.cloudProviderHint` | Hint for the cloud provider plugin (`GCE`, `AZURE`, `OKE`, `AWS`, `ALIBABA`, `webhook`, `NONE`); auto-detected if unset | binary default: `""` |
+| `args.cloudProviderHint` | Hint for the cloud provider plugin (`GCE`, `AZURE`, `OKE`, `AWS`, `ALIBABA`, `CKS`, `webhook`, `NONE`); auto-detected if unset | binary default: `""` |
 | `args.profileProvider` | Provider for user profile configuration (`cloud`, `webhook`, `none`) | binary default: `cloud` |
 | `args.webhookURL` | HTTP, HTTPS, or Unix socket URL; required when either provider uses `webhook` | binary default: `""` |
 | `args.featureGates` | Comma-separated feature gate settings in `key=value` format | binary default: `""` |

--- a/deployments/helm/dranet/values.schema.json
+++ b/deployments/helm/dranet/values.schema.json
@@ -100,7 +100,7 @@
         },
         "cloudProviderHint": {
           "type": "string",
-          "enum": ["GCE", "AZURE", "OKE", "AWS", "ALIBABA", "webhook", "NONE"],
+          "enum": ["GCE", "AZURE", "OKE", "AWS", "ALIBABA", "CKS", "webhook", "NONE"],
           "description": "Hint for the cloud provider plugin; auto-detected if unset"
         },
         "profileProvider": {

--- a/pkg/cloudprovider/coreweave/coreweave.go
+++ b/pkg/cloudprovider/coreweave/coreweave.go
@@ -101,7 +101,7 @@ func OnCKS(ctx context.Context, nodes corev1client.NodeInterface, nodeName strin
 // device mapping used by CKS per-interface topology labels.
 func GetInstance(ctx context.Context, nodes corev1client.NodeInterface, nodeName string) (cloudprovider.CloudInstance, error) {
 	if nodes == nil {
-		return nil, fmt.Errorf("Kubernetes Node client is required for CKS")
+		return nil, fmt.Errorf("kubernetes Node client is required for CKS")
 	}
 	if nodeName == "" {
 		return nil, fmt.Errorf("node name is required for CKS")
@@ -112,7 +112,7 @@ func GetInstance(ctx context.Context, nodes corev1client.NodeInterface, nodeName
 		return nil, fmt.Errorf("get CKS Node %q: %w", nodeName, err)
 	}
 	if node.Labels[LabelCKSCluster] == "" {
-		return nil, fmt.Errorf("Node %q does not have the %q CKS label", nodeName, LabelCKSCluster)
+		return nil, fmt.Errorf("node %q does not have the %q CKS label", nodeName, LabelCKSCluster)
 	}
 
 	labels := make(map[string]string, len(node.Labels))

--- a/pkg/cloudprovider/coreweave/coreweave.go
+++ b/pkg/cloudprovider/coreweave/coreweave.go
@@ -1,0 +1,195 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coreweave
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/dranet/pkg/apis"
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
+)
+
+const (
+	AttrPrefix = "coreweave.dra.net"
+
+	AttrFabricFlavor  = AttrPrefix + "/fabricFlavor"
+	AttrFabric        = AttrPrefix + "/fabric"
+	AttrSuperpod      = AttrPrefix + "/superpod"
+	AttrLeafgroup     = AttrPrefix + "/leafgroup"
+	AttrLeafgroupName = AttrPrefix + "/leafgroupName"
+	AttrRack          = AttrPrefix + "/rack"
+	AttrSpeedCurrent  = AttrPrefix + "/speedCurrent"
+	AttrSpeedExpected = AttrPrefix + "/speedExpected"
+	AttrInstanceType  = AttrPrefix + "/instanceType"
+	AttrLeafSwitch    = AttrPrefix + "/leafSwitch"
+
+	LabelCKSCluster    = "cks.coreweave.com/cluster"
+	LabelFabricFlavor  = "backend.coreweave.cloud/flavor"
+	LabelFabric        = "backend.coreweave.cloud/fabric"
+	LabelSuperpod      = "backend.coreweave.cloud/superpod"
+	LabelLeafgroup     = "backend.coreweave.cloud/leafgroup"
+	LabelLeafgroupName = "backend.coreweave.cloud/leafgroup-name"
+	LabelRack          = "node.coreweave.cloud/rack"
+	LabelSpeedCurrent  = "backend.coreweave.cloud/speed.current"
+	LabelSpeedExpected = "backend.coreweave.cloud/speed.expected"
+	LabelInstanceType  = "node.kubernetes.io/instance-type"
+
+	neighborLabelPrefix = "backend.coreweave.cloud/neighbors.expected."
+	neighborLabelSuffix = ".device"
+	defaultRDMASysfs    = "/sys/class/infiniband"
+)
+
+var nodeAttributeLabels = map[resourceapi.QualifiedName]string{
+	AttrFabricFlavor:  LabelFabricFlavor,
+	AttrFabric:        LabelFabric,
+	AttrSuperpod:      LabelSuperpod,
+	AttrLeafgroup:     LabelLeafgroup,
+	AttrLeafgroupName: LabelLeafgroupName,
+	AttrRack:          LabelRack,
+	AttrSpeedCurrent:  LabelSpeedCurrent,
+	AttrSpeedExpected: LabelSpeedExpected,
+	AttrInstanceType:  LabelInstanceType,
+}
+
+var _ cloudprovider.CloudInstance = (*Instance)(nil)
+
+// Instance contains the CKS node metadata used to enrich network devices.
+// CKS publishes this information as Kubernetes Node labels instead of through
+// an instance metadata service.
+type Instance struct {
+	labels          map[string]string
+	rdmaDeviceByPCI map[string]string
+}
+
+// OnCKS reports whether nodeName belongs to a CoreWeave Kubernetes Service
+// cluster. The CKS cluster label is present on both compute and GPU nodes.
+func OnCKS(ctx context.Context, nodes corev1client.NodeInterface, nodeName string) bool {
+	if nodes == nil || nodeName == "" {
+		return false
+	}
+	node, err := nodes.Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		klog.V(4).Infof("could not get Node %q for CKS detection: %v", nodeName, err)
+		return false
+	}
+	return node.Labels[LabelCKSCluster] != ""
+}
+
+// GetInstance reads the local CKS Node labels and discovers the PCI-to-RDMA
+// device mapping used by CKS per-interface topology labels.
+func GetInstance(ctx context.Context, nodes corev1client.NodeInterface, nodeName string) (cloudprovider.CloudInstance, error) {
+	if nodes == nil {
+		return nil, fmt.Errorf("Kubernetes Node client is required for CKS")
+	}
+	if nodeName == "" {
+		return nil, fmt.Errorf("node name is required for CKS")
+	}
+
+	node, err := nodes.Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get CKS Node %q: %w", nodeName, err)
+	}
+	if node.Labels[LabelCKSCluster] == "" {
+		return nil, fmt.Errorf("Node %q does not have the %q CKS label", nodeName, LabelCKSCluster)
+	}
+
+	labels := make(map[string]string, len(node.Labels))
+	for key, value := range node.Labels {
+		labels[key] = value
+	}
+
+	instance := &Instance{
+		labels:          labels,
+		rdmaDeviceByPCI: discoverRDMADevicesByPCI(defaultRDMASysfs),
+	}
+	klog.Infof("CoreWeave CKS node %s: fabric flavor=%q fabric=%q superpod=%q leafgroup=%q",
+		nodeName, labels[LabelFabricFlavor], labels[LabelFabric], labels[LabelSuperpod], labels[LabelLeafgroup])
+	return instance, nil
+}
+
+// GetDeviceAttributes returns CKS fabric topology attributes for a device.
+func (i *Instance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
+	for attribute, label := range nodeAttributeLabels {
+		addStringAttribute(attributes, attribute, i.labels[label])
+	}
+
+	rdmaDevice := i.rdmaDeviceByPCI[normalizePCIAddress(id.PCIAddress)]
+	if rdmaDevice == "" && strings.HasPrefix(id.Name, "ibp") {
+		rdmaDevice = id.Name
+	}
+	if rdmaDevice != "" {
+		label := neighborLabelPrefix + rdmaDevice + neighborLabelSuffix
+		addStringAttribute(attributes, AttrLeafSwitch, i.labels[label])
+	}
+
+	return attributes
+}
+
+// GetDeviceConfig returns nil because CKS topology labels do not define an IP,
+// subnet, gateway, or other per-claim network allocation contract.
+func (i *Instance) GetDeviceConfig(cloudprovider.DeviceIdentifiers) *apis.NetworkConfig {
+	return nil
+}
+
+func addStringAttribute(attributes map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, name resourceapi.QualifiedName, value string) {
+	if value == "" {
+		return
+	}
+	if len(value) > resourceapi.DeviceAttributeMaxValueLength {
+		klog.Warningf("ignoring CKS attribute %s: value exceeds %d bytes", name, resourceapi.DeviceAttributeMaxValueLength)
+		return
+	}
+	attributes[name] = resourceapi.DeviceAttribute{StringValue: ptr.To(value)}
+}
+
+func discoverRDMADevicesByPCI(sysfsRoot string) map[string]string {
+	devices := map[string]string{}
+	paths, err := filepath.Glob(filepath.Join(sysfsRoot, "*", "device"))
+	if err != nil {
+		klog.V(4).Infof("could not enumerate RDMA devices in %s: %v", sysfsRoot, err)
+		return devices
+	}
+	for _, path := range paths {
+		target, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			klog.V(4).Infof("could not resolve RDMA device path %s: %v", path, err)
+			continue
+		}
+		pciAddress := normalizePCIAddress(filepath.Base(target))
+		if pciAddress == "" {
+			continue
+		}
+		rdmaDevice := filepath.Base(filepath.Dir(path))
+		if _, exists := devices[pciAddress]; !exists {
+			devices[pciAddress] = rdmaDevice
+		}
+	}
+	return devices
+}
+
+func normalizePCIAddress(address string) string {
+	return strings.ToLower(strings.TrimPrefix(address, "0000:"))
+}

--- a/pkg/cloudprovider/coreweave/coreweave_test.go
+++ b/pkg/cloudprovider/coreweave/coreweave_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coreweave
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/dranet/pkg/cloudprovider"
+)
+
+func TestOnCKS(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "cks-node",
+			Labels: map[string]string{LabelCKSCluster: "test-cluster"},
+		},
+	}
+	nodes := fake.NewSimpleClientset(node).CoreV1().Nodes()
+
+	if !OnCKS(context.Background(), nodes, node.Name) {
+		t.Fatal("OnCKS() = false, want true")
+	}
+	if OnCKS(context.Background(), nodes, "missing-node") {
+		t.Fatal("OnCKS() = true for a missing Node")
+	}
+	if OnCKS(context.Background(), nil, node.Name) {
+		t.Fatal("OnCKS() = true with a nil Node client")
+	}
+}
+
+func TestGetInstanceRejectsNonCKSNode(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "other-node"}}
+	nodes := fake.NewSimpleClientset(node).CoreV1().Nodes()
+
+	if _, err := GetInstance(context.Background(), nodes, node.Name); err == nil {
+		t.Fatal("GetInstance() error = nil, want missing CKS label error")
+	}
+}
+
+func TestGetDeviceAttributes(t *testing.T) {
+	labels := map[string]string{
+		LabelCKSCluster:    "use15",
+		LabelFabricFlavor:  "infiniband",
+		LabelFabric:        "US-EAST-15A-FAB66",
+		LabelSuperpod:      "2",
+		LabelLeafgroup:     "856886992745",
+		LabelLeafgroupName: "90.1-DH1",
+		LabelRack:          "82",
+		LabelSpeedCurrent:  "3200G",
+		LabelSpeedExpected: "3200G",
+		LabelInstanceType:  "b200-8x",
+		neighborLabelPrefix + "ibp0" + neighborLabelSuffix: "L90.1.3",
+	}
+	instance := &Instance{
+		labels:          labels,
+		rdmaDeviceByPCI: map[string]string{"18:00.0": "ibp0"},
+	}
+
+	attributes := instance.GetDeviceAttributes(cloudprovider.DeviceIdentifiers{PCIAddress: "0000:18:00.0"})
+	want := map[resourceapi.QualifiedName]string{
+		AttrFabricFlavor:  "infiniband",
+		AttrFabric:        "US-EAST-15A-FAB66",
+		AttrSuperpod:      "2",
+		AttrLeafgroup:     "856886992745",
+		AttrLeafgroupName: "90.1-DH1",
+		AttrRack:          "82",
+		AttrSpeedCurrent:  "3200G",
+		AttrSpeedExpected: "3200G",
+		AttrInstanceType:  "b200-8x",
+		AttrLeafSwitch:    "L90.1.3",
+	}
+	if len(attributes) != len(want) {
+		t.Fatalf("GetDeviceAttributes() returned %d attributes, want %d: %#v", len(attributes), len(want), attributes)
+	}
+	for name, wantValue := range want {
+		attribute, ok := attributes[name]
+		if !ok || attribute.StringValue == nil || *attribute.StringValue != wantValue {
+			t.Errorf("attribute %s = %#v, want %q", name, attribute, wantValue)
+		}
+	}
+}
+
+func TestGetDeviceAttributesSkipsUnavailableValues(t *testing.T) {
+	instance := &Instance{labels: map[string]string{
+		LabelFabric: strings.Repeat("x", resourceapi.DeviceAttributeMaxValueLength+1),
+	}}
+
+	attributes := instance.GetDeviceAttributes(cloudprovider.DeviceIdentifiers{})
+	if len(attributes) != 0 {
+		t.Fatalf("GetDeviceAttributes() = %#v, want no attributes", attributes)
+	}
+}
+
+func TestGetDeviceAttributesUsesRDMABasedName(t *testing.T) {
+	instance := &Instance{labels: map[string]string{
+		neighborLabelPrefix + "ibp7" + neighborLabelSuffix: "L90.1.5",
+	}}
+
+	attributes := instance.GetDeviceAttributes(cloudprovider.DeviceIdentifiers{Name: "ibp7"})
+	if got := attributes[AttrLeafSwitch].StringValue; got == nil || *got != "L90.1.5" {
+		t.Fatalf("leaf switch attribute = %#v, want L90.1.5", got)
+	}
+}
+
+func TestDiscoverRDMADevicesByPCI(t *testing.T) {
+	root := t.TempDir()
+	pciDevice := filepath.Join(root, "devices", "pci0000:00", "0000:18:00.0")
+	if err := os.MkdirAll(pciDevice, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rdmaDevice := filepath.Join(root, "class", "infiniband", "ibp0")
+	if err := os.MkdirAll(rdmaDevice, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(pciDevice, filepath.Join(rdmaDevice, "device")); err != nil {
+		t.Fatal(err)
+	}
+
+	devices := discoverRDMADevicesByPCI(filepath.Join(root, "class", "infiniband"))
+	if got := devices["18:00.0"]; got != "ibp0" {
+		t.Fatalf("discoverRDMADevicesByPCI() = %#v, want 18:00.0 -> ibp0", devices)
+	}
+}
+
+func TestGetDeviceConfig(t *testing.T) {
+	instance := &Instance{}
+	if config := instance.GetDeviceConfig(cloudprovider.DeviceIdentifiers{}); config != nil {
+		t.Fatalf("GetDeviceConfig() = %#v, want nil", config)
+	}
+}

--- a/pkg/cloudprovider/discovery/discovery.go
+++ b/pkg/cloudprovider/discovery/discovery.go
@@ -52,6 +52,11 @@ type Dependencies struct {
 	NodeName   string
 }
 
+type cloudProviderProbe struct {
+	hint  CloudProviderHint
+	match func() bool
+}
+
 // DiscoverCloudProvider probes the environment to detect which cloud provider DRANET is running on.
 func DiscoverCloudProvider(ctx context.Context, webhookURL string) CloudProviderHint {
 	return DiscoverCloudProviderWithDependencies(ctx, webhookURL, Dependencies{})
@@ -60,26 +65,30 @@ func DiscoverCloudProvider(ctx context.Context, webhookURL string) CloudProvider
 // DiscoverCloudProviderWithDependencies probes the environment using additional
 // Kubernetes-local provider inputs when available.
 func DiscoverCloudProviderWithDependencies(ctx context.Context, webhookURL string, dependencies Dependencies) CloudProviderHint {
-	if metadata.OnGCE() {
-		return CloudProviderHintGCE
+	return detectCloudProvider(cloudProviderProbes(ctx, webhookURL, dependencies))
+}
+
+func cloudProviderProbes(ctx context.Context, webhookURL string, dependencies Dependencies) []cloudProviderProbe {
+	return []cloudProviderProbe{
+		{hint: CloudProviderHintGCE, match: metadata.OnGCE},
+		{hint: CloudProviderHintAWS, match: func() bool { return aws.OnAWS(ctx) }},
+		{hint: CloudProviderHintAzure, match: func() bool { return azure.OnAzure(ctx) }},
+		{hint: CloudProviderHintOKE, match: func() bool { return oke.OnOKE(ctx) }},
+		{hint: CloudProviderHintAlibaba, match: func() bool { return alibaba.OnAlibaba(ctx) }},
+		{hint: CloudProviderHintCKS, match: func() bool {
+			return coreweave.OnCKS(ctx, dependencies.NodeClient, dependencies.NodeName)
+		}},
+		{hint: CloudProviderHintWebhook, match: func() bool {
+			return webhookURL != "" && webhook.OnWebhook(ctx, webhookURL)
+		}},
 	}
-	if aws.OnAWS(ctx) {
-		return CloudProviderHintAWS
-	}
-	if azure.OnAzure(ctx) {
-		return CloudProviderHintAzure
-	}
-	if oke.OnOKE(ctx) {
-		return CloudProviderHintOKE
-	}
-	if alibaba.OnAlibaba(ctx) {
-		return CloudProviderHintAlibaba
-	}
-	if coreweave.OnCKS(ctx, dependencies.NodeClient, dependencies.NodeName) {
-		return CloudProviderHintCKS
-	}
-	if webhookURL != "" && webhook.OnWebhook(ctx, webhookURL) {
-		return CloudProviderHintWebhook
+}
+
+func detectCloudProvider(probes []cloudProviderProbe) CloudProviderHint {
+	for _, probe := range probes {
+		if probe.match() {
+			return probe.hint
+		}
 	}
 	return CloudProviderHintNone
 }

--- a/pkg/cloudprovider/discovery/discovery.go
+++ b/pkg/cloudprovider/discovery/discovery.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/compute/metadata"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/alibaba"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/aws"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/azure"
+	"sigs.k8s.io/dranet/pkg/cloudprovider/coreweave"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/gce"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/oke"
 	"sigs.k8s.io/dranet/pkg/cloudprovider/webhook"
@@ -38,12 +40,31 @@ const (
 	CloudProviderHintAzure   CloudProviderHint = "AZURE"
 	CloudProviderHintOKE     CloudProviderHint = "OKE"
 	CloudProviderHintAlibaba CloudProviderHint = "ALIBABA"
+	CloudProviderHintCKS     CloudProviderHint = "CKS"
 	CloudProviderHintWebhook CloudProviderHint = "webhook"
 	CloudProviderHintNone    CloudProviderHint = "NONE"
 )
 
+// Dependencies contains Kubernetes-local inputs used by providers that do not
+// expose a conventional instance metadata service.
+type Dependencies struct {
+	Nodes    corev1client.NodeInterface
+	NodeName string
+}
+
 // DiscoverCloudProvider probes the environment to detect which cloud provider DRANET is running on.
 func DiscoverCloudProvider(ctx context.Context, webhookURL string) CloudProviderHint {
+	return DiscoverCloudProviderWithDependencies(ctx, webhookURL, Dependencies{})
+}
+
+// DiscoverCloudProviderWithDependencies probes the environment using additional
+// Kubernetes-local provider inputs when available.
+func DiscoverCloudProviderWithDependencies(ctx context.Context, webhookURL string, dependencies Dependencies) CloudProviderHint {
+	// CKS is checked first because its authoritative metadata is already in the
+	// Kubernetes Node object. Avoid slower link-local metadata probes on CKS.
+	if coreweave.OnCKS(ctx, dependencies.Nodes, dependencies.NodeName) {
+		return CloudProviderHintCKS
+	}
 	if metadata.OnGCE() {
 		return CloudProviderHintGCE
 	}
@@ -67,6 +88,12 @@ func DiscoverCloudProvider(ctx context.Context, webhookURL string) CloudProvider
 
 // GetInstanceProperties initializes and returns the specified cloud provider instance.
 func GetInstanceProperties(ctx context.Context, hint CloudProviderHint, webhookURL string) (cloudprovider.CloudInstance, error) {
+	return GetInstancePropertiesWithDependencies(ctx, hint, webhookURL, Dependencies{})
+}
+
+// GetInstancePropertiesWithDependencies initializes the specified cloud provider
+// using additional Kubernetes-local provider inputs when available.
+func GetInstancePropertiesWithDependencies(ctx context.Context, hint CloudProviderHint, webhookURL string, dependencies Dependencies) (cloudprovider.CloudInstance, error) {
 	switch hint {
 	case CloudProviderHintGCE:
 		return gce.GetInstance(ctx)
@@ -78,6 +105,8 @@ func GetInstanceProperties(ctx context.Context, hint CloudProviderHint, webhookU
 		return oke.GetInstance(ctx)
 	case CloudProviderHintAlibaba:
 		return alibaba.GetInstance(ctx)
+	case CloudProviderHintCKS:
+		return coreweave.GetInstance(ctx, dependencies.Nodes, dependencies.NodeName)
 	case CloudProviderHintWebhook:
 		if webhookURL == "" {
 			return nil, fmt.Errorf("--webhook-url is required when using the webhook cloud provider")

--- a/pkg/cloudprovider/discovery/discovery.go
+++ b/pkg/cloudprovider/discovery/discovery.go
@@ -57,14 +57,9 @@ type cloudProviderProbe struct {
 	match func() bool
 }
 
-// DiscoverCloudProvider probes the environment to detect which cloud provider DRANET is running on.
-func DiscoverCloudProvider(ctx context.Context, webhookURL string) CloudProviderHint {
-	return DiscoverCloudProviderWithDependencies(ctx, webhookURL, Dependencies{})
-}
-
-// DiscoverCloudProviderWithDependencies probes the environment using additional
-// Kubernetes-local provider inputs when available.
-func DiscoverCloudProviderWithDependencies(ctx context.Context, webhookURL string, dependencies Dependencies) CloudProviderHint {
+// DiscoverCloudProvider probes the environment using additional Kubernetes-local
+// provider inputs when available to detect which cloud provider DRANET is running on.
+func DiscoverCloudProvider(ctx context.Context, webhookURL string, dependencies Dependencies) CloudProviderHint {
 	return detectCloudProvider(cloudProviderProbes(ctx, webhookURL, dependencies))
 }
 
@@ -93,14 +88,9 @@ func detectCloudProvider(probes []cloudProviderProbe) CloudProviderHint {
 	return CloudProviderHintNone
 }
 
-// GetInstanceProperties initializes and returns the specified cloud provider instance.
-func GetInstanceProperties(ctx context.Context, hint CloudProviderHint, webhookURL string) (cloudprovider.CloudInstance, error) {
-	return GetInstancePropertiesWithDependencies(ctx, hint, webhookURL, Dependencies{})
-}
-
-// GetInstancePropertiesWithDependencies initializes the specified cloud provider
-// using additional Kubernetes-local provider inputs when available.
-func GetInstancePropertiesWithDependencies(ctx context.Context, hint CloudProviderHint, webhookURL string, dependencies Dependencies) (cloudprovider.CloudInstance, error) {
+// GetInstanceProperties initializes the specified cloud provider using additional
+// Kubernetes-local provider inputs when available.
+func GetInstanceProperties(ctx context.Context, hint CloudProviderHint, webhookURL string, dependencies Dependencies) (cloudprovider.CloudInstance, error) {
 	switch hint {
 	case CloudProviderHintGCE:
 		return gce.GetInstance(ctx)

--- a/pkg/cloudprovider/discovery/discovery.go
+++ b/pkg/cloudprovider/discovery/discovery.go
@@ -48,8 +48,8 @@ const (
 // Dependencies contains Kubernetes-local inputs used by providers that do not
 // expose a conventional instance metadata service.
 type Dependencies struct {
-	Nodes    corev1client.NodeInterface
-	NodeName string
+	NodeClient corev1client.NodeInterface
+	NodeName   string
 }
 
 // DiscoverCloudProvider probes the environment to detect which cloud provider DRANET is running on.
@@ -60,11 +60,6 @@ func DiscoverCloudProvider(ctx context.Context, webhookURL string) CloudProvider
 // DiscoverCloudProviderWithDependencies probes the environment using additional
 // Kubernetes-local provider inputs when available.
 func DiscoverCloudProviderWithDependencies(ctx context.Context, webhookURL string, dependencies Dependencies) CloudProviderHint {
-	// CKS is checked first because its authoritative metadata is already in the
-	// Kubernetes Node object. Avoid slower link-local metadata probes on CKS.
-	if coreweave.OnCKS(ctx, dependencies.Nodes, dependencies.NodeName) {
-		return CloudProviderHintCKS
-	}
 	if metadata.OnGCE() {
 		return CloudProviderHintGCE
 	}
@@ -79,6 +74,9 @@ func DiscoverCloudProviderWithDependencies(ctx context.Context, webhookURL strin
 	}
 	if alibaba.OnAlibaba(ctx) {
 		return CloudProviderHintAlibaba
+	}
+	if coreweave.OnCKS(ctx, dependencies.NodeClient, dependencies.NodeName) {
+		return CloudProviderHintCKS
 	}
 	if webhookURL != "" && webhook.OnWebhook(ctx, webhookURL) {
 		return CloudProviderHintWebhook
@@ -106,7 +104,7 @@ func GetInstancePropertiesWithDependencies(ctx context.Context, hint CloudProvid
 	case CloudProviderHintAlibaba:
 		return alibaba.GetInstance(ctx)
 	case CloudProviderHintCKS:
-		return coreweave.GetInstance(ctx, dependencies.Nodes, dependencies.NodeName)
+		return coreweave.GetInstance(ctx, dependencies.NodeClient, dependencies.NodeName)
 	case CloudProviderHintWebhook:
 		if webhookURL == "" {
 			return nil, fmt.Errorf("--webhook-url is required when using the webhook cloud provider")

--- a/pkg/cloudprovider/discovery/discovery_test.go
+++ b/pkg/cloudprovider/discovery/discovery_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/dranet/pkg/cloudprovider/coreweave"
+)
+
+func TestDiscoverCloudProviderDetectsCKS(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "cks-node",
+		Labels: map[string]string{
+			coreweave.LabelCKSCluster: "use15",
+		},
+	}}
+	dependencies := Dependencies{
+		Nodes:    fake.NewSimpleClientset(node).CoreV1().Nodes(),
+		NodeName: node.Name,
+	}
+
+	if got := DiscoverCloudProviderWithDependencies(context.Background(), "", dependencies); got != CloudProviderHintCKS {
+		t.Fatalf("DiscoverCloudProviderWithDependencies() = %q, want %q", got, CloudProviderHintCKS)
+	}
+}
+
+func TestGetInstancePropertiesCKS(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "cks-node",
+		Labels: map[string]string{
+			coreweave.LabelCKSCluster:   "use15",
+			coreweave.LabelFabricFlavor: "infiniband",
+			coreweave.LabelFabric:       "US-EAST-15A-FAB66",
+		},
+	}}
+	dependencies := Dependencies{
+		Nodes:    fake.NewSimpleClientset(node).CoreV1().Nodes(),
+		NodeName: node.Name,
+	}
+
+	instance, err := GetInstancePropertiesWithDependencies(context.Background(), CloudProviderHintCKS, "", dependencies)
+	if err != nil {
+		t.Fatalf("GetInstancePropertiesWithDependencies() error = %v", err)
+	}
+	if _, ok := instance.(*coreweave.Instance); !ok {
+		t.Fatalf("GetInstancePropertiesWithDependencies() = %T, want *coreweave.Instance", instance)
+	}
+}
+
+func TestGetInstancePropertiesCKSRequiresDependencies(t *testing.T) {
+	if _, err := GetInstanceProperties(context.Background(), CloudProviderHintCKS, ""); err == nil {
+		t.Fatal("GetInstanceProperties() error = nil, want missing Kubernetes dependency error")
+	}
+}

--- a/pkg/cloudprovider/discovery/discovery_test.go
+++ b/pkg/cloudprovider/discovery/discovery_test.go
@@ -26,20 +26,36 @@ import (
 	"sigs.k8s.io/dranet/pkg/cloudprovider/coreweave"
 )
 
-func TestDiscoverCloudProviderDetectsCKS(t *testing.T) {
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
-		Name: "cks-node",
-		Labels: map[string]string{
-			coreweave.LabelCKSCluster: "use15",
-		},
-	}}
-	dependencies := Dependencies{
-		NodeClient: fake.NewSimpleClientset(node).CoreV1().Nodes(),
-		NodeName:   node.Name,
+func TestCloudProviderProbeOrder(t *testing.T) {
+	probes := cloudProviderProbes(context.Background(), "", Dependencies{})
+	want := []CloudProviderHint{
+		CloudProviderHintGCE,
+		CloudProviderHintAWS,
+		CloudProviderHintAzure,
+		CloudProviderHintOKE,
+		CloudProviderHintAlibaba,
+		CloudProviderHintCKS,
+		CloudProviderHintWebhook,
 	}
 
-	if got := DiscoverCloudProviderWithDependencies(context.Background(), "", dependencies); got != CloudProviderHintCKS {
-		t.Fatalf("DiscoverCloudProviderWithDependencies() = %q, want %q", got, CloudProviderHintCKS)
+	if len(probes) != len(want) {
+		t.Fatalf("cloudProviderProbes() returned %d probes, want %d", len(probes), len(want))
+	}
+	for i := range want {
+		if probes[i].hint != want[i] {
+			t.Errorf("cloudProviderProbes()[%d].hint = %q, want %q", i, probes[i].hint, want[i])
+		}
+	}
+}
+
+func TestDetectCloudProviderReturnsFirstMatch(t *testing.T) {
+	probes := []cloudProviderProbe{
+		{hint: CloudProviderHintAzure, match: func() bool { return true }},
+		{hint: CloudProviderHintCKS, match: func() bool { return true }},
+	}
+
+	if got := detectCloudProvider(probes); got != CloudProviderHintAzure {
+		t.Fatalf("detectCloudProvider() = %q, want %q", got, CloudProviderHintAzure)
 	}
 }
 

--- a/pkg/cloudprovider/discovery/discovery_test.go
+++ b/pkg/cloudprovider/discovery/discovery_test.go
@@ -34,8 +34,8 @@ func TestDiscoverCloudProviderDetectsCKS(t *testing.T) {
 		},
 	}}
 	dependencies := Dependencies{
-		Nodes:    fake.NewSimpleClientset(node).CoreV1().Nodes(),
-		NodeName: node.Name,
+		NodeClient: fake.NewSimpleClientset(node).CoreV1().Nodes(),
+		NodeName:   node.Name,
 	}
 
 	if got := DiscoverCloudProviderWithDependencies(context.Background(), "", dependencies); got != CloudProviderHintCKS {
@@ -53,8 +53,8 @@ func TestGetInstancePropertiesCKS(t *testing.T) {
 		},
 	}}
 	dependencies := Dependencies{
-		Nodes:    fake.NewSimpleClientset(node).CoreV1().Nodes(),
-		NodeName: node.Name,
+		NodeClient: fake.NewSimpleClientset(node).CoreV1().Nodes(),
+		NodeName:   node.Name,
 	}
 
 	instance, err := GetInstancePropertiesWithDependencies(context.Background(), CloudProviderHintCKS, "", dependencies)

--- a/pkg/cloudprovider/discovery/discovery_test.go
+++ b/pkg/cloudprovider/discovery/discovery_test.go
@@ -73,17 +73,17 @@ func TestGetInstancePropertiesCKS(t *testing.T) {
 		NodeName:   node.Name,
 	}
 
-	instance, err := GetInstancePropertiesWithDependencies(context.Background(), CloudProviderHintCKS, "", dependencies)
+	instance, err := GetInstanceProperties(context.Background(), CloudProviderHintCKS, "", dependencies)
 	if err != nil {
-		t.Fatalf("GetInstancePropertiesWithDependencies() error = %v", err)
+		t.Fatalf("GetInstanceProperties() error = %v", err)
 	}
 	if _, ok := instance.(*coreweave.Instance); !ok {
-		t.Fatalf("GetInstancePropertiesWithDependencies() = %T, want *coreweave.Instance", instance)
+		t.Fatalf("GetInstanceProperties() = %T, want *coreweave.Instance", instance)
 	}
 }
 
 func TestGetInstancePropertiesCKSRequiresDependencies(t *testing.T) {
-	if _, err := GetInstanceProperties(context.Background(), CloudProviderHintCKS, ""); err == nil {
+	if _, err := GetInstanceProperties(context.Background(), CloudProviderHintCKS, "", Dependencies{}); err == nil {
 		t.Fatal("GetInstanceProperties() error = nil, want missing Kubernetes dependency error")
 	}
 }


### PR DESCRIPTION
Part of #301.

Adds native CKS discovery through Kubernetes Node labels and publishes InfiniBand fabric, superpod, leafgroup, rack, speed, instance type, and per-device leaf-switch attributes. Also adds the `CKS` provider hint to the binary and Helm chart.

Verification:
- `go test ./...`
- `hack/verify-gofmt.sh`
- `helm lint --strict deployments/helm/dranet`
- `helm template dranet deployments/helm/dranet --set args.cloudProviderHint=CKS`
- Read-only validation against CKS `use15` confirmed the implemented fabric and `neighbors.expected.ibpN.device` label contract.

#### Does this PR introduce a user-facing change?

```release-note
Add CoreWeave Kubernetes Service (CKS) cloud-provider discovery and InfiniBand topology attributes.
```