### PR TITLE
driver: Handle missing namespace paths during subinterface cleanup

### DIFF
--- a/pkg/driver/subinterfaces.go
+++ b/pkg/driver/subinterfaces.go
@@ -19,8 +19,10 @@ package driver
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -153,8 +155,15 @@ func nsCreateSubinterface(hostIfName string, containerNsPath string, config apis
 }
 
 // nsDeleteSubinterface deletes a subinterface inside the container namespace.
+// A namespace path that no longer exists counts as cleaned up. The kernel
+// deletes any IPvlan child still in the namespace when the namespace is
+// destroyed.
 func nsDeleteSubinterface(containerNsPath string, devName string) error {
 	containerNs, err := netns.GetFromPath(containerNsPath)
+	if errors.Is(err, os.ErrNotExist) {
+		klog.V(2).Infof("Network namespace path %s is gone; relying on the kernel to delete subinterface %s when the namespace is destroyed", containerNsPath, devName)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("could not get container network namespace %s: %w", containerNsPath, err)
 	}

--- a/pkg/driver/subinterfaces_test.go
+++ b/pkg/driver/subinterfaces_test.go
@@ -213,3 +213,11 @@ func TestSubinterface_IPVlan(t *testing.T) {
 		}
 	}()
 }
+
+func TestNsDeleteSubinterfaceMissingNamespace(t *testing.T) {
+	// A nonexistent namespace path counts as cleaned up and returns nil.
+	nsPath := path.Join(t.TempDir(), "netns-gone")
+	if err := nsDeleteSubinterface(nsPath, "rdma15"); err != nil {
+		t.Fatalf("nsDeleteSubinterface() returned error for a missing namespace: %v", err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

cri-o removes the pod network namespace before the NRI `StopPodSandbox` hook runs, so `nsDeleteSubinterface` fails to open the path and the hook logs `Failed to delete subinterface ... no such file or directory`. The kernel deletes any IPvlan child still in the namespace when it destroys the namespace, so there is nothing left to do.

Treat a missing namespace path like a link that is already gone: return nil and log at verbosity 2. Cleanup is unchanged when the path still exists, including the normal containerd sequence. The pod shutdown result does not change.

#### Which issue(s) this PR is related to:

#137 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Dranet no longer logs "Failed to delete subinterface" when the pod network namespace path is already missing.
```