### PR TITLE
docs: update Kubernetes version and mark DRA as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ Works](https://dranet.sigs.k8s.io/docs/concepts/howitworks/).
 To get started with DRANET, your Kubernetes cluster needs to have [Dynamic
 Resource Allocation (DRA)
 enabled](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/).
-DRA is beta and is disabled by default in Kubernetes v1.32. You will need to
-enable both the [feature gates and the API
-groups](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#enabling-dynamic-resource-allocation)
-for DRA until it reaches GA.
+DRA is stable since Kubernetes v1.35 and enabled by default. 
 
 ![](site/static/images/dranet.gif)
 
@@ -68,11 +65,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.37
+  image: kindest/node:v1.37.0
 - role: worker
-  image: kindest/node:v1.37
+  image: kindest/node:v1.37.0
 - role: worker
-  image: kindest/node:v1.37
+  image: kindest/node:v1.37.0
 ```
 
 Then to create the cluster:

--- a/examples/demo_gke_multinetwork/README.md
+++ b/examples/demo_gke_multinetwork/README.md
@@ -5,13 +5,11 @@ connect to these GCE Networks.
 
 1. Create a cluster
 
-DRA is beta in 1.32, so it requires to explicitly enable the feature.
-
 ```sh
 PROJECT="test-project"
 CLUSTER="test-cluster"
 ZONE="us-central1-c"
-VERSION="1.34"
+VERSION="1.36"
 
 gcloud container clusters create "${CLUSTER}" \
     --cluster-version="${VERSION}" \

--- a/site/content/docs/quick-start.md
+++ b/site/content/docs/quick-start.md
@@ -4,9 +4,7 @@ date: 2024-12-17T14:47:05Z
 weight: 1
 ---
 
-`DRANET` depends on the Kubernetes feature [Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/), that is beta (disabled by default in Kubernetes ∂v1.32).
-
-In order to enable DRA you need to enable both the [feature gates and the API groups](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#enabling-dynamic-resource-allocation).
+`DRANET` depends on the Kubernetes feature [Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/), that is stable and enabled by default since Kubernetes v1.35.
 
 ## Kubernetes cluster with DRA
 
@@ -21,17 +19,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.33.1
+  image: kindest/node:v1.37.0
 - role: worker
-  image: kindest/node:v1.33.1
+  image: kindest/node:v1.37.0
 - role: worker
-  image: kindest/node:v1.33.1
-featureGates:
-  # Enable the corresponding DRA feature gates
-  DynamicResourceAllocation: true
-  DRAResourceClaimDeviceStatus: true
-runtimeConfig:
-  api/beta : true
+  image: kindest/node:v1.37.0
 ```
 
 ```
@@ -46,9 +38,14 @@ For instructions on setting up DRA on GKE, refer to the official documentation:
 A quick and easy way to find if DRA is enabled is by checking the metrics in the kube-apiserver
 
 ```sh
-kubectl get --raw /metrics | grep kubernetes_feature_enabled | grep DynamicResourceAllocation
+kubectl api-resources --api-group=resource.k8s.io
 
-kubernetes_feature_enabled{name="DynamicResourceAllocation",stage="BETA"} 1
+NAME                     SHORTNAMES   APIVERSION           NAMESPACED   KIND
+deviceclasses                         resource.k8s.io/v1   false        DeviceClass
+devicetaintrules                      resource.k8s.io/v1   false        DeviceTaintRule
+resourceclaims                        resource.k8s.io/v1   true         ResourceClaim
+resourceclaimtemplates                resource.k8s.io/v1   true         ResourceClaimTemplate
+resourceslices                        resource.k8s.io/v1   false        ResourceSlice
 ```
 
 ## Installation


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

DRA is stable/GA since Kubernetes 1.35. This PR:
* Update the docs statement about DRA being Beta, and instead mark it as stable
* Fixes the kind configuration file that was pointing to a wrong/unexisting tag

#### Does this PR introduce a user-facing change?
```release-note
NONE
```