### PR TITLE
test: populate NetworkInterfaceStateInPod in the checkpoint fixture

### DIFF
--- a/pkg/driver/pod_device_config_bolt_version_test.go
+++ b/pkg/driver/pod_device_config_bolt_version_test.go
@@ -95,6 +95,13 @@ func fullDeviceConfig() DeviceConfig {
 				PrivateFlags: map[string]bool{"my-flag": false},
 			},
 		},
+		NetworkInterfaceStateInPod: &NetworkInterfaceState{
+			DHCPLease: &DHCPLeaseRecord{
+				ClientIP:  "10.0.0.5",
+				ClientMAC: "02:00:00:00:00:01",
+				ServerID:  "10.0.0.1",
+			},
+		},
 		RDMADevice: RDMAConfig{
 			LinkDev: "mlx5_0",
 			DevChars: []LinuxDevice{{
@@ -113,7 +120,7 @@ func fullDeviceConfig() DeviceConfig {
 // goldenDeviceConfigJSON is the expected JSON output of fullDeviceConfig().
 // If TestDeviceConfigWireFormatGolden fails, either make the change backward-compatible
 // or bump checkpointSchemaVersion, add a migration, and update this golden string.
-const goldenDeviceConfigJSON = `{"claim":{"Namespace":"default","Name":"claim-1"},"deviceSnapshot":{"name":"dev0","attributes":{"dra.net/mac":{"string":"aa:bb:cc:dd:ee:ff"}}},"networkInterfaceConfigInHost":{"interface":{"name":"eth1","addresses":["192.168.1.10/24"],"hardwareAddr":"aa:bb:cc:dd:ee:ff"}},"networkInterfaceConfigInPod":{"profile":"hpc","interface":{"name":"net0","type":"IPVLAN","addressing":"DHCP","addresses":["10.0.0.5/24"],"dhcp":true,"mtu":9000,"hardwareAddr":"02:00:00:00:00:01","gsoMaxSize":65536,"groMaxSize":65536,"gsoIPv4MaxSize":65536,"groIPv4MaxSize":65536,"disableEbpfPrograms":true,"forwarding":true,"arpIgnore":1,"arpAnnounce":2,"vrf":{"name":"vrf0","table":100},"ipvlan":{"mode":"L2","flag":"Bridge"}},"routes":[{"destination":"0.0.0.0/0","gateway":"10.0.0.1","source":"10.0.0.5","scope":253,"table":100}],"rules":[{"priority":1000,"source":"10.0.0.5/32","destination":"10.1.0.0/16","table":100}],"neighbors":[{"destination":"10.0.0.1","hardwareAddr":"02:00:00:00:00:02"}],"ethtool":{"features":{"tcp-segmentation-offload":true},"privateFlags":{"my-flag":false}}},"rdmaDevice":{"linkDev":"mlx5_0","devChars":[{"path":"/dev/infiniband/uverbs0","type":"c","major":231,"minor":192,"fileMode":438,"uid":1000,"gid":1000}]}}`
+const goldenDeviceConfigJSON = `{"claim":{"Namespace":"default","Name":"claim-1"},"deviceSnapshot":{"name":"dev0","attributes":{"dra.net/mac":{"string":"aa:bb:cc:dd:ee:ff"}}},"networkInterfaceConfigInHost":{"interface":{"name":"eth1","addresses":["192.168.1.10/24"],"hardwareAddr":"aa:bb:cc:dd:ee:ff"}},"networkInterfaceConfigInPod":{"profile":"hpc","interface":{"name":"net0","type":"IPVLAN","addressing":"DHCP","addresses":["10.0.0.5/24"],"dhcp":true,"mtu":9000,"hardwareAddr":"02:00:00:00:00:01","gsoMaxSize":65536,"groMaxSize":65536,"gsoIPv4MaxSize":65536,"groIPv4MaxSize":65536,"disableEbpfPrograms":true,"forwarding":true,"arpIgnore":1,"arpAnnounce":2,"vrf":{"name":"vrf0","table":100},"ipvlan":{"mode":"L2","flag":"Bridge"}},"routes":[{"destination":"0.0.0.0/0","gateway":"10.0.0.1","source":"10.0.0.5","scope":253,"table":100}],"rules":[{"priority":1000,"source":"10.0.0.5/32","destination":"10.1.0.0/16","table":100}],"neighbors":[{"destination":"10.0.0.1","hardwareAddr":"02:00:00:00:00:02"}],"ethtool":{"features":{"tcp-segmentation-offload":true},"privateFlags":{"my-flag":false}}},"networkInterfaceStateInPod":{"dhcpLease":{"clientIP":"10.0.0.5","clientMAC":"02:00:00:00:00:01","serverID":"10.0.0.1"}},"rdmaDevice":{"linkDev":"mlx5_0","devChars":[{"path":"/dev/infiniband/uverbs0","type":"c","major":231,"minor":192,"fileMode":438,"uid":1000,"gid":1000}]}}`
 
 func openRawBolt(t *testing.T, path string) *bolt.DB {
 	t.Helper()
@@ -194,15 +201,17 @@ func seedPreVersioningDB(t *testing.T, path, podUID, deviceName string, cfg Devi
 func TestDeviceConfigFixturePopulated(t *testing.T) {
 	cfg := fullDeviceConfig()
 	for name, v := range map[string]reflect.Value{
-		"DeviceConfig":    reflect.ValueOf(cfg),
-		"NetworkConfig":   reflect.ValueOf(cfg.NetworkInterfaceConfigInPod),
-		"InterfaceConfig": reflect.ValueOf(cfg.NetworkInterfaceConfigInPod.Interface),
-		"RDMAConfig":      reflect.ValueOf(cfg.RDMADevice),
-		"LinuxDevice":     reflect.ValueOf(cfg.RDMADevice.DevChars[0]),
-		"RouteConfig":     reflect.ValueOf(cfg.NetworkInterfaceConfigInPod.Routes[0]),
-		"RuleConfig":      reflect.ValueOf(cfg.NetworkInterfaceConfigInPod.Rules[0]),
-		"NeighborConfig":  reflect.ValueOf(cfg.NetworkInterfaceConfigInPod.Neighbors[0]),
-		"EthtoolConfig":   reflect.ValueOf(*cfg.NetworkInterfaceConfigInPod.Ethtool),
+		"DeviceConfig":          reflect.ValueOf(cfg),
+		"NetworkConfig":         reflect.ValueOf(cfg.NetworkInterfaceConfigInPod),
+		"InterfaceConfig":       reflect.ValueOf(cfg.NetworkInterfaceConfigInPod.Interface),
+		"RDMAConfig":            reflect.ValueOf(cfg.RDMADevice),
+		"LinuxDevice":           reflect.ValueOf(cfg.RDMADevice.DevChars[0]),
+		"RouteConfig":           reflect.ValueOf(cfg.NetworkInterfaceConfigInPod.Routes[0]),
+		"RuleConfig":            reflect.ValueOf(cfg.NetworkInterfaceConfigInPod.Rules[0]),
+		"NeighborConfig":        reflect.ValueOf(cfg.NetworkInterfaceConfigInPod.Neighbors[0]),
+		"EthtoolConfig":         reflect.ValueOf(*cfg.NetworkInterfaceConfigInPod.Ethtool),
+		"NetworkInterfaceState": reflect.ValueOf(*cfg.NetworkInterfaceStateInPod),
+		"DHCPLeaseRecord":       reflect.ValueOf(*cfg.NetworkInterfaceStateInPod.DHCPLease),
 	} {
 		for i := 0; i < v.NumField(); i++ {
 			field := v.Type().Field(i)


### PR DESCRIPTION
/kind failing-test

#### What this PR does / why we need it:

`main` fails `TestDeviceConfigFixturePopulated` since #304 and #314 merged in the same tide batch: #304 added `DeviceConfig.NetworkInterfaceStateInPod`, #314 added the test that requires every `DeviceConfig` field to be set in `fullDeviceConfig()`, and neither PR's CI saw the other.

This sets the field in the fixture, adds it to the golden wire format, and adds `NetworkInterfaceState` and `DHCPLeaseRecord` to the populated-field check. The field is additive (`omitempty`), so no `checkpointSchemaVersion` bump per DEVELOPER.md.

#### Which issue(s) this PR is related to:

Follow-up to #304 and #314.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```