### PR TITLE
tests: fix flaky e2e tests caused by racy 'kubectl wait'

### DIFF
--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -585,11 +585,11 @@ EOF
 spec:
   template:
     spec:
-      affinity: {}
+      affinity:
 EOF
 )
   kubectl label node "$NODE_NAME" e2e-test-do-not-schedule-
-  kubectl wait --namespace=kube-system --for=condition=Ready pod -l app=dranet --field-selector spec.nodeName="$NODE_NAME" --timeout=60s
+  kubectl wait --namespace=kube-system --for=create --for=condition=Ready pod -l app=dranet --field-selector spec.nodeName="$NODE_NAME" --timeout=60s
 
   # The driver should asynchronously process the cleanup after the restart.
   # Inspect the bbolt database again to verify the pod configs have been deleted.

--- a/tests/python_webhook.bats
+++ b/tests/python_webhook.bats
@@ -31,7 +31,7 @@ setup_file() {
   
   # Delete dranet pods to restart them with new config
   kubectl --context kind-dranet-test-cluster delete pods -n kube-system -l app=dranet
-  kubectl --context kind-dranet-test-cluster wait --for=condition=ready pods --namespace=kube-system -l app=dranet --timeout=120s
+  kubectl --context kind-dranet-test-cluster wait --for=create --for=condition=ready pods --namespace=kube-system -l app=dranet --timeout=120s
 }
 
 teardown_file() {

--- a/tests/webhook.bats
+++ b/tests/webhook.bats
@@ -6,7 +6,7 @@ load 'test_helper/bats-assert/load'
 setup_file() {
   export BATS_TEST_TIMEOUT=300
   kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/whereabouts_upstream.yaml
-  kubectl -n kube-system wait --for=condition=ready pods -l app=whereabouts --timeout=120s
+  kubectl -n kube-system wait --for=create --for=condition=ready pods -l app=whereabouts --timeout=120s
 
 	# Build and load webhook image
 	docker build --load -t dranet/webhook-whereabouts:test -f "$BATS_TEST_DIRNAME"/../cmd/webhook-whereabouts/Dockerfile "$BATS_TEST_DIRNAME"/../
@@ -14,7 +14,7 @@ setup_file() {
 
 	# Deploy whereabouts webhook daemonset and configmap
 	kubectl apply -f "$BATS_TEST_DIRNAME"/../tests/manifests/whereabouts_webhook_daemonset.yaml
-	kubectl -n kube-system wait --for=condition=ready pods -l app=whereabouts-webhook --timeout=120s
+	kubectl -n kube-system wait --for=create --for=condition=ready pods -l app=whereabouts-webhook --timeout=120s
 
   kubectl patch daemonset dranet -n kube-system --type=json -p='[
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--profile-provider=webhook"},
@@ -24,10 +24,10 @@ setup_file() {
   
   # Delete dranet pods to restart them with new config
   kubectl delete pods -n kube-system -l app=dranet
-  kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=dranet --timeout=120s
+  kubectl wait --for=create --for=condition=ready pods --namespace=kube-system -l k8s-app=dranet --timeout=120s
   # Restart dranet pods again to load the new config
   kubectl delete pods -n kube-system -l app=dranet
-  kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=dranet --timeout=120s
+  kubectl wait --for=create --for=condition=ready pods --namespace=kube-system -l k8s-app=dranet --timeout=120s
 }
 
 teardown_file() {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The bats-based e2e and webhook tests intermittently fail with "error: no matching resources found". The root cause is that `kubectl wait --for=condition=ready` errors out immediately when no resource currently matches its selector; it does not wait for pods that do not exist yet.

This PR:

- Add `--for=create` to the racy waits, so kubectl polls until the pod exists and then waits for readiness.
- In e2e.bats, restore the DaemonSet with `affinity:` (YAML null) so the merge patch actually removes the `nodeAffinity`.

#### Which issue(s) this PR is related to:

Related to #322

#### Does this PR introduce a user-facing change?

```release-note
NONE
```