### PR TITLE
Azure: publish per-device IPv4 subnet attribute

### DIFF
--- a/pkg/cloudprovider/azure/azure.go
+++ b/pkg/cloudprovider/azure/azure.go
@@ -45,6 +45,7 @@ const (
 	AttrAzureVMSize                 = AzureAttrPrefix + "/" + "vmSize"
 	AttrAzureInterconnectGroupID    = AzureAttrPrefix + "/" + "interconnectGroupId"
 	AttrAzureInterconnectSubgroupID = AzureAttrPrefix + "/" + "interconnectSubgroupId"
+	AttrAzureIPv4Subnet             = AzureAttrPrefix + "/" + "ipv4Subnet"
 
 	// imdsEndpoint is the Azure Instance Metadata Service endpoint.
 	imdsEndpoint = "http://169.254.169.254/metadata/instance"
@@ -122,8 +123,8 @@ type AzureInstance struct {
 }
 
 // GetDeviceAttributes returns Azure-specific attributes for a device.
-// PlacementGroupID and VMSize are node-level properties that apply to all
-// devices on the node.
+// Node-level properties apply to all devices on the node. The IPv4 subnet is
+// device-specific and is matched using the device MAC address.
 func (a *AzureInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 
@@ -141,6 +142,24 @@ func (a *AzureInstance) GetDeviceAttributes(id cloudprovider.DeviceIdentifiers) 
 
 	if a.InterconnectSubgroupID != "" {
 		attributes[AttrAzureInterconnectSubgroupID] = resourceapi.DeviceAttribute{StringValue: &a.InterconnectSubgroupID}
+	}
+
+	if id.MAC == "" {
+		return attributes
+	}
+
+	normalizedMAC := normalizeMAC(id.MAC)
+	for i := range a.Interfaces {
+		if normalizeMAC(a.Interfaces[i].MacAddress) != normalizedMAC || len(a.Interfaces[i].IPv4.Subnet) == 0 {
+			continue
+		}
+
+		subnet := a.Interfaces[i].IPv4.Subnet[0]
+		if subnet.Address != "" && subnet.Prefix != "" {
+			subnetCIDR := subnet.Address + "/" + subnet.Prefix
+			attributes[AttrAzureIPv4Subnet] = resourceapi.DeviceAttribute{StringValue: &subnetCIDR}
+		}
+		break
 	}
 
 	return attributes

--- a/pkg/cloudprovider/azure/azure_test.go
+++ b/pkg/cloudprovider/azure/azure_test.go
@@ -116,6 +116,93 @@ func TestGetDeviceAttributes(t *testing.T) {
 				AttrAzureInterconnectGroupID: {StringValue: ptr.To("2deed8b4-d1e9-42be-a40a-9882201aa9f5")},
 			},
 		},
+		{
+			name: "matching interface includes subnet",
+			instance: &AzureInstance{
+				VMSize: "Standard_ND128isr_GB300_v6",
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "000D3AF806EC",
+						IPv4: ipv4Config{
+							Subnet: []subnet{{Address: "10.144.133.128", Prefix: "26"}},
+						},
+					},
+				},
+			},
+			id: cloudprovider.DeviceIdentifiers{MAC: "00:0d:3a:f8:06:ec"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttrAzureVMSize:     {StringValue: ptr.To("Standard_ND128isr_GB300_v6")},
+				AttrAzureIPv4Subnet: {StringValue: ptr.To("10.144.133.128/26")},
+			},
+		},
+		{
+			name: "subnet is selected from matching interface",
+			instance: &AzureInstance{
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "AABBCCDDEEFF",
+						IPv4: ipv4Config{
+							Subnet: []subnet{{Address: "10.0.0.0", Prefix: "24"}},
+						},
+					},
+					{
+						MacAddress: "001122334455",
+						IPv4: ipv4Config{
+							Subnet: []subnet{{Address: "192.168.1.0", Prefix: "24"}},
+						},
+					},
+				},
+			},
+			id: cloudprovider.DeviceIdentifiers{MAC: "00-11-22-33-44-55"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttrAzureIPv4Subnet: {StringValue: ptr.To("192.168.1.0/24")},
+			},
+		},
+		{
+			name: "missing device MAC omits subnet",
+			instance: &AzureInstance{
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "001122334455",
+						IPv4: ipv4Config{
+							Subnet: []subnet{{Address: "192.168.1.0", Prefix: "24"}},
+						},
+					},
+				},
+			},
+			id:   cloudprovider.DeviceIdentifiers{Name: "dev1"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
+		},
+		{
+			name: "unmatched interface omits subnet",
+			instance: &AzureInstance{
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "AABBCCDDEEFF",
+						IPv4: ipv4Config{
+							Subnet: []subnet{{Address: "10.0.0.0", Prefix: "24"}},
+						},
+					},
+				},
+			},
+			id:   cloudprovider.DeviceIdentifiers{MAC: "00:11:22:33:44:55"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
+		},
+		{
+			name: "incomplete subnet metadata is omitted",
+			instance: &AzureInstance{
+				Interfaces: []networkInterface{
+					{
+						MacAddress: "001122334455",
+						IPv4: ipv4Config{
+							Subnet: []subnet{{Address: "192.168.1.0"}},
+						},
+					},
+				},
+			},
+			id:   cloudprovider.DeviceIdentifiers{MAC: "00:11:22:33:44:55"},
+			want: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does
Publishes each Azure network interface's IPv4 subnet CIDR as the device-specific `azure.dra.net/ipv4Subnet` ResourceSlice attribute.

The Azure IMDS interface is matched to the DraNet device by normalized MAC address. The attribute is omitted when the device MAC, matching interface, or complete IPv4 subnet metadata is unavailable. Existing node-level Azure attributes are unchanged.

An IPv4-specific attribute name is used because Azure dual-stack NICs can also have an IPv6 subnet, while Azure IMDS currently exposes explicit subnet address and prefix metadata under the IPv4 interface data.

## Testing
- `go test -race -count 1 ./pkg/cloudprovider/azure`
- `go test ./pkg/inventory ./pkg/driver`

```release-note
Expose the Azure IPv4 subnet CIDR for each network device as the `azure.dra.net/ipv4Subnet` ResourceSlice attribute.
```