### PR TITLE
fix: clear copied host route source not assigned in the Pod

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"slices"
 	"sort"
 	"strings"
@@ -404,6 +405,7 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 				errorList = append(errorList, err)
 				continue
 			}
+			clearStaleRouteSources(routes, deviceCfg.NetworkInterfaceConfigInPod.Interface.Addresses)
 			deviceCfg.NetworkInterfaceConfigInPod.Routes = append(deviceCfg.NetworkInterfaceConfigInPod.Routes, routes...)
 
 			// If VRF is enabled, we do not need to copy the rules from the host
@@ -702,6 +704,26 @@ func getRouteInfo(nlHandle nlwrap.Handle, ifName string, link netlink.Link) ([]a
 		}
 	}
 	return routes, tables, nil
+}
+
+// clearStaleRouteSources drops the preferred source of copied host routes when
+// that address is not among the addresses the interface gets in the Pod. The
+// kernel rejects a route whose prefsrc is not a local address with EINVAL, and
+// the Pod may get different addresses than the host had (DHCP, or addresses
+// set in the claim). Without a source the kernel picks one itself.
+func clearStaleRouteSources(routes []apis.RouteConfig, addresses []string) {
+	podIPs := sets.New[string]()
+	for _, addr := range addresses {
+		if ip, _, err := net.ParseCIDR(addr); err == nil {
+			podIPs.Insert(ip.String())
+		}
+	}
+	for i := range routes {
+		if routes[i].Source != "" && !podIPs.Has(routes[i].Source) {
+			klog.V(4).Infof("Clearing source %s of route %s: address not assigned in the Pod", routes[i].Source, routes[i].Destination)
+			routes[i].Source = ""
+		}
+	}
 }
 
 // getDeviceNetworkConfig merges the user configuration with the cloud provider configuration and resolves the dynamic profile.

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1416,3 +1416,59 @@ func testPrepareResourceClaim_Namespaced(t *testing.T) {
 		})
 	}
 }
+
+func TestClearStaleRouteSources(t *testing.T) {
+	testCases := []struct {
+		name        string
+		routes      []apis.RouteConfig
+		addresses   []string
+		wantSources []string
+	}{
+		{
+			name:        "source not assigned in the pod is cleared",
+			routes:      []apis.RouteConfig{{Destination: "172.17.14.0/24", Source: "172.17.14.28"}},
+			addresses:   []string{"172.17.14.101/24"},
+			wantSources: []string{""},
+		},
+		{
+			name:        "source assigned in the pod is kept",
+			routes:      []apis.RouteConfig{{Destination: "172.17.14.0/24", Source: "172.17.14.28"}},
+			addresses:   []string{"172.17.14.28/24"},
+			wantSources: []string{"172.17.14.28"},
+		},
+		{
+			name:        "route without source is untouched",
+			routes:      []apis.RouteConfig{{Destination: "0.0.0.0/0", Gateway: "172.17.14.1"}},
+			addresses:   nil,
+			wantSources: []string{""},
+		},
+		{
+			name:        "source is cleared when the pod has no addresses",
+			routes:      []apis.RouteConfig{{Destination: "10.0.0.0/8", Gateway: "172.17.14.1", Source: "172.17.14.28"}},
+			addresses:   nil,
+			wantSources: []string{""},
+		},
+		{
+			name:        "IPv6 source matches a non-canonical pod address",
+			routes:      []apis.RouteConfig{{Destination: "fd00:10::/64", Source: "fd00:10::1c"}},
+			addresses:   []string{"fd00:0010:0000:0000::001c/64"},
+			wantSources: []string{"fd00:10::1c"},
+		},
+		{
+			name:        "IPv6 source not assigned in the pod is cleared",
+			routes:      []apis.RouteConfig{{Destination: "fd00:10::/64", Source: "fd00:10::1c"}},
+			addresses:   []string{"fd00:10::65/64"},
+			wantSources: []string{""},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearStaleRouteSources(tc.routes, tc.addresses)
+			for i, want := range tc.wantSources {
+				if tc.routes[i].Source != want {
+					t.Errorf("route %d source = %q, want %q", i, tc.routes[i].Source, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

`getRouteInfo()` copies the host routes of an interface into the Pod, including
their preferred source (`src` in `ip route`). When the Pod gets different
addresses than the host had, that source does not exist in the Pod namespace
and the kernel rejects the route with EINVAL (`fib_create_info`: "Invalid
prefsrc address"). `applyRoutes` only tolerates EEXIST, so prepare fails and
the Pod is stuck in `ContainerCreating` while the host has already lost the
interface.

This happens whenever a copied route carries a source and the Pod addresses
differ from the host ones: `addressing: dhcp`, or `addresses` set in the claim.
The kernel adds a `src` to the connected route of any interface that has an
address on the host, so it shows up on interfaces the host had configured, for
example a PF:

```
172.17.14.0/24 dev ens4013np0 proto kernel scope link src 172.17.14.28
```

The fix clears the source of a copied route when it is not one of the Pod's
addresses. A source that matches a Pod address is kept, so a Pod that keeps the
host addresses is unchanged. Without a source the kernel picks one itself. This follows the existing filters in `getRouteInfo` that drop
copied routes which cannot be valid in the Pod (local table, IPv6 link-local,
IPv6 `proto kernel`).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`TestClearStaleRouteSources` covers the source being cleared, kept when it
matches a Pod address, and routes without a source left untouched.

`go build ./...`, `go vet` and `gofmt` are clean. `go test ./pkg/driver/` has
the same six failures as an unmodified `main` in my environment (tests that
need a real netns or ethtool); no new failures.

We have been running this fix in production with DHCP mode for a few weeks.

#### Does this PR introduce a user-facing change?

```release-note
Fix Pod creation failing with EINVAL when a host route copied into the Pod has a preferred source that is not one of the Pod's addresses (e.g. with DHCP or addresses set in the claim).
```
