### PR TITLE
inventory: cap pci vendor attribute length

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -874,7 +874,22 @@ func (db *DB) addPCIAttributes(devices []resourceapi.Device, pciInfo *ghw.PCIInf
 			devices[i].Attributes[apis.AttrNUMANode] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(pciDev.Node.ID))}
 		}
 		if _, hasAttr := devices[i].Attributes[apis.AttrPCIVendor]; !hasAttr && pciDev.Vendor != nil {
-			devices[i].Attributes[apis.AttrPCIVendor] = resourceapi.DeviceAttribute{StringValue: &pciDev.Vendor.Name}
+			vendorName := pciDev.Vendor.Name
+
+			if len(vendorName) > resourceapi.DeviceAttributeMaxValueLength {
+				klog.V(4).Infof(
+					"Truncating PCI vendor name %q from %d to %d bytes",
+					vendorName,
+					len(vendorName),
+					resourceapi.DeviceAttributeMaxValueLength,
+				)
+
+				vendorName = vendorName[:resourceapi.DeviceAttributeMaxValueLength]
+			}
+
+			devices[i].Attributes[apis.AttrPCIVendor] = resourceapi.DeviceAttribute{
+				StringValue: &vendorName,
+			}
 		}
 		if _, hasAttr := devices[i].Attributes[apis.AttrPCIDevice]; !hasAttr && pciDev.Product != nil {
 			productName := pciDev.Product.Name

--- a/pkg/inventory/db_test.go
+++ b/pkg/inventory/db_test.go
@@ -676,6 +676,40 @@ func TestAddPCIAttributes(t *testing.T) {
 		}
 	})
 
+	t.Run("truncates long vendor name", func(t *testing.T) {
+		longName := strings.Repeat("b", resourceapi.DeviceAttributeMaxValueLength+10)
+		longPCIInfo := &ghw.PCIInfo{
+			Devices: []*ghw.PCIDevice{
+				{
+					Address: "0000:00:1f.0",
+					Class:   &pcidb.Class{ID: "02"},
+					Vendor:  &pcidb.Vendor{Name: longName},
+				},
+			},
+		}
+		devices := []resourceapi.Device{
+			{
+				Name: "0000:00:1f.0",
+				Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					apis.AttrPCIAddress: {StringValue: ptr.To("0000:00:1f.0")},
+				},
+			},
+		}
+		db := &DB{}
+		result := db.addPCIAttributes(devices, longPCIInfo)
+
+		v, ok := result[0].Attributes[apis.AttrPCIVendor]
+		if !ok || v.StringValue == nil {
+			t.Fatalf("AttrPCIVendor not set, got: %v", v)
+		}
+		if len(*v.StringValue) != resourceapi.DeviceAttributeMaxValueLength {
+			t.Errorf("AttrPCIVendor length = %d, want %d", len(*v.StringValue), resourceapi.DeviceAttributeMaxValueLength)
+		}
+		if *v.StringValue != longName[:resourceapi.DeviceAttributeMaxValueLength] {
+			t.Errorf("AttrPCIVendor = %q, want prefix of long name", *v.StringValue)
+		}
+	})
+
 	t.Run("does not overwrite existing attributes", func(t *testing.T) {
 		devices := []resourceapi.Device{
 			{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Some PCI vendor names reported by ghw/pcidb can exceed the DRA API's per-attribute value length limit, causing the ResourceSlice to be rejected with a validation error like Too long: may not be more than 64 bytes. This previously only surfaced for the PCI device (product) name; the vendor name has the same class of bug.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Refer this PR --> https://github.com/kubernetes-sigs/dranet/pull/300
This change was requested by [aojea](https://github.com/aojea)

#### Does this PR introduce a user-facing change?
```release-note
Prevent ResourceSlice creation failures caused by PCI vendor names that exceed Kubernetes device attribute length limits by truncating the published `dra.net/pciVendor` attribute value.
```