### PR TITLE
feat: release the DHCP lease when the claim goes away

### DIFF
--- a/pkg/driver/dhcp.go
+++ b/pkg/driver/dhcp.go
@@ -18,51 +18,139 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"sigs.k8s.io/dranet/pkg/apis"
 
+	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
 	"github.com/vishvananda/netlink"
 	"sigs.k8s.io/dranet/internal/nlwrap"
 )
 
-func getDHCP(ctx context.Context, ifName string) (ip string, routes []apis.RouteConfig, err error) {
+// getDHCP obtains an address for ifName over DHCP and returns it together with
+// the lease record. The caller keeps the record so the lease can be released
+// when the claim goes away: the client here is one-shot, so without a
+// DHCPRELEASE the server holds the address for the whole valid-lifetime even
+// though nothing uses it.
+func getDHCP(ctx context.Context, ifName string) (ip string, routes []apis.RouteConfig, lease *DHCPLeaseRecord, err error) {
 	link, err := nlwrap.LinkByName(ifName)
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	if link.Attrs().OperState != netlink.OperUp {
 		if err := netlink.LinkSetUp(link); err != nil {
-			return "", nil, fmt.Errorf("failed to set interface %s up: %v", ifName, err)
+			return "", nil, nil, fmt.Errorf("failed to set interface %s up: %w", ifName, err)
 		}
 	}
 	dhclient, err := nclient4.New(ifName)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to create DHCP client on interface %s  up: %v", ifName, err)
+		return "", nil, nil, fmt.Errorf("failed to create DHCP client on interface %s: %w", ifName, err)
 	}
 	defer dhclient.Close()
 
-	lease, err := dhclient.Request(ctx)
+	result, err := dhclient.Request(ctx)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to obtain DHCP lease on interface %s  up: %v", ifName, err)
+		return "", nil, nil, fmt.Errorf("failed to obtain DHCP lease on interface %s: %w", ifName, err)
 	}
-	if lease.ACK == nil {
-		return "", nil, fmt.Errorf("failed to obtain DHCP lease on interface %s  up: %v", ifName, err)
+	ack := result.ACK
+	if ack == nil {
+		return "", nil, nil, fmt.Errorf("no DHCPACK in the lease obtained on interface %s", ifName)
 	}
 	ip = (&net.IPNet{
-		IP:   lease.ACK.YourIPAddr,
-		Mask: lease.ACK.SubnetMask(),
+		IP:   ack.YourIPAddr,
+		Mask: ack.SubnetMask(),
 	}).String()
 
 	// only support opt 121 (ignore 33)
-	for _, route := range lease.ACK.ClasslessStaticRoute() {
+	for _, route := range ack.ClasslessStaticRoute() {
 		routeCfg := apis.RouteConfig{
 			Destination: route.Dest.String(),
 			Gateway:     route.Router.String(),
 		}
 		routes = append(routes, routeCfg)
 	}
-	return
+	return ip, routes, newDHCPLeaseRecord(ack), nil
+}
+
+// newDHCPLeaseRecord extracts from the ACK what a later DHCPRELEASE needs.
+// RELEASE is unicast to the server identifier, so an ACK without one leaves
+// nothing to release to and yields no record; the lease then expires on its
+// own, as it did before releases were sent at all.
+func newDHCPLeaseRecord(ack *dhcpv4.DHCPv4) *DHCPLeaseRecord {
+	serverID := ack.ServerIdentifier()
+	if serverID == nil || serverID.IsUnspecified() {
+		return nil
+	}
+	return &DHCPLeaseRecord{
+		ClientIP:  ack.YourIPAddr.String(),
+		ClientMAC: ack.ClientHWAddr.String(),
+		ServerID:  serverID.String(),
+	}
+}
+
+// dhcpReleaseTimeout bounds the release attempt. RELEASE is not answered, so
+// this is how long the send is allowed to take, not a wait for a reply.
+const dhcpReleaseTimeout = 2 * time.Second
+
+// releaseDHCP sends a DHCPRELEASE for lease, so the server frees the address
+// immediately instead of holding it for the rest of the valid-lifetime.
+// Callers treat a failure as non-fatal: the lease then expires on its own,
+// which is the behaviour without this call at all.
+//
+// The release goes out on ifName, the host interface the lease was taken on.
+// The kernel returns a netdev to the host namespace when the pod's namespace
+// goes away, so by unprepare time the interface is normally back. If it is
+// not, there is nothing to send from and the caller logs it.
+func releaseDHCP(ctx context.Context, ifName string, lease *DHCPLeaseRecord) error {
+	if lease == nil {
+		return nil
+	}
+	release, err := newDHCPRelease(lease)
+	if err != nil {
+		return fmt.Errorf("failed to build DHCPRELEASE for interface %s: %w", ifName, err)
+	}
+	dhclient, err := nclient4.New(ifName)
+	if err != nil {
+		return fmt.Errorf("failed to create DHCP client on interface %s: %w", ifName, err)
+	}
+	defer dhclient.Close()
+
+	// The server does not answer a RELEASE, so the read that follows the send
+	// always ends with the context running out. That is the success path here,
+	// not a failure, for both a deadline and an explicit cancel.
+	server := &net.UDPAddr{IP: release.ServerIdentifier(), Port: nclient4.ServerPort}
+	_, err = dhclient.SendAndRead(ctx, server, release, nil)
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("failed to send DHCPRELEASE on interface %s: %w", ifName, err)
+	}
+	return nil
+}
+
+// newDHCPRelease builds the DHCPRELEASE message for lease. The record is
+// checkpointed as strings, so each field is parsed and checked here rather
+// than trusted.
+func newDHCPRelease(lease *DHCPLeaseRecord) (*dhcpv4.DHCPv4, error) {
+	clientIP := net.ParseIP(lease.ClientIP)
+	if clientIP == nil || clientIP.IsUnspecified() {
+		return nil, fmt.Errorf("invalid client IP %q", lease.ClientIP)
+	}
+	hwAddr, err := net.ParseMAC(lease.ClientMAC)
+	if err != nil {
+		return nil, fmt.Errorf("invalid client MAC %q: %w", lease.ClientMAC, err)
+	}
+	serverID := net.ParseIP(lease.ServerID)
+	if serverID == nil || serverID.IsUnspecified() {
+		return nil, fmt.Errorf("invalid server identifier %q", lease.ServerID)
+	}
+	return dhcpv4.New(
+		dhcpv4.WithMessageType(dhcpv4.MessageTypeRelease),
+		dhcpv4.WithClientIP(clientIP),
+		dhcpv4.WithHwAddr(hwAddr),
+		dhcpv4.WithBroadcast(false),
+		dhcpv4.WithOption(dhcpv4.OptServerIdentifier(serverID)),
+	)
 }

--- a/pkg/driver/dhcp_test.go
+++ b/pkg/driver/dhcp_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+)
+
+var (
+	testClientMAC = net.HardwareAddr{0x92, 0x0e, 0x50, 0x89, 0x7a, 0x97}
+	testClientIP  = net.IP{172, 17, 11, 66}
+	testServerID  = net.IP{172, 17, 11, 1}
+)
+
+func testACK(t *testing.T, modifiers ...dhcpv4.Modifier) *dhcpv4.DHCPv4 {
+	t.Helper()
+	ack, err := dhcpv4.New(append([]dhcpv4.Modifier{
+		dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+		dhcpv4.WithHwAddr(testClientMAC),
+		dhcpv4.WithYourIP(testClientIP),
+	}, modifiers...)...)
+	if err != nil {
+		t.Fatalf("build ACK: %v", err)
+	}
+	return ack
+}
+
+// The record must carry exactly what the server keyed the lease by, and the
+// address the release is unicast to.
+func TestNewDHCPLeaseRecord(t *testing.T) {
+	ack := testACK(t, dhcpv4.WithOption(dhcpv4.OptServerIdentifier(testServerID)))
+
+	got := newDHCPLeaseRecord(ack)
+	want := &DHCPLeaseRecord{
+		ClientIP:  "172.17.11.66",
+		ClientMAC: "92:0e:50:89:7a:97",
+		ServerID:  "172.17.11.1",
+	}
+	if got == nil || *got != *want {
+		t.Errorf("newDHCPLeaseRecord = %+v, want %+v", got, want)
+	}
+}
+
+// An ACK without a server identifier gives a release nowhere to go, so no
+// record is kept and unprepare has nothing to do.
+func TestNewDHCPLeaseRecordWithoutServerIdentifier(t *testing.T) {
+	if got := newDHCPLeaseRecord(testACK(t)); got != nil {
+		t.Errorf("newDHCPLeaseRecord = %+v, want nil", got)
+	}
+}
+
+// The release must keep the address and the hardware address of the lease:
+// the server keys the lease by them, so a release that loses either frees
+// nothing. It must also be addressed to the server that granted it.
+func TestNewDHCPRelease(t *testing.T) {
+	rec := newDHCPLeaseRecord(testACK(t, dhcpv4.WithOption(dhcpv4.OptServerIdentifier(testServerID))))
+
+	release, err := newDHCPRelease(rec)
+	if err != nil {
+		t.Fatalf("build release: %v", err)
+	}
+	if got := release.MessageType(); got != dhcpv4.MessageTypeRelease {
+		t.Errorf("MessageType = %v, want RELEASE", got)
+	}
+	if !release.ClientIPAddr.Equal(testClientIP) {
+		t.Errorf("ClientIPAddr = %v, want %v", release.ClientIPAddr, testClientIP)
+	}
+	if release.ClientHWAddr.String() != testClientMAC.String() {
+		t.Errorf("ClientHWAddr = %v, want %v", release.ClientHWAddr, testClientMAC)
+	}
+	if !release.ServerIdentifier().Equal(testServerID) {
+		t.Errorf("ServerIdentifier = %v, want %v", release.ServerIdentifier(), testServerID)
+	}
+	if release.IsBroadcast() {
+		t.Error("release must be unicast")
+	}
+}
+
+// The record is checkpointed as strings, so a corrupt one must surface as an
+// error rather than a malformed packet.
+func TestNewDHCPReleaseRejectsInvalidRecord(t *testing.T) {
+	valid := DHCPLeaseRecord{ClientIP: "172.17.11.66", ClientMAC: "92:0e:50:89:7a:97", ServerID: "172.17.11.1"}
+	for name, mutate := range map[string]func(*DHCPLeaseRecord){
+		"client IP":         func(r *DHCPLeaseRecord) { r.ClientIP = "not-an-ip" },
+		"client MAC":        func(r *DHCPLeaseRecord) { r.ClientMAC = "zz" },
+		"server identifier": func(r *DHCPLeaseRecord) { r.ServerID = "0.0.0.0" },
+	} {
+		rec := valid
+		mutate(&rec)
+		if _, err := newDHCPRelease(&rec); err == nil {
+			t.Errorf("%s: invalid record should error", name)
+		}
+	}
+}
+
+// A claim that took no lease must not make unprepare open a socket on an
+// interface that may no longer exist.
+func TestReleaseDHCPWithoutLease(t *testing.T) {
+	if err := releaseDHCP(context.Background(), "does-not-exist", nil); err != nil {
+		t.Errorf("nil lease should be a no-op, got %v", err)
+	}
+}

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -342,12 +342,15 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 			klog.V(2).Infof("trying to get network configuration via DHCP")
 			contextCancel, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
-			ip, routes, err := getDHCP(contextCancel, ifName)
+			ip, routes, lease, err := getDHCP(contextCancel, ifName)
 			if err != nil {
 				errorList = append(errorList, fmt.Errorf("fail to get configuration via DHCP for %s: %w", ifName, err))
 			} else {
 				deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses = []string{ip}
 				deviceCfg.NetworkInterfaceConfigInPod.Routes = append(deviceCfg.NetworkInterfaceConfigInPod.Routes, routes...)
+				if lease != nil {
+					deviceCfg.NetworkInterfaceStateInPod = &NetworkInterfaceState{DHCPLease: lease}
+				}
 			}
 		} else if !deviceCfg.NetworkInterfaceConfigInPod.Interface.IsSubinterface() && len(deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses) == 0 {
 			// For a passthrough interface with no custom addresses and no DHCP, then use the existing ones
@@ -547,6 +550,20 @@ func (np *NetworkDriver) unprepareResourceClaim(_ context.Context, claim kubelet
 		}
 		for deviceName, devCfg := range podCfg.DeviceConfigs {
 			if devCfg.Claim.Namespace == claim.Namespace && devCfg.Claim.Name == claim.Name {
+				// Give the address back: the client is one-shot, so without
+				// this the server holds it for the whole valid-lifetime even
+				// though nothing uses it any more.
+				if state := devCfg.NetworkInterfaceStateInPod; state != nil && state.DHCPLease != nil {
+					releaseCtx, cancel := context.WithTimeout(context.Background(), dhcpReleaseTimeout)
+					ifName := devCfg.NetworkInterfaceConfigInHost.Interface.Name
+					if err := releaseDHCP(releaseCtx, ifName, state.DHCPLease); err != nil {
+						// Non-fatal: the lease expires on its own, which is the
+						// behaviour without this release. Failing here would
+						// instead block the pod's teardown.
+						klog.Infof("failed to release DHCP lease for claim %v device %s: %v", claim.NamespacedName, deviceName, err)
+					}
+					cancel()
+				}
 				if devCfg.NetworkInterfaceConfigInPod.Profile != "" {
 					if err := np.netdb.ReleaseProfileConfig(deviceName, claim.UID, &devCfg.NetworkInterfaceConfigInPod); err != nil {
 						klog.Errorf("failed to release profile config for claim %v: %v", claim.NamespacedName, err)

--- a/pkg/driver/pod_device_config.go
+++ b/pkg/driver/pod_device_config.go
@@ -63,9 +63,44 @@ type DeviceConfig struct {
 	// Pod's namespace.
 	NetworkInterfaceConfigInPod apis.NetworkConfig `json:"networkInterfaceConfigInPod"`
 
+	// NetworkInterfaceStateInPod holds runtime state the driver derived from
+	// NetworkInterfaceConfigInPod at prepare time and needs back at unprepare
+	// time. It is never part of the user claim schema (pkg/apis). Checkpointed
+	// with the rest of the device config so a daemon restart mid-claim keeps it.
+	NetworkInterfaceStateInPod *NetworkInterfaceState `json:"networkInterfaceStateInPod,omitempty"`
+
 	// RDMADevice holds RDMA-specific configurations if the network device
 	// has associated RDMA capabilities.
 	RDMADevice RDMAConfig `json:"rdmaDevice,omitempty"`
+}
+
+// NetworkInterfaceState is the driver-recorded runtime counterpart of an
+// interface's apis.NetworkConfig: values that only exist once the config has
+// been applied, so they cannot be expressed or rebuilt from the config itself.
+type NetworkInterfaceState struct {
+	// DHCPLease records the lease this claim took, so it can be released when
+	// the claim goes away. The DHCP client is one-shot: without the release the
+	// server keeps the address reserved for the whole valid-lifetime, and fast
+	// claim churn can exhaust the pool long before that.
+	DHCPLease *DHCPLeaseRecord `json:"dhcpLease,omitempty"`
+}
+
+// DHCPLeaseRecord is what a DHCPRELEASE has to carry, taken from the DHCPACK
+// that granted the lease: the server keys the lease by the address and the
+// hardware address, and the release is unicast to the server identifier
+// (RFC 2131 Table 5, §4.4.4).
+type DHCPLeaseRecord struct {
+	// ClientIP is the address the server assigned (yiaddr of the ACK).
+	ClientIP string `json:"clientIP"`
+
+	// ClientMAC is the hardware address the lease was granted to (chaddr of
+	// the ACK). It is recorded rather than read back from the interface at
+	// release time, because the interface's MAC may have changed since.
+	ClientMAC string `json:"clientMAC"`
+
+	// ServerID is the server identifier from the ACK, the address the release
+	// is unicast to.
+	ServerID string `json:"serverID"`
 }
 
 // RDMAConfig contains parameters for setting up an RDMA device associated


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

`getDHCP()` takes a lease and the client is then closed. Nothing ever renews or
releases it, so when the claim is unprepared the server keeps the address bound
for the whole `valid-lifetime` even though nothing uses it.

This records from the DHCPACK what a DHCPRELEASE has to carry (assigned
address, hardware address, server identifier) with the rest of the device
config and sends the release on unprepare, so the server frees the address
right away.

RFC 2131 §4.4.6 has the client relinquish its lease with a DHCPRELEASE when it
no longer needs the address. The server has no other way to learn that the
address became free — it must hold the binding until the lease expires or the
client releases it. A client that only ever does DORA leaves the server holding
addresses it could otherwise hand out.

How much that costs depends on `valid-lifetime` and on how often claims come and
go. It is worst where the two combine: a long lifetime chosen for stability plus
pods created and deleted continuously. Each new claim on the same VF also
arrives as a *new* client whenever the VF's MAC is regenerated, so the previous
address is not reused — it just sits in the lease table until it expires. With
enough churn the pool runs dry while almost every lease in it is already dead.

Reclaiming from outside the client means inferring which addresses are still in
use and deleting the rest, and the inference is the fragile part: a VF that has
moved into a pod network namespace no longer reports its netdev-derived
attributes (including `dra.net/mac`) in the ResourceSlice, so a protected set
built from slice attributes silently omits exactly the leases that *are* in use.
Deleting one of those frees an address a live pod still has configured. Having
the client release its own lease avoids the inference entirely.

Implementation notes:

- `getDHCP()` now also returns a `DHCPLeaseRecord`. `releaseDHCP()` sits next to
  it and uses the same `nclient4` path, so the two are symmetric.
- `DeviceConfig.NetworkInterfaceStateInPod.DHCPLease` stores the assigned
  address, the hardware address and the server identifier from the ACK, under
  a state stanza kept apart from the user claim config. RFC 2131 requires the server
  identifier in a DHCPRELEASE (Table 5) and it is not available anywhere else
  in the device config; the hardware address is recorded rather than read back
  from the interface because it may have changed since the lease was taken.
  The record is checkpointed with the rest of the device config, so a daemon
  restart in the middle of a claim can still release. The interface to send on
  is `NetworkInterfaceConfigInHost.Interface.Name`.
- The release is sent on the interface the lease was taken on. `getDHCP` already
  runs in the root namespace, and the kernel returns a netdev to the host
  namespace when the pod's namespace goes away, so by unprepare time the
  interface is normally back. If it is not, there is nothing to send from.
- A failed release is logged, not returned. The lease then expires on its own —
  the behaviour without this change — whereas failing unprepare would block the
  pod's teardown. This is deliberately unlike `restoreOriginalDriver`, where a
  failure leaks a function to vfio-pci until someone intervenes.
- An ACK without a server identifier yields no record: RELEASE is unicast to
  the granting server, so there is nothing to release to, and the lease expires
  on its own as before.

Alternatives considered:

- **Send from inside the pod namespace.** The namespace may already be gone at
  unprepare time, and it would pull a namespace-entering path into teardown.
- **Send from the PF carrying the VF's `chaddr`.** No timing dependency, but it
  is not standard client behaviour and relies on the server keying the lease by
  `chaddr` rather than the ethernet source.
- **Implement renew instead.** That would also make short lifetimes safe and
  would cover the ungraceful cases this does not (a node that dies never runs
  unprepare). It needs a long-lived per-interface client and restart recovery, so
  it is a much larger change. Release is the smaller step, is independently
  useful, and does not close the door on renew.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

New unit tests in `pkg/driver/dhcp_test.go` cover:

- the record taking the assigned address, hardware address and server
  identifier from the ACK — all three are what a release uses to name the
  lease — and an ACK with no server identifier yielding no record;
- the DHCPRELEASE built from the record keeping that identity and being
  unicast, since a release that loses any of it frees nothing;
- a corrupt record (bad address, MAC or server identifier) being an error
  rather than a malformed packet;
- a claim with no lease being a no-op.

`go build ./...`, `go vet ./...` and `gofmt` are clean. `go test ./pkg/...`
passes except `Test_applyEthtoolConfig` and `Test_nhNetdev`, which fail the same
way on an unmodified tree in my environment (no real netdev/ethtool available).

The DHCPRELEASE on the wire is not covered by unit tests, and there is no DHCP
scenario in `tests/` today. Happy to add a bats case with a DHCP server in the
kind environment if that is wanted here.

Also happy to put the release behind a config knob if it should be opt-in
rather than the default.

#### Does this PR introduce a user-facing change?

```release-note
DRANET now sends a DHCPRELEASE when a claim using `addressing: DHCP` (or the deprecated `dhcp: true`) is unprepared, so the server frees the address immediately instead of holding it for the full lease lifetime.
```



