### PR TITLE
cloudprovider: support alibaba RDMA bonds

### DIFF
--- a/pkg/cloudprovider/alibaba/alibaba.go
+++ b/pkg/cloudprovider/alibaba/alibaba.go
@@ -20,19 +20,27 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	resourceapi "k8s.io/api/resource/v1"
+	"sigs.k8s.io/dranet/internal/nlwrap"
 	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
+	"sigs.k8s.io/dranet/pkg/inventory"
+	"sigs.k8s.io/dranet/pkg/ipam"
 )
 
 const (
@@ -46,12 +54,20 @@ const (
 	imdsTokenTTL  = "21600"
 )
 
-var _ cloudprovider.CloudInstance = (*AlibabaInstance)(nil)
+var (
+	_ cloudprovider.CloudInstance   = (*AlibabaInstance)(nil)
+	_ cloudprovider.ProfileProvider = (*AlibabaInstance)(nil)
+)
 
 type AlibabaInstance struct {
 	InstanceType      string
 	ERDMAPCIAddresses sets.Set[string]
+
+	// localIPAM is seeded with addresses restored from the driver checkpoint.
+	localIPAM *ipam.LocalIPAM
 }
+
+const alibabaEfloSubinterfaceProfile = "alibaba-eflo-subinterface"
 
 // OnAlibaba returns true if running on an Alibaba Cloud ECS instance.
 func OnAlibaba(ctx context.Context) bool {
@@ -77,7 +93,7 @@ func OnAlibaba(ctx context.Context) bool {
 }
 
 // GetInstance retrieves Alibaba Cloud instance metadata via IMDS.
-func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
+func GetInstance(ctx context.Context, opts ...Option) (cloudprovider.CloudInstance, error) {
 	instanceType, err := queryIMDS(ctx, "/meta-data/instance/instance-type")
 	if err != nil {
 		klog.Infof("could not get Alibaba instance type: %v", err)
@@ -86,10 +102,23 @@ func GetInstance(ctx context.Context) (cloudprovider.CloudInstance, error) {
 	erdmaPCIAddresses := detectERDMAPCIAddresses()
 	klog.Infof("Alibaba Cloud instance: type=%q erdma=%v", instanceType, erdmaPCIAddresses.UnsortedList())
 
-	return &AlibabaInstance{
+	instance := &AlibabaInstance{
 		InstanceType:      instanceType,
 		ERDMAPCIAddresses: erdmaPCIAddresses,
-	}, nil
+		localIPAM:         ipam.NewLocalIPAM(nil),
+	}
+	for _, opt := range opts {
+		opt(instance)
+	}
+	return instance, nil
+}
+
+type Option func(*AlibabaInstance)
+
+func WithReservedAddresses(addrs []string) Option {
+	return func(instance *AlibabaInstance) {
+		instance.localIPAM = ipam.NewLocalIPAM(addrs)
+	}
 }
 
 func (a *AlibabaInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
@@ -105,7 +134,265 @@ func (a *AlibabaInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers
 }
 
 func (a *AlibabaInstance) GetDeviceConfig(id cloudprovider.DeviceIdentifiers) *apis.NetworkConfig {
+	// Moving an LACP bond into a pod netns would break link aggregation. Only
+	// eFLO RDMA bonds are served through a subinterface, which requires the
+	// IPv6 address the block is derived from; an IPv4-only bond is not an eFLO
+	// device and keeps the default handling.
+	if id.Name == "" || !inventory.IsLACPBond(id.Name) || !hasEfloIPv6(id.Name) {
+		return nil
+	}
+
+	return &apis.NetworkConfig{
+		Profile: alibabaEfloSubinterfaceProfile,
+		Interface: apis.InterfaceConfig{
+			Type: apis.InterfaceTypeIPVLAN,
+		},
+	}
+}
+
+// GetProfileConfig allocates an eFLO subinterface address.
+func (a *AlibabaInstance) GetProfileConfig(id cloudprovider.DeviceIdentifiers, claim *resourceapi.ResourceClaim, config *apis.NetworkConfig) (*apis.NetworkConfig, error) {
+	if config == nil || !config.Interface.IsSubinterface() {
+		return nil, nil
+	}
+	if a.localIPAM == nil {
+		return nil, fmt.Errorf("alibaba profile IPAM is not initialized for subinterface device %q", id.Name)
+	}
+
+	prefix, parentRoutes, err := getNICIPv6Config(id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("determining eflo RDMA IPv6 config for device %q: %w", id.Name, err)
+	}
+
+	if len(config.Interface.Addresses) > 0 {
+		if err := a.localIPAM.Reserve(config.Interface.Addresses); err != nil {
+			return nil, fmt.Errorf("reserving static subinterface addresses for device %q: %w", id.Name, err)
+		}
+		return efloSourceRoutingConfig(id.Name, config, nil, parentRoutes), nil
+	}
+
+	ranges, err := a.subinterfaceRanges(id.Name, prefix)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := a.localIPAM.Allocate(ranges)
+	if err != nil {
+		return nil, fmt.Errorf("allocating subinterface addresses for device %q: %w", id.Name, err)
+	}
+	return efloSourceRoutingConfig(id.Name, config, addrs, parentRoutes), nil
+}
+
+// efloSourceRoutingConfig returns the allocated addresses plus PBR for them:
+// the parent's IPv6 routes moved to a per-device table and one source rule
+// per address. If the merged config already defines routes, rules or a VRF,
+// routing is user-owned and nothing is synthesized.
+func efloSourceRoutingConfig(ifName string, config *apis.NetworkConfig, allocated []string, parentRoutes []apis.RouteConfig) *apis.NetworkConfig {
+	profile := &apis.NetworkConfig{Interface: apis.InterfaceConfig{Addresses: allocated}}
+
+	addrs := allocated
+	if len(addrs) == 0 {
+		addrs = config.Interface.Addresses
+	}
+	if len(config.Routes) > 0 || len(config.Rules) > 0 || config.Interface.VRF != nil {
+		if len(allocated) == 0 {
+			return nil
+		}
+		return profile
+	}
+
+	tableID := apis.TableIDForName(ifName)
+	for i := range parentRoutes {
+		route := parentRoutes[i]
+		route.Table = tableID
+		profile.Routes = append(profile.Routes, route)
+	}
+	for _, addrStr := range addrs {
+		prefix, err := netip.ParsePrefix(addrStr)
+		if err != nil {
+			continue
+		}
+		// Host prefix so rules for sibling subinterfaces never overlap.
+		profile.Rules = append(profile.Rules, apis.RuleConfig{
+			Source:   netip.PrefixFrom(prefix.Addr(), prefix.Addr().BitLen()).String(),
+			Table:    tableID,
+			Priority: apis.SourceRoutingRulePriority,
+		})
+	}
+	if len(allocated) == 0 && len(profile.Routes) == 0 && len(profile.Rules) == 0 {
+		return nil
+	}
+	return profile
+}
+
+// ReleaseProfileConfig releases subinterface addresses.
+func (a *AlibabaInstance) ReleaseProfileConfig(id cloudprovider.DeviceIdentifiers, claimUID types.UID, config *apis.NetworkConfig) error {
+	if config == nil || !config.Interface.IsSubinterface() || a.localIPAM == nil {
+		return nil
+	}
+	for _, addr := range config.Interface.Addresses {
+		a.localIPAM.Release(addr)
+	}
 	return nil
+}
+
+func (a *AlibabaInstance) subinterfaceRanges(bondName string, prefix *net.IPNet) ([]ipam.IPRange, error) {
+	cidr, err := efloRDMASubinterfaceRange(prefix)
+	if err != nil {
+		return nil, fmt.Errorf("deriving eflo RDMA subinterface range for bond %s: %w", bondName, err)
+	}
+	start, end, err := cloudprovider.IPRangeFromCIDR(cidr, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("deriving allocation range from %q: %w", cidr, err)
+	}
+	return []ipam.IPRange{{Start: start, End: end}}, nil
+}
+
+// hasEfloIPv6 reports whether ifName carries the IPv6 address the eFLO
+// subinterface block is derived from. Link-local addresses are never usable
+// for this, and neither is an IPv4-only interface.
+func hasEfloIPv6(ifName string) bool {
+	link, err := nlwrap.LinkByName(ifName)
+	if err != nil {
+		return false
+	}
+	addrs, err := nlwrap.AddrList(link, netlink.FAMILY_V6)
+	if err != nil {
+		return false
+	}
+	for _, addr := range addrs {
+		if !addr.IP.IsGlobalUnicast() {
+			continue
+		}
+		if ones, bits := addr.Mask.Size(); bits == 128 && ones <= 124 {
+			return true
+		}
+	}
+	return false
+}
+
+// eFLO reserves 0000:000f:0000:0c00/124 within each RDMA NIC's IPv6 network.
+var efloRDMABlockSuffix = [8]byte{0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x0c, 0x00}
+
+func efloRDMASubinterfaceRange(prefix *net.IPNet) (string, error) {
+	ones, bits := prefix.Mask.Size()
+	if bits != 128 {
+		return "", fmt.Errorf("address %s is not IPv6", prefix)
+	}
+	if ones > 124 {
+		return "", fmt.Errorf("expected prefix length <= /124 for eFLO range, got /%d for %s", ones, prefix)
+	}
+
+	pattern := make(net.IP, net.IPv6len)
+	copy(pattern[8:], efloRDMABlockSuffix[:])
+
+	rangeIP := make(net.IP, 16)
+	prefixIP := prefix.IP.To16()
+	if prefixIP == nil {
+		return "", fmt.Errorf("invalid IPv6 prefix %s", prefix)
+	}
+	copy(rangeIP, prefixIP)
+	for i := ones; i < 124; i++ {
+		if getIPBit(pattern, i) {
+			setIPBit(rangeIP, i, true)
+		} else {
+			setIPBit(rangeIP, i, false)
+		}
+	}
+
+	return (&net.IPNet{IP: rangeIP, Mask: net.CIDRMask(124, 128)}).String(), nil
+}
+
+func getIPBit(ip net.IP, i int) bool {
+	byteOffset := i / 8
+	bitOffset := uint(7 - i%8)
+	return ip[byteOffset]&(1<<bitOffset) != 0
+}
+
+func setIPBit(ip net.IP, i int, set bool) {
+	byteOffset := i / 8
+	bitOffset := uint(7 - i%8)
+	if set {
+		ip[byteOffset] |= 1 << bitOffset
+	} else {
+		ip[byteOffset] &^= 1 << bitOffset
+	}
+}
+
+// getNICIPv6Config returns the global IPv6 prefix (<= /124) of ifName together
+// with its IPv6 routes, which seed the eFLO subinterface source-routing config.
+func getNICIPv6Config(ifName string) (*net.IPNet, []apis.RouteConfig, error) {
+	link, err := nlwrap.LinkByName(ifName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not find interface %s: %w", ifName, err)
+	}
+	addrs, err := nlwrap.AddrList(link, netlink.FAMILY_V6)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not list IPv6 addresses for %s: %w", ifName, err)
+	}
+	var parentIP net.IP
+	var prefix *net.IPNet
+	for _, addr := range addrs {
+		if !addr.IP.IsGlobalUnicast() {
+			continue
+		}
+		ones, bits := addr.Mask.Size()
+		if bits != 128 || ones > 124 {
+			continue
+		}
+		parentIP = addr.IP
+		prefix = &net.IPNet{IP: addr.IP.Mask(addr.Mask), Mask: addr.Mask}
+		break
+	}
+	if parentIP == nil {
+		return nil, nil, fmt.Errorf("no global IPv6 address with prefix length <= /124 found on %s", ifName)
+	}
+	filter := &netlink.Route{LinkIndex: link.Attrs().Index}
+	routes, err := nlwrap.RouteListFiltered(netlink.FAMILY_V6, filter, netlink.RT_FILTER_OIF)
+	if err != nil {
+		return nil, nil, err
+	}
+	result, err := efloRouteConfigs(ifName, routes)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(result) == 0 {
+		return nil, nil, fmt.Errorf("no IPv6 routes found on %s", ifName)
+	}
+	return prefix, result, nil
+}
+
+func efloRouteConfigs(ifName string, routes []netlink.Route) ([]apis.RouteConfig, error) {
+	result := make([]apis.RouteConfig, 0, len(routes)+1)
+	gateways := sets.New[string]()
+	for _, route := range routes {
+		if route.Dst == nil {
+			continue
+		}
+		if route.Gw == nil {
+			result = append(result, apis.RouteConfig{
+				Destination: route.Dst.String(),
+				Scope:       unix.RT_SCOPE_LINK,
+			})
+			continue
+		}
+		gateway := route.Gw.String()
+		if !gateways.Has(gateway) {
+			gatewayAddr, err := netip.ParseAddr(gateway)
+			if err != nil {
+				return nil, fmt.Errorf("invalid IPv6 gateway %q on %s: %w", gateway, ifName, err)
+			}
+			result = append(result, apis.RouteConfig{
+				Destination: netip.PrefixFrom(gatewayAddr, 128).String(),
+				Scope:       unix.RT_SCOPE_LINK,
+			})
+			gateways.Insert(gateway)
+		}
+		result = append(result, apis.RouteConfig{
+			Destination: route.Dst.String(),
+			Gateway:     gateway,
+		})
+	}
+	return result, nil
 }
 
 // detectERDMAPCIAddresses returns the PCI addresses of eRDMA devices found in

--- a/pkg/cloudprovider/alibaba/alibaba_test.go
+++ b/pkg/cloudprovider/alibaba/alibaba_test.go
@@ -17,10 +17,25 @@ limitations under the License.
 package alibaba
 
 import (
+	"context"
+	"net"
+	"net/netip"
+	"reflect"
+	"sort"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	userns "sigs.k8s.io/dranet/internal/testutils"
+	"sigs.k8s.io/dranet/pkg/apis"
 	"sigs.k8s.io/dranet/pkg/cloudprovider"
+	"sigs.k8s.io/dranet/pkg/ipam"
 )
 
 const testPCIAddress = "0000:00:0b.0"
@@ -105,13 +120,408 @@ func TestGetDeviceAttributes(t *testing.T) {
 }
 
 func TestGetDeviceConfig(t *testing.T) {
+	userns.Run(t, testGetDeviceConfig_Namespaced, syscall.CLONE_NEWNET)
+}
+
+func testGetDeviceConfig_Namespaced(t *testing.T) {
+	addBond := func(name string, mode netlink.BondMode) {
+		t.Helper()
+		bond := netlink.NewLinkBond(netlink.LinkAttrs{Name: name})
+		bond.Mode = mode
+		if err := netlink.LinkAdd(bond); err != nil {
+			t.Fatalf("failed to add bond %s: %v", name, err)
+		}
+	}
+	addAddr := func(ifName, cidr string) {
+		t.Helper()
+		link, err := netlink.LinkByName(ifName)
+		if err != nil {
+			t.Fatalf("failed to look up %s: %v", ifName, err)
+		}
+		addr, err := netlink.ParseAddr(cidr)
+		if err != nil {
+			t.Fatalf("failed to parse address %s: %v", cidr, err)
+		}
+		if err := netlink.AddrAdd(link, addr); err != nil {
+			t.Fatalf("failed to add address %s to %s: %v", cidr, ifName, err)
+		}
+	}
+
+	// An eFLO RDMA bond is 802.3ad and carries the IPv6 address the
+	// subinterface block is derived from.
+	addBond("bond0", netlink.BOND_MODE_802_3AD)
+	addAddr("bond0", "2001:db8:1234:5678::1/64")
+	// An 802.3ad bond without addresses is not an eFLO device.
+	addBond("bond1", netlink.BOND_MODE_802_3AD)
+	// An IPv4-only 802.3ad bond keeps the default handling.
+	addBond("bond2", netlink.BOND_MODE_802_3AD)
+	addAddr("bond2", "10.0.0.1/24")
+	// A non-LACP bond with IPv6 is not an eFLO device either.
+	addBond("bond3", netlink.BOND_MODE_ACTIVE_BACKUP)
+	addAddr("bond3", "2001:db8:1234:5678::2/64")
+	// A regular NIC.
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		t.Fatalf("failed to add dummy eth0: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		id          cloudprovider.DeviceIdentifiers
+		wantNil     bool
+		wantProfile string
+		wantType    apis.InterfaceType
+	}{
+		{
+			name:    "no interface name -> nil config",
+			id:      cloudprovider.DeviceIdentifiers{PCIAddress: testPCIAddress},
+			wantNil: true,
+		},
+		{
+			name:    "regular NIC, not a bond -> nil config",
+			id:      cloudprovider.DeviceIdentifiers{Name: "eth0"},
+			wantNil: true,
+		},
+		{
+			name:    "unconfigured LACP bond is not an eflo device -> nil config",
+			id:      cloudprovider.DeviceIdentifiers{Name: "bond1", PCIAddress: testPCIAddress},
+			wantNil: true,
+		},
+		{
+			name:    "IPv4-only LACP bond is not an eflo device -> nil config",
+			id:      cloudprovider.DeviceIdentifiers{Name: "bond2", PCIAddress: testPCIAddress},
+			wantNil: true,
+		},
+		{
+			name:    "non-LACP bond with IPv6 is not an eflo device -> nil config",
+			id:      cloudprovider.DeviceIdentifiers{Name: "bond3", PCIAddress: testPCIAddress},
+			wantNil: true,
+		},
+		{
+			name:        "LACP bond with an IPv6 address -> IPVlan subinterface with eflo profile",
+			id:          cloudprovider.DeviceIdentifiers{Name: "bond0", PCIAddress: testPCIAddress},
+			wantNil:     false,
+			wantProfile: alibabaEfloSubinterfaceProfile,
+			wantType:    apis.InterfaceTypeIPVLAN,
+		},
+	}
 	instance := &AlibabaInstance{
 		InstanceType:      "ecs.gn8is-2x.8xlarge",
 		ERDMAPCIAddresses: sets.New[string](testPCIAddress),
 	}
-	config := instance.GetDeviceConfig(cloudprovider.DeviceIdentifiers{PCIAddress: testPCIAddress})
-	if config != nil {
-		t.Errorf("expected nil config for eRDMA device, got %v", config)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := instance.GetDeviceConfig(tt.id)
+			if tt.wantNil {
+				if config != nil {
+					t.Errorf("expected nil config, got %v", config)
+				}
+				return
+			}
+			if config == nil {
+				t.Fatalf("expected non-nil config, got nil")
+			}
+			if config.Profile != tt.wantProfile {
+				t.Errorf("Profile = %q, want %q", config.Profile, tt.wantProfile)
+			}
+			if config.Interface.Type != tt.wantType {
+				t.Errorf("Interface.Type = %q, want %q", config.Interface.Type, tt.wantType)
+			}
+			if len(config.Interface.Addresses) != 0 {
+				t.Errorf("expected no static Addresses in GetDeviceConfig, got %v", config.Interface.Addresses)
+			}
+		})
+	}
+}
+
+func TestGetProfileConfig(t *testing.T) {
+	userns.Run(t, testGetProfileConfig_Namespaced, syscall.CLONE_NEWNET)
+}
+
+func testGetProfileConfig_Namespaced(t *testing.T) {
+	// An eFLO RDMA parent: an 802.3ad bond carrying the global IPv6 address
+	// the subinterface block is derived from, plus IPv6 routes. Everything
+	// getNICIPv6Config needs is read back from the kernel.
+	bond := netlink.NewLinkBond(netlink.LinkAttrs{Name: "bond0"})
+	bond.Mode = netlink.BOND_MODE_802_3AD
+	if err := netlink.LinkAdd(bond); err != nil {
+		t.Fatalf("failed to add bond0: %v", err)
+	}
+	link, err := netlink.LinkByName("bond0")
+	if err != nil {
+		t.Fatalf("failed to look up bond0: %v", err)
+	}
+	// A bond only gets carrier (and thus a link-local address) once it has a
+	// slave, so enslave a dummy like the physical ports of a real bond.
+	slave := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "bond0-port0"}}
+	if err := netlink.LinkAdd(slave); err != nil {
+		t.Fatalf("failed to add bond slave: %v", err)
+	}
+	if err := netlink.LinkSetDown(slave); err != nil {
+		t.Fatalf("failed to set bond slave down: %v", err)
+	}
+	if err := netlink.LinkSetMasterByIndex(slave, link.Attrs().Index); err != nil {
+		t.Fatalf("failed to enslave bond slave: %v", err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("failed to bring bond0 up: %v", err)
+	}
+	// addrconf installs the link-local address asynchronously once the bond
+	// has carrier; the fabric route below depends on the resulting fe80::/64
+	// route being present.
+	if err := wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 10*time.Second, true, func(context.Context) (bool, error) {
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
+		if err != nil {
+			return false, nil
+		}
+		for _, a := range addrs {
+			if a.IP.IsLinkLocalUnicast() {
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("bond0 did not get a link-local address: %v", err)
+	}
+	addr, err := netlink.ParseAddr("2001:db8:1234:5678::1/64")
+	if err != nil {
+		t.Fatalf("failed to parse bond0 address: %v", err)
+	}
+	if err := netlink.AddrAdd(link, addr); err != nil {
+		t.Fatalf("failed to add address to bond0: %v", err)
+	}
+	_, fabric, err := net.ParseCIDR("2001:db8:1000::/36")
+	if err != nil {
+		t.Fatalf("failed to parse fabric CIDR: %v", err)
+	}
+	if err := netlink.RouteAdd(&netlink.Route{
+		Dst:       fabric,
+		Gw:        net.ParseIP("fe80::1"),
+		LinkIndex: link.Attrs().Index,
+	}); err != nil {
+		t.Fatalf("failed to add fabric route via fe80::1: %v", err)
+	}
+
+	const addrHostPrefix = "2001:db8:1234:5678:0:f:0:c0"
+	wantTable := apis.TableIDForName("bond0")
+	wantParentRoutes := []apis.RouteConfig{
+		{Destination: "2001:db8:1234:5678::/64", Scope: unix.RT_SCOPE_LINK, Table: wantTable},
+		{Destination: "fe80::/64", Scope: unix.RT_SCOPE_LINK, Table: wantTable},
+		{Destination: "fe80::1/128", Scope: unix.RT_SCOPE_LINK, Table: wantTable},
+		{Destination: "2001:db8:1000::/36", Gateway: "fe80::1", Table: wantTable},
+	}
+	// The kernel does not guarantee a dump order for routes; compare as sets.
+	sortedRoutes := func(routes []apis.RouteConfig) []apis.RouteConfig {
+		sorted := make([]apis.RouteConfig, len(routes))
+		copy(sorted, routes)
+		sort.Slice(sorted, func(i, j int) bool {
+			if sorted[i].Destination != sorted[j].Destination {
+				return sorted[i].Destination < sorted[j].Destination
+			}
+			return sorted[i].Gateway < sorted[j].Gateway
+		})
+		return sorted
+	}
+
+	t.Run("allocates an eflo range address with no user addresses", func(t *testing.T) {
+		instance := &AlibabaInstance{localIPAM: ipam.NewLocalIPAM(nil)}
+		id := cloudprovider.DeviceIdentifiers{Name: "bond0"}
+		req := &apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN}}
+		got, err := instance.GetProfileConfig(id, nil, req)
+		if err != nil {
+			t.Fatalf("GetProfileConfig() error = %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected allocated config, got nil")
+		}
+		if len(got.Interface.Addresses) != 1 {
+			t.Fatalf("expected 1 address, got %v", got.Interface.Addresses)
+		}
+		addr := got.Interface.Addresses[0]
+		if !strings.HasPrefix(addr, addrHostPrefix) {
+			t.Errorf("allocated address %q not within eflo /124 range %s*", addr, addrHostPrefix)
+		}
+		if !reflect.DeepEqual(sortedRoutes(got.Routes), sortedRoutes(wantParentRoutes)) {
+			t.Errorf("routes = %+v, want %+v", got.Routes, wantParentRoutes)
+		}
+		wantRules := []apis.RuleConfig{{Source: addr, Table: wantTable, Priority: apis.SourceRoutingRulePriority}}
+		if !reflect.DeepEqual(got.Rules, wantRules) {
+			t.Errorf("rules = %+v, want %+v", got.Rules, wantRules)
+		}
+	})
+
+	t.Run("static user address is reserved and released", func(t *testing.T) {
+		instance := &AlibabaInstance{localIPAM: ipam.NewLocalIPAM(nil)}
+		id := cloudprovider.DeviceIdentifiers{Name: "bond0"}
+		req := &apis.NetworkConfig{Interface: apis.InterfaceConfig{
+			Type:      apis.InterfaceTypeIPVLAN,
+			Addresses: []string{"2001:db8:1234:5678:0:f:0:c01/128"},
+		}}
+		got, err := instance.GetProfileConfig(id, nil, req)
+		if err != nil {
+			t.Fatalf("GetProfileConfig() with static address error = %v", err)
+		}
+		if got == nil || !reflect.DeepEqual(sortedRoutes(got.Routes), sortedRoutes(wantParentRoutes)) {
+			t.Errorf("expected parent routes in table %d for static address, got %v", wantTable, got)
+		}
+		wantRules := []apis.RuleConfig{{Source: "2001:db8:1234:5678:0:f:0:c01/128", Table: wantTable, Priority: apis.SourceRoutingRulePriority}}
+		if got == nil || !reflect.DeepEqual(got.Rules, wantRules) {
+			t.Errorf("rules = %+v, want %+v", got.Rules, wantRules)
+		}
+		if _, err := instance.GetProfileConfig(id, nil, req); err == nil {
+			t.Fatal("expected the reserved static address to be rejected")
+		}
+		if err := instance.ReleaseProfileConfig(id, types.UID("claim-1"), req); err != nil {
+			t.Fatalf("ReleaseProfileConfig() error = %v", err)
+		}
+		if _, err := instance.GetProfileConfig(id, nil, req); err != nil {
+			t.Fatalf("expected static address reuse after release: %v", err)
+		}
+	})
+
+	t.Run("user-owned routing suppresses synthesized PBR", func(t *testing.T) {
+		instance := &AlibabaInstance{localIPAM: ipam.NewLocalIPAM(nil)}
+		id := cloudprovider.DeviceIdentifiers{Name: "bond0"}
+		req := &apis.NetworkConfig{
+			Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN},
+			Routes:    []apis.RouteConfig{{Destination: "2001:db8:9999::/48"}},
+		}
+		got, err := instance.GetProfileConfig(id, nil, req)
+		if err != nil {
+			t.Fatalf("GetProfileConfig() error = %v", err)
+		}
+		if got == nil || len(got.Interface.Addresses) != 1 {
+			t.Fatalf("expected allocated address only, got %v", got)
+		}
+		if len(got.Routes) != 0 || len(got.Rules) != 0 {
+			t.Errorf("expected no synthesized routes/rules when user owns routing, got %+v", got)
+		}
+	})
+
+	t.Run("non-subinterface request is a no-op", func(t *testing.T) {
+		instance := &AlibabaInstance{localIPAM: ipam.NewLocalIPAM(nil)}
+		id := cloudprovider.DeviceIdentifiers{Name: "bond0"}
+		req := &apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypePassthrough}}
+		got, err := instance.GetProfileConfig(id, nil, req)
+		if err != nil {
+			t.Fatalf("GetProfileConfig() error = %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil for passthrough request, got %v", got)
+		}
+	})
+
+	t.Run("uninitialized IPAM errors instead of silent success", func(t *testing.T) {
+		instance := &AlibabaInstance{localIPAM: nil}
+		id := cloudprovider.DeviceIdentifiers{Name: "bond0"}
+		req := &apis.NetworkConfig{Interface: apis.InterfaceConfig{Type: apis.InterfaceTypeIPVLAN}}
+		got, err := instance.GetProfileConfig(id, nil, req)
+		if err == nil {
+			t.Fatal("expected error when profile IPAM is not initialized, got nil")
+		}
+		if got != nil {
+			t.Errorf("expected nil config on error, got %v", got)
+		}
+	})
+
+}
+
+func TestEfloRouteConfigs(t *testing.T) {
+	_, connected, _ := net.ParseCIDR("2001:db8:1234:5678::/64")
+	_, linkLocal, _ := net.ParseCIDR("fe80:db8:1234:5678::/64")
+	_, fabric, _ := net.ParseCIDR("2001:db8:1000::/36")
+	routes := []netlink.Route{
+		{Dst: connected},
+		{Dst: linkLocal},
+		{Dst: fabric, Gw: net.ParseIP("fe80::1")},
+	}
+
+	got, err := efloRouteConfigs("bond0", routes)
+	if err != nil {
+		t.Fatalf("efloRouteConfigs() error = %v", err)
+	}
+	want := []apis.RouteConfig{
+		{Destination: "2001:db8:1234:5678::/64", Scope: unix.RT_SCOPE_LINK},
+		{Destination: "fe80:db8:1234:5678::/64", Scope: unix.RT_SCOPE_LINK},
+		{Destination: "fe80::1/128", Scope: unix.RT_SCOPE_LINK},
+		{Destination: "2001:db8:1000::/36", Gateway: "fe80::1"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("efloRouteConfigs() = %+v, want %+v", got, want)
+	}
+}
+
+func TestEfloRDMASubinterfaceRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		cidr    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "typical /64 prefix",
+			cidr: "2001:db8:1234:5678::/64",
+			want: "2001:db8:1234:5678:0:f:0:c00/124",
+		},
+		{
+			name: "prefix with non-zero host bits gets masked away",
+			cidr: "2001:db8:1234:5678::1/64",
+			want: "2001:db8:1234:5678:0:f:0:c00/124",
+		},
+		{
+			name: "subnet with /96 still supported",
+			cidr: "2001:db8:1234:5678::/96",
+			want: "2001:db8:1234:5678::c00/124",
+		},
+		{
+			name: "subnet with /80 still supported",
+			cidr: "2001:db8:1234:5678:abcd::/80",
+			want: "2001:db8:1234:5678:abcd:f:0:c00/124",
+		},
+		{
+			name: "minimum supported prefix /124",
+			cidr: "2001:db8:1234:5678::/124",
+			want: "2001:db8:1234:5678::/124",
+		},
+		{
+			name:    "IPv4 rejected",
+			cidr:    "10.0.0.0/24",
+			wantErr: true,
+		},
+		{
+			name:    "prefix longer than /124 rejected",
+			cidr:    "2001:db8:1234:5678::/125",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, prefix, err := net.ParseCIDR(tt.cidr)
+			if err != nil {
+				t.Fatalf("failed to parse test CIDR: %v", err)
+			}
+			got, err := efloRDMASubinterfaceRange(prefix)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("efloRDMASubinterfaceRange() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("efloRDMASubinterfaceRange() = %q, want %q", got, tt.want)
+			}
+			if err == nil {
+				// Keep the eFLO range within the parent subnet.
+				parent, err := netip.ParsePrefix(tt.cidr)
+				if err != nil {
+					t.Fatalf("failed to parse test CIDR: %v", err)
+				}
+				rangePrefix, err := netip.ParsePrefix(got)
+				if err != nil {
+					t.Fatalf("derived range %q is not a valid prefix: %v", got, err)
+				}
+				if !parent.Contains(rangePrefix.Addr()) {
+					t.Errorf("derived range %q is outside parent prefix %q", got, tt.cidr)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/cloudprovider/discovery/discovery.go
+++ b/pkg/cloudprovider/discovery/discovery.go
@@ -103,7 +103,7 @@ func GetInstanceProperties(ctx context.Context, hint CloudProviderHint, webhookU
 	case CloudProviderHintOKE:
 		return oke.GetInstance(ctx)
 	case CloudProviderHintAlibaba:
-		return alibaba.GetInstance(ctx)
+		return alibaba.GetInstance(ctx, alibaba.WithReservedAddresses(dependencies.ReservedAddresses))
 	case CloudProviderHintCKS:
 		return coreweave.GetInstance(ctx, dependencies.NodeClient, dependencies.NodeName)
 	case CloudProviderHintWebhook:

--- a/pkg/inventory/net.go
+++ b/pkg/inventory/net.go
@@ -215,3 +215,20 @@ func getTcxFilters(device netlink.Link) ([]string, bool) {
 	}
 	return programNames.UnsortedList(), isTcxEBPF
 }
+
+// IsLACPBond reports whether ifName is an 802.3ad (LACP) bond.
+func IsLACPBond(ifName string) bool {
+	link, err := nlwrap.LinkByName(ifName)
+	if err != nil {
+		klog.Errorf("failed to get interface %s: %v", ifName, err)
+		return false
+	}
+
+	bond, ok := link.(*netlink.Bond)
+	if !ok {
+		// Not a bonding interface.
+		return false
+	}
+
+	return bond.Mode == netlink.BOND_MODE_802_3AD
+}

--- a/pkg/inventory/net_test.go
+++ b/pkg/inventory/net_test.go
@@ -371,6 +371,45 @@ func testGetExcludedUplinkInterfaces_Namespaced(t *testing.T) {
 	}
 }
 
+func TestIsLACPBond(t *testing.T) {
+	userns.Run(t, testIsLACPBond_Namespaced, syscall.CLONE_NEWNET)
+}
+
+func testIsLACPBond_Namespaced(t *testing.T) {
+	addBond := func(name string, mode netlink.BondMode) {
+		t.Helper()
+		bond := netlink.NewLinkBond(netlink.LinkAttrs{Name: name})
+		bond.Mode = mode
+		if err := netlink.LinkAdd(bond); err != nil {
+			t.Fatalf("failed to add bond %s: %v", name, err)
+		}
+	}
+
+	addBond("lacp0", netlink.BOND_MODE_802_3AD)
+	addBond("backup0", netlink.BOND_MODE_ACTIVE_BACKUP)
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "dummy0"}}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		t.Fatalf("failed to add dummy0: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "lacp0", want: true},
+		{name: "backup0"},
+		{name: "dummy0"},
+		{name: "nonexistent"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsLACPBond(tt.name); got != tt.want {
+				t.Errorf("IsLACPBond(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 // addBridgeUplink creates a bridge, assigns it an address, brings it up, and
 // installs an IPv4 default route through it so it looks like the active
 // default-gateway uplink.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:

On some Alibaba nodes the RDMA NICs are 802.3ad bonds, which cannot be moved into a pod netns.  Related to #239 (this is the provider side of it)

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Alibaba Cloud: RDMA bonds on EFLO nodes are now given to pods as IPVLAN `subinterfaces`. 
```