### PR TITLE
apis: default and validate the merged NetworkConfig

### DIFF
--- a/pkg/apis/validation.go
+++ b/pkg/apis/validation.go
@@ -37,7 +37,7 @@ const (
 )
 
 // ValidateConfig unmarshals and validates the NetworkConfig from a runtime.RawExtension.
-// It performs strict unmarshalling and then calls specific validation functions for each part of the config.
+// It performs strict unmarshalling and then defaults and validates the result via Validate.
 // Returns the parsed NetworkConfig and a slice of errors if any validation fails.
 func ValidateConfig(raw *runtime.RawExtension) (*NetworkConfig, []error) {
 	if raw == nil || raw.Raw == nil || len(raw.Raw) == 0 {
@@ -60,41 +60,55 @@ func ValidateConfig(raw *runtime.RawExtension) (*NetworkConfig, []error) {
 		}
 	}
 
-	// Apply defaults
-	config.Default()
-
-	// Validate InterfaceConfig
-	allErrors = append(allErrors, validateInterfaceConfig(&config.Interface, "interface")...)
-
-	// Validate Routes
-	if len(config.Routes) > 0 {
-		allErrors = append(allErrors, validateRoutes(config.Routes, "routes")...)
-	}
-
-	// Validate Rules
-	if len(config.Rules) > 0 {
-		if config.Interface.VRF != nil {
-			allErrors = append(allErrors, fmt.Errorf("rules are not supported when VRF is enabled"))
-		} else {
-			allErrors = append(allErrors, validateRules(config.Rules, "rules")...)
-		}
-	}
-
-	// Validate EthtoolConfig if present
-	if config.Ethtool != nil {
-		allErrors = append(allErrors, validateEthtoolConfig(config.Ethtool, "ethtool")...)
-	}
-
-	// Validate Neighbors
-	if len(config.Neighbors) > 0 {
-		allErrors = append(allErrors, validateNeighborConfig(config.Neighbors, "neighbors")...)
-	}
+	allErrors = append(allErrors, config.Validate()...)
 
 	if len(allErrors) > 0 {
 		return &config, allErrors // Return partially parsed config with errors
 	}
 
 	return &config, nil
+}
+
+// Validate applies defaults to an already parsed NetworkConfig and validates it.
+// Use it for configurations assembled in memory rather than unmarshalled from a
+// ResourceClaim, most importantly the result of MergeNetworkConfig: the cloud
+// provider and profile configurations merged in there are unvalidated external
+// input, and cross-field invariants (e.g. rules combined with a VRF) only become
+// checkable once every source has been merged.
+func (c *NetworkConfig) Validate() []error {
+	// Apply defaults
+	c.Default()
+
+	var allErrors []error
+
+	// Validate InterfaceConfig
+	allErrors = append(allErrors, validateInterfaceConfig(&c.Interface, "interface")...)
+
+	// Validate Routes
+	if len(c.Routes) > 0 {
+		allErrors = append(allErrors, validateRoutes(c.Routes, "routes")...)
+	}
+
+	// Validate Rules
+	if len(c.Rules) > 0 {
+		if c.Interface.VRF != nil {
+			allErrors = append(allErrors, fmt.Errorf("rules are not supported when VRF is enabled"))
+		} else {
+			allErrors = append(allErrors, validateRules(c.Rules, "rules")...)
+		}
+	}
+
+	// Validate EthtoolConfig if present
+	if c.Ethtool != nil {
+		allErrors = append(allErrors, validateEthtoolConfig(c.Ethtool, "ethtool")...)
+	}
+
+	// Validate Neighbors
+	if len(c.Neighbors) > 0 {
+		allErrors = append(allErrors, validateNeighborConfig(c.Neighbors, "neighbors")...)
+	}
+
+	return allErrors
 }
 
 // isValidLinuxInterfaceName checks if the provided name is a valid Linux interface name.

--- a/pkg/apis/validation_test.go
+++ b/pkg/apis/validation_test.go
@@ -924,3 +924,170 @@ func TestValidateNeighborConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestNetworkConfigValidate(t *testing.T) {
+	// Validate is the entry point for configurations assembled in memory, most
+	// importantly the result of MergeNetworkConfig. It must both apply defaults
+	// (the merged config never goes through ValidateConfig) and catch cross-field
+	// combinations that can only appear once user, cloud provider and profile
+	// configurations have been merged together.
+	tests := []struct {
+		name        string
+		config      *NetworkConfig
+		expectErr   bool
+		errContains []string
+		expectedCfg *NetworkConfig
+	}{
+		{
+			name: "defaults an empty ipvlan block supplied by a provider",
+			config: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type:       InterfaceTypeIPVLAN,
+					Addressing: AddressingModeUnnumbered,
+					IPVlan:     &IPVlanConfig{},
+				},
+			},
+			expectedCfg: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type:       InterfaceTypeIPVLAN,
+					Addressing: AddressingModeUnnumbered,
+					IPVlan:     &IPVlanConfig{Mode: IPVlanModeL2, Flag: IPVlanFlagBridge},
+				},
+			},
+		},
+		{
+			name: "defaults a missing ipvlan block for an ipvlan interface",
+			config: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type:       InterfaceTypeIPVLAN,
+					Addressing: AddressingModeUnnumbered,
+				},
+			},
+			expectedCfg: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type:       InterfaceTypeIPVLAN,
+					Addressing: AddressingModeUnnumbered,
+					IPVlan:     &IPVlanConfig{Mode: IPVlanModeL2, Flag: IPVlanFlagBridge},
+				},
+			},
+		},
+		{
+			name: "folds the deprecated dhcp field into addressing",
+			config: &NetworkConfig{
+				Interface: InterfaceConfig{Name: "eth0", DHCP: ptr.To(true)},
+			},
+			expectedCfg: &NetworkConfig{
+				Interface: InterfaceConfig{Name: "eth0", DHCP: ptr.To(true), Addressing: AddressingModeDHCP},
+			},
+		},
+		{
+			name: "derives a vrf table from the vrf name",
+			config: &NetworkConfig{
+				Interface: InterfaceConfig{Name: "eth0", VRF: &VRFConfig{Name: "tenant-a"}},
+			},
+			expectedCfg: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Name: "eth0",
+					VRF:  &VRFConfig{Name: "tenant-a", Table: ptr.To(TableIDForName("tenant-a"))},
+				},
+			},
+		},
+		{
+			name: "rejects rules combined with a vrf",
+			config: &NetworkConfig{
+				Interface: InterfaceConfig{Name: "eth0", VRF: &VRFConfig{Name: "vrf0"}},
+				Rules:     []RuleConfig{{Source: "10.0.0.0/8", Table: 100}},
+			},
+			expectErr:   true,
+			errContains: []string{"rules are not supported when VRF is enabled"},
+		},
+		{
+			name: "rejects an mtu below the minimum",
+			config: &NetworkConfig{
+				Interface: InterfaceConfig{Name: "eth0", MTU: ptr.To[int32](MinMTU - 1)},
+			},
+			expectErr:   true,
+			errContains: []string{"mtu: must be at least"},
+		},
+		{
+			name: "rejects fields unsupported on a subinterface",
+			config: &NetworkConfig{
+				Interface: InterfaceConfig{
+					Type: InterfaceTypeIPVLAN,
+					MTU:  ptr.To[int32](1500),
+				},
+			},
+			expectErr:   true,
+			errContains: []string{"not yet supported for subinterface types"},
+		},
+		{
+			name: "rejects an invalid address contributed to the merged config",
+			config: &NetworkConfig{
+				Interface: InterfaceConfig{Name: "eth0", Addresses: []string{"not-a-cidr"}},
+			},
+			expectErr:   true,
+			errContains: []string{"invalid IP CIDR format"},
+		},
+		{
+			name: "accepts a fully populated valid config",
+			config: &NetworkConfig{
+				Interface: InterfaceConfig{Name: "eth0", Addresses: []string{"192.168.1.1/24"}, MTU: ptr.To[int32](1500)},
+				Routes: []RouteConfig{
+					{Destination: "0.0.0.0/0", Gateway: "192.168.1.254", Scope: unix.RT_SCOPE_UNIVERSE},
+				},
+				Rules:     []RuleConfig{{Source: "10.0.0.0/8", Table: 100}},
+				Neighbors: []NeighborConfig{{Destination: "192.168.1.5", HardwareAddr: "02:00:00:00:00:01"}},
+				Ethtool:   &EthtoolConfig{Features: map[string]bool{"tso": true}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := tt.config.Validate()
+
+			if tt.expectErr && len(errs) == 0 {
+				t.Fatalf("Validate() expected errors, got none")
+			}
+			if !tt.expectErr && len(errs) > 0 {
+				t.Fatalf("Validate() expected no errors, got %v", errs)
+			}
+
+			for _, want := range tt.errContains {
+				found := false
+				for _, err := range errs {
+					if strings.Contains(err.Error(), want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Validate() errors %v do not contain %q", errs, want)
+				}
+			}
+
+			// Defaults must be applied in place: getDeviceNetworkConfig relies on
+			// Validate to default the merged config it is about to return.
+			if tt.expectedCfg != nil && !reflect.DeepEqual(tt.config, tt.expectedCfg) {
+				t.Errorf("Validate() did not default in place:\ngot  %+v\nwant %+v", tt.config.Interface, tt.expectedCfg.Interface)
+			}
+		})
+	}
+}
+
+func TestValidateConfigDelegatesToValidate(t *testing.T) {
+	// ValidateConfig must keep defaulting and validating via Validate, so the two
+	// entry points cannot drift apart.
+	raw := newRawExtensionFromString(t, `{"interface": {"type": "IPVLAN", "addressing": "Unnumbered", "ipvlan": {}}}`)
+
+	cfg, errs := ValidateConfig(raw)
+	if len(errs) > 0 {
+		t.Fatalf("ValidateConfig() unexpected errors: %v", errs)
+	}
+	if cfg.Interface.IPVlan == nil {
+		t.Fatalf("ValidateConfig() left ipvlan nil")
+	}
+	if cfg.Interface.IPVlan.Mode != IPVlanModeL2 || cfg.Interface.IPVlan.Flag != IPVlanFlagBridge {
+		t.Errorf("ValidateConfig() ipvlan = %+v, want mode %s flag %s", cfg.Interface.IPVlan, IPVlanModeL2, IPVlanFlagBridge)
+	}
+}

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -706,6 +706,7 @@ func getRouteInfo(nlHandle nlwrap.Handle, ifName string, link netlink.Link) ([]a
 
 // getDeviceNetworkConfig merges the user configuration with the cloud provider configuration and resolves the dynamic profile.
 // User configuration always takes precedence in case of conflicts.
+// The merged result is defaulted and validated before it is returned.
 func (np *NetworkDriver) getDeviceNetworkConfig(device string, claim *resourceapi.ResourceClaim, userConf *apis.NetworkConfig) (*apis.NetworkConfig, error) {
 	cloudConf, ok := np.netdb.GetDeviceConfig(device)
 	if ok && cloudConf != nil {
@@ -719,6 +720,15 @@ func (np *NetworkDriver) getDeviceNetworkConfig(device string, claim *resourceap
 			return nil, fmt.Errorf("failed to get profile config: %v", err)
 		}
 		mergedConf = apis.MergeNetworkConfig(mergedConf, profileConf)
+	}
+
+	// The user configuration was already validated when the claim was parsed, but
+	// the cloud provider and profile configurations are unvalidated external input
+	// and some invariants only become checkable once everything is merged. Default
+	// and validate the configuration that is actually going to be applied, so a bad
+	// provider config fails here with a clear error instead of partially applying.
+	if errs := mergedConf.Validate(); len(errs) > 0 {
+		return nil, fmt.Errorf("merged network config for device %s is invalid: %v", device, errs)
 	}
 	return mergedConf, nil
 }

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -663,9 +663,11 @@ func TestGetDeviceNetworkConfigWithWebhook(t *testing.T) {
 		profileResponse   *apis.NetworkConfig
 		profileStatusCode int
 		expectedError     bool
+		errContains       string
 		expectedAddresses []string
 		expectedMTU       int32
 		expectedProfile   string
+		expectedIPVlan    *apis.IPVlanConfig
 	}{
 		{
 			name:              "No configurations provided",
@@ -747,6 +749,60 @@ func TestGetDeviceNetworkConfigWithWebhook(t *testing.T) {
 			profileStatusCode: http.StatusForbidden,
 			expectedError:     true,
 		},
+		{
+			// The merged configuration never goes through ValidateConfig, so an
+			// ipvlan block contributed by a provider is only defaulted if
+			// getDeviceNetworkConfig does it. Without that, addIPVlan rejects the
+			// empty mode with "unsupported ipvlan mode".
+			name:     "Cloud provider ipvlan block is defaulted",
+			userConf: &apis.NetworkConfig{},
+			cloudConfResponse: &apis.NetworkConfig{
+				Interface: apis.InterfaceConfig{
+					Type:       apis.InterfaceTypeIPVLAN,
+					Addressing: apis.AddressingModeUnnumbered,
+					IPVlan:     &apis.IPVlanConfig{},
+				},
+			},
+			expectedIPVlan: &apis.IPVlanConfig{Mode: apis.IPVlanModeL2, Flag: apis.IPVlanFlagBridge},
+			expectedError:  false,
+		},
+		{
+			// Neither configuration is invalid on its own: the conflict only
+			// exists once they have been merged.
+			name: "User rules combined with cloud provider VRF is rejected",
+			userConf: &apis.NetworkConfig{
+				Rules: []apis.RuleConfig{{Source: "10.0.0.0/8", Table: 100}},
+			},
+			cloudConfResponse: &apis.NetworkConfig{
+				Interface: apis.InterfaceConfig{VRF: &apis.VRFConfig{Name: "vrf0"}},
+			},
+			expectedError: true,
+			errContains:   "rules are not supported when VRF is enabled",
+		},
+		{
+			name:     "Invalid cloud provider MTU is rejected",
+			userConf: &apis.NetworkConfig{},
+			cloudConfResponse: &apis.NetworkConfig{
+				Interface: apis.InterfaceConfig{MTU: ptr.To[int32](1)},
+			},
+			expectedError: true,
+			errContains:   "mtu: must be at least",
+		},
+		{
+			// Validation has to run after the profile merge, not only after the
+			// cloud provider merge.
+			name:     "Invalid Profile configuration is rejected",
+			userConf: &apis.NetworkConfig{},
+			cloudConfResponse: &apis.NetworkConfig{
+				Profile: "cloud-profile",
+			},
+			profileResponse: &apis.NetworkConfig{
+				Interface: apis.InterfaceConfig{Addresses: []string{"not-a-cidr"}},
+			},
+			profileStatusCode: http.StatusOK,
+			expectedError:     true,
+			errContains:       "invalid IP CIDR format",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -817,6 +873,9 @@ func TestGetDeviceNetworkConfigWithWebhook(t *testing.T) {
 				if err == nil {
 					t.Fatalf("Expected an error but got nil")
 				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("Expected error containing %q, got %v", tc.errContains, err)
+				}
 				return
 			}
 
@@ -856,6 +915,12 @@ func TestGetDeviceNetworkConfigWithWebhook(t *testing.T) {
 				}
 			} else if mergedConf.Profile != "" {
 				t.Errorf("Expected empty profile, got %s", mergedConf.Profile)
+			}
+
+			if tc.expectedIPVlan != nil {
+				if diff := cmp.Diff(tc.expectedIPVlan, mergedConf.Interface.IPVlan); diff != "" {
+					t.Errorf("Unexpected ipvlan config (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}
@@ -1293,6 +1358,9 @@ func testPrepareResourceClaim_Namespaced(t *testing.T) {
 								Name:       "dummy0",
 								Type:       "IPVLAN",
 								Addressing: apis.AddressingModeUnnumbered,
+								// The merged config is defaulted, so the ipvlan
+								// block the provider left unset is populated.
+								IPVlan: &apis.IPVlanConfig{Mode: apis.IPVlanModeL2, Flag: apis.IPVlanFlagBridge},
 							},
 						},
 					},
@@ -1362,6 +1430,9 @@ func testPrepareResourceClaim_Namespaced(t *testing.T) {
 								Name:      "dummy0",
 								Type:      "IPVLAN",
 								Addresses: []string{"10.24.3.5/32"},
+								// The merged config is defaulted, so the ipvlan
+								// block the provider left unset is populated.
+								IPVlan: &apis.IPVlanConfig{Mode: apis.IPVlanModeL2, Flag: apis.IPVlanFlagBridge},
 							},
 							Routes: []apis.RouteConfig{
 								{Destination: "10.24.3.1/32", Scope: 253, Table: 1100},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

MergeNetworkConfig combines the user's ResourceClaim config with the cloud provider's device config and the resolved profile config, and the result is what gets applied to netlink. Validation only ever ran on the user's raw claim parameters, and NetworkConfig.Default() only ever ran inside ValidateConfig, so nothing defaulted or checked the merged config.

Provider and profile configs are unvalidated external input, and some invariants only become checkable once everything is merged:

  - A provider supplying "type: IPVLAN" with an empty "ipvlan" block was never defaulted, so addIPVlan rejected the empty mode with "unsupported ipvlan mode". The identical config from a user works, because ValidateConfig defaults it first.
  - A user supplying rules plus a provider supplying a VRF produced a merged config that validation declares unsupported, with nothing left to reject it.

Extract the post-unmarshal half of ValidateConfig into NetworkConfig.Validate() and call it on the merged config in getDeviceNetworkConfig. No validation rules change; ValidateConfig keeps its existing behavior by delegating to Validate.

#### Which issue(s) this PR is related to:

Fixes #315 
Found in #316

#### Special notes for your reviewer:

There is a behavior change for GCE + addressing: unnumbered.

Validating the merged config newly rejects one combination that is currently tolerated, reachable on GCE without any user errors. 

GCEInstance.GetProfileConfig (gce.go:197) gates only on IsSubinterface(). An Unnumbered IPVLan interface is a sub interface, so GCE allocates addresses from IPAM even though the user explicitly waved addressing. The merged config then carries both:

```
addressing=Unnumbered addrs=[10.128.0.5/32]
errs=[interface.addressing: 'Unnumbered' cannot be set together with addresses]
```

Today, that reaches Dra_hooks.go:454, which logs `skipping address and route configuration` and proceeds. With this PR it's a failure.

I think failing is the correct case here: `validateInterfaceConfig` explicitly forbids the combination, and allocating an IPAM lease for an interface the user asked to be unnumbered is a provider bug that should surface rather than be silently absorbed.

The GCE-side fix would be to skip allocation and PBR synthesis when `Addressing == Unnumbered`. I could take a shot at it, but I can't test it myself.

Alternatively I could change the PR to let this slide, but I don't think we should.

#### Does this PR introduce a user-facing change?

NONE

```release-note
Cleaned up config validation, where merged configs were only getting validated and defaulted before the merge. 
```