### PR TITLE
Add CKS B200 InfiniBand NCCL example

### DIFF
--- a/examples/coreweave_cks_examples/README.md
+++ b/examples/coreweave_cks_examples/README.md
@@ -1,0 +1,13 @@
+# CoreWeave Kubernetes Service + DRANET examples
+
+End-to-end examples of topology-aware RDMA device allocation on CoreWeave
+Kubernetes Service (CKS) using Kubernetes Dynamic Resource Allocation (DRA).
+
+| Example | Node type | Fabric | Validation |
+|---|---|---|---|
+| [`b200-infiniband/`](b200-infiniband/) | 8 x NVIDIA B200 | 8 x 400 Gb/s InfiniBand HCA | Two-node NCCL all-reduce over a DRA-allocated HCA |
+
+CKS exposes its network topology through Kubernetes Node labels. The native
+CKS provider copies that topology into each network device published by
+DRANET, allowing claims to select devices by fabric, superpod, leafgroup, or
+leaf switch without querying an instance metadata service.

--- a/examples/coreweave_cks_examples/b200-infiniband/README.md
+++ b/examples/coreweave_cks_examples/b200-infiniband/README.md
@@ -1,0 +1,159 @@
+# CKS B200 InfiniBand DRANET example
+
+This example runs NCCL `all_reduce_perf` across two B200 nodes on CoreWeave
+Kubernetes Service (CKS). Each worker receives one GPU and one backend
+InfiniBand HCA. DRANET publishes the HCA through DRA and injects only its RDMA
+character devices into the container through NRI.
+
+The workflow was validated on a CKS cluster running Kubernetes 1.36 with
+8-GPU NVIDIA B200 nodes. It intentionally uses
+`--move-ib-interfaces=false`: the HCA is exposed as an IB-only RDMA device and
+its host IPoIB interface is not moved into the pod network namespace.
+
+## Prerequisites
+
+- A DRANET image containing the native CKS cloud provider.
+- Kubernetes DRA using the `resource.k8s.io/v1` API.
+- Containerd with NRI enabled and its socket available at `/var/run/nri`.
+- CKS B200 nodes carrying `cks.coreweave.com/cluster` and
+  `backend.coreweave.cloud/*` topology labels.
+- Kubeflow MPI Operator v0.7.0 for the two-node NCCL test:
+
+  ```bash
+  kubectl apply --server-side -k \
+    "https://github.com/kubeflow/mpi-operator/manifests/overlays/standalone?ref=v0.7.0"
+  ```
+
+Confirm the node architecture and topology before installing:
+
+```bash
+kubectl get nodes -l node.kubernetes.io/instance-type=b200-8x \
+  -L kubernetes.io/arch,backend.coreweave.cloud/fabric,backend.coreweave.cloud/superpod
+```
+
+## Install DRANET on two nodes
+
+Choose exactly two idle B200 nodes in the same fabric, superpod, and leafgroup,
+then label them for the test:
+
+```bash
+kubectl label nodes <node-1> <node-2> dra.net/cks-nccl-test=true
+
+helm upgrade --install dranet-cks-test ../../../deployments/helm/dranet \
+  --namespace dranet-e2e \
+  --create-namespace \
+  --set image.repository=<image-repository> \
+  --set image.tag=<image-tag> \
+  --set image.pullPolicy=Always \
+  --set-string 'nodeSelector.dra\.net/cks-nccl-test=true' \
+  --set args.cloudProviderHint=CKS \
+  --set args.profileProvider=none \
+  --set args.moveIBInterfaces=false \
+  --wait
+```
+
+Verify the DaemonSet and the resulting `dra.net` ResourceSlice:
+
+```bash
+kubectl -n dranet-e2e get daemonset,pods -o wide
+kubectl get resourceslices \
+  -o custom-columns=NAME:.metadata.name,NODE:.spec.nodeName,DRIVER:.spec.driver \
+  | grep dra.net
+```
+
+## CKS topology attributes
+
+The CKS provider publishes these attributes under `coreweave.dra.net`:
+
+| Attribute | Scope | Example from validation |
+|---|---|---|
+| `fabricFlavor` | Node | `infiniband` |
+| `fabric` | Node | `US-EAST-15A-FAB66` |
+| `superpod` | Node | `2` |
+| `leafgroup` | Node | `856886992745` |
+| `leafgroupName` | Node | `90.1-DH1` |
+| `rack` | Node | `82` |
+| `speedCurrent` | Node | `3200G` |
+| `speedExpected` | Node | `3200G` |
+| `instanceType` | Node | `b200-8x` |
+| `leafSwitch` | HCA | `L90.1.3` |
+
+On the validated node, DRANET published all eight backend HCAs (`ibp0` through
+`ibp7`) with leaf-switch values. The `DeviceClass` requires `leafSwitch` to be
+present, excluding RDMA-capable internal devices which are not backend fabric
+HCAs.
+
+To constrain a claim to a known fabric location, add selectors to the NIC
+request in `resource-claim-template.yaml`. For example:
+
+```yaml
+selectors:
+- cel:
+    expression: >-
+      device.attributes["coreweave.dra.net"].fabric == "US-EAST-15A-FAB66" &&
+      device.attributes["coreweave.dra.net"].superpod == "2" &&
+      device.attributes["coreweave.dra.net"].leafgroup == "856886992745"
+```
+
+Use values from your own cluster; the identifiers above are validation
+examples and are not portable between CKS fabrics.
+
+## Run the two-node NCCL test
+
+The test uses Kubeflow MPI Operator and CoreWeave's NCCL test image. Confirm
+that both nodes publish a `dra.net` ResourceSlice, then apply the class, claim
+template, and MPIJob:
+
+```bash
+kubectl get resourceslices \
+  -o custom-columns=NODE:.spec.nodeName,DRIVER:.spec.driver \
+  | grep dra.net
+
+kubectl apply -f device-class.yaml
+kubectl -n dranet-e2e apply -f resource-claim-template.yaml
+kubectl -n dranet-e2e apply -f mpi-job.yaml
+
+kubectl -n dranet-e2e get pods -o wide
+kubectl -n dranet-e2e logs -f \
+  -l training.kubeflow.org/job-name=cks-nccl-test-dra,training.kubeflow.org/job-role=launcher
+```
+
+Each worker requests one `nvidia.com/gpu` and one
+`infiniband.cks.coreweave.com` device. Required pod anti-affinity places the
+workers on different nodes, while the test node label confines them to the two
+nodes whose DRANET instances publish CKS topology. `NCCL_SHM_DISABLE=1` and
+the cross-node placement ensure the collective uses the InfiniBand transport
+rather than satisfying the test through intra-node NVLink or shared memory.
+
+### Validated NCCL result
+
+The test completed successfully across two B200 nodes in the same fabric,
+superpod, and leafgroup. Each claim allocated `pci-0000-1a-00-0` (`ibp0`) and
+reached `RDMAOnlyDeviceReady`. NCCL reported
+`NET/IBext_v11/0/GDRDMA`, confirming that the collective used the
+DRA-allocated InfiniBand HCA with GPUDirect RDMA.
+
+| Message size | Out-of-place bus bandwidth | Validation errors |
+|---:|---:|---:|
+| 8 MiB | 30.33 GB/s | 0 |
+| 128 MiB | 43.82 GB/s | 0 |
+| 512 MiB | 45.79 GB/s | 0 |
+| 1 GiB | 46.35 GB/s | 0 |
+
+Average bus bandwidth across the tested sizes was 41.72 GB/s. These values
+document one validation run and are not a general CKS performance guarantee.
+
+## Clean up
+
+Delete the MPIJob first so kubelet calls `NodeUnprepareResources` and releases
+the generated claims:
+
+```bash
+kubectl -n dranet-e2e delete mpijob.kubeflow.org cks-nccl-test-dra
+kubectl -n dranet-e2e delete resourceclaimtemplate cks-infiniband-1nic
+kubectl delete deviceclass infiniband.cks.coreweave.com
+
+kubectl label nodes <node-1> <node-2> dra.net/cks-nccl-test-
+helm uninstall dranet-cks-test --namespace dranet-e2e
+kubectl delete namespace dranet-e2e
+```

--- a/examples/coreweave_cks_examples/b200-infiniband/device-class.yaml
+++ b/examples/coreweave_cks_examples/b200-infiniband/device-class.yaml
@@ -1,0 +1,18 @@
+# Selects physical CKS InfiniBand HCAs with per-device leaf-switch topology.
+# The presence checks exclude other RDMA-capable devices on B200 nodes which
+# are not connected to the backend InfiniBand fabric.
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: infiniband.cks.coreweave.com
+spec:
+  selectors:
+  - cel:
+      expression: >-
+        device.driver == "dra.net" &&
+        device.attributes["dra.net"].rdma == true
+  - cel:
+      expression: >-
+        "coreweave.dra.net" in device.attributes &&
+        device.attributes["coreweave.dra.net"].fabricFlavor == "infiniband" &&
+        "leafSwitch" in device.attributes["coreweave.dra.net"]

--- a/examples/coreweave_cks_examples/b200-infiniband/mpi-job.yaml
+++ b/examples/coreweave_cks_examples/b200-infiniband/mpi-job.yaml
@@ -1,0 +1,82 @@
+# Two-node NCCL all-reduce with one GPU and one DRA-allocated InfiniBand HCA
+# per worker. Install Kubeflow MPI Operator v0.7.0 before applying this file.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: cks-nccl-test-dra
+spec:
+  slotsPerWorker: 1
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          activeDeadlineSeconds: 900
+          containers:
+          - name: nccl
+            image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu24.04-nccl2.29.2-1-d73ec07
+            command: ["/bin/bash", "-c"]
+            args:
+            - |
+              while ! (for host in $(awk '{print $1}' /etc/mpi/hostfile); do
+                ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no "$host" exit 2>/dev/null || exit 1
+              done); do
+                echo "Waiting for workers to be ready..."
+                sleep 5
+              done
+              mpirun -np 2 \
+                --allow-run-as-root \
+                -bind-to none \
+                -x LD_LIBRARY_PATH \
+                -x NCCL_DEBUG=INFO \
+                -x NCCL_SOCKET_IFNAME=eth0 \
+                -x NCCL_IB_DISABLE=0 \
+                -x NCCL_IB_HCA=ibp \
+                -x NCCL_SHM_DISABLE=1 \
+                -x NCCL_MNNVL_ENABLE=0 \
+                -x NCCL_NVLS_ENABLE=0 \
+                -x NCCL_NET_GDR_LEVEL=PHB \
+                -x NCCL_IB_DATA_DIRECT=0 \
+                /opt/nccl_tests/build/all_reduce_perf \
+                  -b 8M -e 1G -f 2 -g 1 -c 1
+    Worker:
+      replicas: 2
+      restartPolicy: Never
+      template:
+        spec:
+          activeDeadlineSeconds: 900
+          automountServiceAccountToken: false
+          nodeSelector:
+            dra.net/cks-nccl-test: "true"
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    training.kubeflow.org/job-name: cks-nccl-test-dra
+                    training.kubeflow.org/job-role: worker
+                topologyKey: kubernetes.io/hostname
+          resourceClaims:
+          - name: infiniband
+            resourceClaimTemplateName: cks-infiniband-1nic
+          containers:
+          - name: nccl
+            image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu24.04-nccl2.29.2-1-d73ec07
+            resources:
+              limits:
+                nvidia.com/gpu: "1"
+              claims:
+              - name: infiniband
+            securityContext:
+              capabilities:
+                add:
+                - IPC_LOCK
+            volumeMounts:
+            - name: shm
+              mountPath: /dev/shm
+          volumes:
+          - name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 8Gi

--- a/examples/coreweave_cks_examples/b200-infiniband/resource-claim-template.yaml
+++ b/examples/coreweave_cks_examples/b200-infiniband/resource-claim-template.yaml
@@ -1,0 +1,13 @@
+# One CKS InfiniBand HCA per pod.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: cks-infiniband-1nic
+spec:
+  spec:
+    devices:
+      requests:
+      - name: nic
+        exactly:
+          deviceClassName: infiniband.cks.coreweave.com
+          count: 1

--- a/site/content/docs/user/coreweave-cks.md
+++ b/site/content/docs/user/coreweave-cks.md
@@ -1,0 +1,57 @@
+---
+title: "CoreWeave CKS with InfiniBand"
+date: 2026-08-26T00:00:00Z
+---
+
+DRANET can publish CoreWeave Kubernetes Service (CKS) InfiniBand HCAs through
+Kubernetes Dynamic Resource Allocation (DRA). The native CKS provider reads
+the local Kubernetes Node labels instead of an instance metadata service and
+adds fabric, superpod, leafgroup, rack, speed, and per-HCA leaf-switch
+attributes to the `dra.net` ResourceSlice.
+
+The complete two-node B200 NCCL test is under
+[`examples/coreweave_cks_examples/b200-infiniband`](https://github.com/kubernetes-sigs/dranet/tree/main/examples/coreweave_cks_examples/b200-infiniband).
+
+## Safe InfiniBand discovery
+
+Run DRANET with `--move-ib-interfaces=false` for the initial CKS InfiniBand
+workflow. DRANET then publishes each HCA as an IB-only RDMA device and leaves
+the host IPoIB network interface in place. When a pod receives a DRA claim,
+DRANET injects only the allocated HCA's `/dev/infiniband` character devices
+through NRI; the workload does not need to be privileged.
+
+The example `DeviceClass` selects only CKS backend fabric HCAs:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: infiniband.cks.coreweave.com
+spec:
+  selectors:
+  - cel:
+      expression: >-
+        device.driver == "dra.net" &&
+        device.attributes["dra.net"].rdma == true
+  - cel:
+      expression: >-
+        "coreweave.dra.net" in device.attributes &&
+        device.attributes["coreweave.dra.net"].fabricFlavor == "infiniband" &&
+        "leafSwitch" in device.attributes["coreweave.dra.net"]
+```
+
+The `leafSwitch` presence check is important on B200 nodes because they may
+also contain RDMA-capable internal devices which are not connected to the
+backend InfiniBand fabric.
+
+## Validated workflow
+
+The example was validated on Kubernetes 1.36 and two 8-GPU B200 CKS nodes.
+Each worker received one GPU and one `ibp0` claim that reached
+`RDMAOnlyDeviceReady`. CoreWeave's NCCL test image exercised the cross-node
+InfiniBand data path through `NET/IBext_v11/0/GDRDMA`, completed with zero data
+errors, averaged 41.72 GB/s bus bandwidth, and reached 46.35 GB/s at a 1 GiB
+message size.
+
+See the example README for the two-node Helm installation, topology-aware CEL
+selectors, NCCL commands, observed results, and cleanup procedure.


### PR DESCRIPTION
Depends on #302. Part of #301.

Adds a CKS B200 example that allocates one GPU and one topology-aware InfiniBand HCA per worker, then runs a two-node NCCL all-reduce using CoreWeave's NCCL test image.

End-to-end verification on CKS `use15` (Kubernetes 1.36):
- Two workers scheduled on separate B200 nodes in the same fabric, superpod, and leafgroup.
- Both DRA claims allocated `ibp0` and reached `RDMAOnlyDeviceReady`.
- NCCL used `NET/IBext_v11/0/GDRDMA` with zero validation errors.
- 41.72 GB/s average bus bandwidth; 46.35 GB/s at 1 GiB.