### PR TITLE
chore: allow testing local changes with local chart

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -21,8 +21,8 @@ on:
 
 env:
   GO_VERSION: "1.26"
-  K8S_VERSION: "v1.36.1"
-  KIND_VERSION: "v0.32.0"
+  K8S_VERSION: "v1.37.0"
+  KIND_VERSION: "v0.33.0"
   IMAGE_NAME: registry.k8s.io/networking/dranet
   KIND_CLUSTER_NAME: kind
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,8 +25,8 @@ on:
 
 env:
   GO_VERSION: "1.26"
-  K8S_VERSION: "v1.36.1"
-  KIND_VERSION: "v0.32.0"
+  K8S_VERSION: "v1.37.0"
+  KIND_VERSION: "v0.33.0"
   IMAGE_NAME: registry.k8s.io/networking/dranet
   KIND_CLUSTER_NAME: kind
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -15,7 +15,7 @@ make kind-cluster
    cluster
 
 ```
-make kind-image
+make kind-install
 ```
 
 3. Test your changes locally, use the [examples folder](./examples) for dropping manifests

--- a/Makefile
+++ b/Makefile
@@ -123,11 +123,20 @@ helm-push: helm-package
 kind-cluster:
 	kind create cluster --name dra --config kind.yaml
 
-kind-image: image-build
+kind-install: image-build
 	docker tag ${IMAGE} registry.k8s.io/networking/dranet:stable
 	kind load docker-image registry.k8s.io/networking/dranet:stable --name dra
 	kubectl delete -f install.yaml || true
 	kubectl apply -f install.yaml
+
+kind-install-helm: image-build ensure-helm
+	kind load docker-image ${IMAGE} --name dra
+	helm uninstall dranet --namespace kube-system || true
+	helm upgrade --install dranet deployments/helm/dranet \
+		--namespace kube-system \
+		--set image.repository=$(REGISTRY)/$(IMAGE_NAME) \
+		--set image.tag=$(TAG) \
+		--set image.pullPolicy=Never
 
 # The main release target, which pushes all images and helm charts.
 release: image-push helm-push

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.36.1
+  image: kindest/node:v1.37
 - role: worker
-  image: kindest/node:v1.36.1
+  image: kindest/node:v1.37
 - role: worker
-  image: kindest/node:v1.36.1
+  image: kindest/node:v1.37
 ```
 
 Then to create the cluster:

--- a/kind.yaml
+++ b/kind.yaml
@@ -15,7 +15,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+  image: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
   kubeadmConfigPatches:
   # Enable the corresponding version of the resource.k8s.io API
   - |
@@ -33,7 +33,7 @@ nodes:
       kubeletExtraArgs:
         v: "5"
 - role: worker
-  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+  image: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -41,7 +41,7 @@ nodes:
       kubeletExtraArgs:
         v: "5"
 - role: worker
-  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+  image: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration

--- a/site/content/docs/contributing/developer-guide.md
+++ b/site/content/docs/contributing/developer-guide.md
@@ -18,7 +18,7 @@ make kind-cluster
    cluster
 
 ```
-make kind-image
+make kind-install
 ```
 
 3. Test your changes locally, use the [examples folder](./examples) for dropping manifests


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add `kind-install-helm` Makefile target that loads the locally built image intockind using its actual tag and deploys it via helm with image tag overridden so the daemonset uses the kind-loaded image instead of pulling from a registry. 

Also, bumps the kind node image to v0.37.0 so have latest changes that landed around DRA in k8s + the kind binary itself to v0.33.
#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```